### PR TITLE
replace t3lib_div:testInt and t3lib_div:intInRange by helper functions

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1401,7 +1401,7 @@ final class tx_dlf_document {
 		// Get UID of superior document.
 		$partof = 0;
 
-		if (!empty($this->tableOfContents[0]['points']) && !t3lib_div::testInt($this->tableOfContents[0]['points'])) {
+		if (!empty($this->tableOfContents[0]['points']) && !tx_dlf_helper::testInt($this->tableOfContents[0]['points'])) {
 
 			$superior =& tx_dlf_document::getInstance($this->tableOfContents[0]['points'], $pid);
 
@@ -2184,7 +2184,7 @@ final class tx_dlf_document {
 	protected function __construct($uid, $pid) {
 
 		// Prepare to check database for the requested document.
-		if (t3lib_div::testInt($uid)) {
+		if (tx_dlf_helper::testInt($uid)) {
 
 			$whereClause = 'tx_dlf_documents.uid='.intval($uid).tx_dlf_helper::whereClause('tx_dlf_documents');
 

--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -1028,7 +1028,7 @@ class tx_dlf_helper {
 		}
 
 		// Check if "index_name" is an UID.
-		if (t3lib_div::testInt($index_name)) {
+		if (tx_dlf_helper::testInt($index_name)) {
 
 			$index_name = self::getIndexName($index_name, $table, $pid);
 
@@ -1173,6 +1173,68 @@ class tx_dlf_helper {
 		}
 
 	}
+
+	/**
+	 * Forces the integer $theInt into the boundaries of $min and $max.
+	 * If the $theInt is 'FALSE' then the $zeroValue is applied.
+	 *
+	 * Inspired by tc_beuser
+	 *
+	 * @access	public
+	 *
+	 * @param integer $theInt Input value
+	 * @param integer $min Lower limit
+	 * @param integer $max Higher limit
+	 * @param integer $zeroValue Default value if input is FALSE.
+	 *
+	 * @return integer The input value forced into the boundaries of $min and $max
+	 * @deprecated removed in TYPO3 6.0.0 already
+	 */
+	public function intInRange($theInt, $min, $max = 2000000000, $zeroValue = 0) {
+
+		// TYPO3 > 6.0
+		if (t3lib_utility_VersionNumber::convertVersionNumberToInteger(TYPO3_version) >= 6000000) {
+
+			return t3lib_utility_Math::forceIntegerInRange($theInt, $min, $max, $zeroValue);
+
+		}
+		// TYPO3 4.5 - 4.7
+		else {
+
+			return t3lib_div::intInRange($theInt, $min, $max, $zeroValue);
+
+		}
+	}
+
+	/**
+	 * Tests if the input can be interpreted as integer.
+	 *
+	 * @access	public
+	 *
+	 * @param integer $theInt Input value
+	 *
+	 * @return integer The input value forced into the boundaries of $min and $max
+	 * @deprecated removed in TYPO3 6.0.0 already
+	 */
+	public function testInt($theInt) {
+
+		$isVersion6 = FALSE;
+
+		// TYPO3 > 6.0
+		if (t3lib_utility_VersionNumber::convertVersionNumberToInteger(TYPO3_version) >= 6000000) {
+
+			return t3lib_utility_Math::canBeInterpretedAsInteger($theInt);
+
+		}
+		// TYPO3 4.5 - 4.7
+		else {
+
+			return t3lib_div::testInt($theInt);
+
+		}
+
+	}
+
 
 	/**
 	 * This is a static class, thus no instances should be created

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -559,7 +559,7 @@ class tx_dlf_indexing {
 
 			$solrDoc->setField('pid', $doc->pid);
 
-			if (t3lib_div::testInt($logicalUnit['points'])) {
+			if (tx_dlf_helper::testInt($logicalUnit['points'])) {
 
 				$solrDoc->setField('page', $logicalUnit['points']);
 

--- a/dlf/common/class.tx_dlf_list.php
+++ b/dlf/common/class.tx_dlf_list.php
@@ -110,7 +110,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 		// Save parameters for logging purposes.
 		$_position = $position;
 
-		$position = t3lib_div::intInRange($position, 0, $this->count, $this->count);
+		$position = tx_dlf_helper::intInRange($position, 0, $this->count, $this->count);
 
 		if (!empty($elements)) {
 
@@ -211,13 +211,13 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 					// Prepare document's metadata.
 					$metadata = unserialize($resArray['metadata']);
 
-					if (!empty($metadata['type'][0]) && t3lib_div::testInt($metadata['type'][0])) {
+					if (!empty($metadata['type'][0]) && tx_dlf_helper::testInt($metadata['type'][0])) {
 
 						$metadata['type'][0] = tx_dlf_helper::getIndexName($metadata['type'][0], 'tx_dlf_structures', $this->metadata['options']['pid']);
 
 					}
 
-					if (!empty($metadata['owner'][0]) && t3lib_div::testInt($metadata['owner'][0])) {
+					if (!empty($metadata['owner'][0]) && tx_dlf_helper::testInt($metadata['owner'][0])) {
 
 						$metadata['owner'][0] = tx_dlf_helper::getIndexName($metadata['owner'][0], 'tx_dlf_libraries', $this->metadata['options']['pid']);
 
@@ -227,7 +227,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 						foreach ($metadata['collection'] as $i => $collection) {
 
-							if (t3lib_div::testInt($collection)) {
+							if (tx_dlf_helper::testInt($collection)) {
 
 								$metadata['collection'][$i] = tx_dlf_helper::getIndexName($metadata['collection'][$i], 'tx_dlf_collections', $this->metadata['options']['pid']);
 
@@ -504,7 +504,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 	 */
 	public function offsetSet($offset, $value) {
 
-		if (t3lib_div::testInt($offset)) {
+		if (tx_dlf_helper::testInt($offset)) {
 
 			$this->elements[$offset] = $value;
 

--- a/dlf/common/class.tx_dlf_solr.php
+++ b/dlf/common/class.tx_dlf_solr.php
@@ -155,7 +155,7 @@ class tx_dlf_solr {
 		$_core = $core;
 
 		// Get core name if UID is given.
-		if (t3lib_div::testInt($core)) {
+		if (tx_dlf_helper::testInt($core)) {
 
 			$core = tx_dlf_helper::getIndexName($core, 'tx_dlf_solrcores');
 
@@ -232,7 +232,7 @@ class tx_dlf_solr {
 		}
 
 		// Set port if not set.
-		$port = t3lib_div::intInRange($conf['solrPort'], 1, 65535, 8180);
+		$port = tx_dlf_helper::intInRange($conf['solrPort'], 1, 65535, 8180);
 
 		// Append core name to path.
 		$path = trim($conf['solrPath'], '/').'/'.$core;
@@ -336,9 +336,9 @@ class tx_dlf_solr {
 				if (!empty($toplevel[$doc->uid]['s']['relevance'])) {
 
 					$docSorting['relevance'] = $toplevel[$doc->uid]['s']['relevance'];
-				
+
 				}
-				
+
 				$toplevel[$doc->uid] = array (
 					'u' => $doc->uid,
 					's' => $docSorting,
@@ -361,7 +361,7 @@ class tx_dlf_solr {
 			if (empty($toplevel[$doc->uid]['s']['relevance'])) {
 
 				$toplevel[$doc->uid]['s']['relevance'] = str_pad($i, 6, '0', STR_PAD_LEFT);
-				
+
 			}
 
 			$i++;
@@ -391,19 +391,19 @@ class tx_dlf_solr {
 					// Prepare document's metadata for sorting.
 					$sorting = unserialize($resArray['metadata_sorting']);
 
-					if (!empty($sorting['type']) && t3lib_div::testInt($sorting['type'])) {
+					if (!empty($sorting['type']) && tx_dlf_helper::testInt($sorting['type'])) {
 
 						$sorting['type'] = tx_dlf_helper::getIndexName($sorting['type'], 'tx_dlf_structures', $this->cPid);
 
 					}
 
-					if (!empty($sorting['owner']) && t3lib_div::testInt($sorting['owner'])) {
+					if (!empty($sorting['owner']) && tx_dlf_helper::testInt($sorting['owner'])) {
 
 						$sorting['owner'] = tx_dlf_helper::getIndexName($sorting['owner'], 'tx_dlf_libraries', $this->cPid);
 
 					}
 
-					if (!empty($sorting['collection']) && t3lib_div::testInt($sorting['collection'])) {
+					if (!empty($sorting['collection']) && tx_dlf_helper::testInt($sorting['collection'])) {
 
 						$sorting['collection'] = tx_dlf_helper::getIndexName($sorting['collection'], 'tx_dlf_collections', $this->cPid);
 
@@ -413,9 +413,9 @@ class tx_dlf_solr {
 					if (!empty($toplevel[$check]['s']['relevance'])) {
 
 						$sorting['relevance'] = $toplevel[$check]['s']['relevance'];
-				
+
 					}
-				
+
 					$toplevel[$check] = array (
 						'u' => $resArray['uid'],
 						's' => $sorting,
@@ -649,7 +649,7 @@ class tx_dlf_solr {
 		}
 
 		// Set port if not set.
-		$port = t3lib_div::intInRange($conf['solrPort'], 1, 65535, 8180);
+		$port = tx_dlf_helper::intInRange($conf['solrPort'], 1, 65535, 8180);
 
 		// Append core name to path.
 		$path = trim($conf['solrPath'], '/').'/'.$core;

--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -76,7 +76,7 @@ class tx_dlf_em {
 		}
 
 		// Set port if not set.
-		$port = (!empty($this->conf['solrPort']) ? t3lib_div::intInRange($this->conf['solrPort'], 0, 65535, 8180) : 8180);
+		$port = (!empty($this->conf['solrPort']) ? tx_dlf_helper::intInRange($this->conf['solrPort'], 0, 65535, 8180) : 8180);
 
 		// Trim path and append trailing slash.
 		$path = (!empty($this->conf['solrPath']) ? trim($this->conf['solrPath'], '/').'/' : '');

--- a/dlf/hooks/class.tx_dlf_tceforms.php
+++ b/dlf/hooks/class.tx_dlf_tceforms.php
@@ -85,7 +85,7 @@ class tx_dlf_tceforms {
 
 			// There is a strange behavior where the uid from the flexform is prepended by the table's name and appended by its title.
 			// i.e. instead of "18" it reads "pages_18|Title"
-			if (!t3lib_div::testInt($pages)) {
+			if (!tx_dlf_helper::testInt($pages)) {
 
 				$parts = explode('|', $pages);
 
@@ -140,7 +140,7 @@ class tx_dlf_tceforms {
 
 			// There is a strange behavior where the uid from the flexform is prepended by the table's name and appended by its title.
 			// i.e. instead of "18" it reads "pages_18|Title"
-			if (!t3lib_div::testInt($pages)) {
+			if (!tx_dlf_helper::testInt($pages)) {
 
 				$_parts = explode('|', $pages);
 
@@ -195,7 +195,7 @@ class tx_dlf_tceforms {
 
 			// There is a strange behavior where the uid from the flexform is prepended by the table's name and appended by its title.
 			// i.e. instead of "18" it reads "pages_18|Title"
-			if (!t3lib_div::testInt($pages)) {
+			if (!tx_dlf_helper::testInt($pages)) {
 
 				$_parts = explode('|', $pages);
 
@@ -250,7 +250,7 @@ class tx_dlf_tceforms {
 
 			// There is a strange behavior where the uid from the flexform is prepended by the table's name and appended by its title.
 			// i.e. instead of "18" it reads "pages_18|Title"
-			if (!t3lib_div::testInt($pages)) {
+			if (!tx_dlf_helper::testInt($pages)) {
 
 				$parts = explode('|', $pages);
 
@@ -305,7 +305,7 @@ class tx_dlf_tceforms {
 
 			// There is a strange behavior where the uid from the flexform is prepended by the table's name and appended by its title.
 			// i.e. instead of "18" it reads "pages_18|Title"
-			if (!t3lib_div::testInt($pages)) {
+			if (!tx_dlf_helper::testInt($pages)) {
 
 				$parts = explode('|', $pages);
 

--- a/dlf/plugins/collection/class.tx_dlf_collection.php
+++ b/dlf/plugins/collection/class.tx_dlf_collection.php
@@ -371,19 +371,19 @@ class tx_dlf_collection extends tx_dlf_plugin {
 				// Prepare document's metadata for sorting.
 				$sorting = unserialize($resArray['metadata_sorting']);
 
-				if (!empty($sorting['type']) && t3lib_div::testInt($sorting['type'])) {
+				if (!empty($sorting['type']) && tx_dlf_helper::testInt($sorting['type'])) {
 
 					$sorting['type'] = tx_dlf_helper::getIndexName($sorting['type'], 'tx_dlf_structures', $this->conf['pages']);
 
 				}
 
-				if (!empty($sorting['owner']) && t3lib_div::testInt($sorting['owner'])) {
+				if (!empty($sorting['owner']) && tx_dlf_helper::testInt($sorting['owner'])) {
 
 					$sorting['owner'] = tx_dlf_helper::getIndexName($sorting['owner'], 'tx_dlf_libraries', $this->conf['pages']);
 
 				}
 
-				if (!empty($sorting['collection']) && t3lib_div::testInt($sorting['collection'])) {
+				if (!empty($sorting['collection']) && tx_dlf_helper::testInt($sorting['collection'])) {
 
 					$sorting['collection'] = tx_dlf_helper::getIndexName($sorting['collection'], 'tx_dlf_collections', $this->conf['pages']);
 

--- a/dlf/plugins/navigation/class.tx_dlf_navigation.php
+++ b/dlf/plugins/navigation/class.tx_dlf_navigation.php
@@ -146,9 +146,9 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 			// Set default values if not set.
 			if ($this->doc->numPages > 0) {
 
-				$this->piVars['page'] = t3lib_div::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+				$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
-				$this->piVars['double'] = t3lib_div::intInRange($this->piVars['double'], 0, 1, 0);
+				$this->piVars['double'] = tx_dlf_helper::intInRange($this->piVars['double'], 0, 1, 0);
 
 			} else {
 

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -213,7 +213,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		} else {
 
 			// Set default values for page if not set.
-			$this->piVars['pointer'] = t3lib_div::intInRange($this->piVars['pointer'], 0, $this->doc->numPages, 0);
+			$this->piVars['pointer'] = tx_dlf_helper::intInRange($this->piVars['pointer'], 0, $this->doc->numPages, 0);
 
 		}
 
@@ -246,7 +246,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		// Set some variable defaults.
 		if (!empty($this->piVars['page'])) {
 
-			$this->piVars['page'] = t3lib_div::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+			$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
 			$this->piVars['pointer'] = intval(floor($this->piVars['page'] / $this->conf['limit']));
 

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -308,9 +308,9 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			$this->piVars['page'] = t3lib_div::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+			$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
-			$this->piVars['double'] = t3lib_div::intInRange($this->piVars['double'], 0, 1, 0);
+			$this->piVars['double'] = tx_dlf_helper::intInRange($this->piVars['double'], 0, 1, 0);
 
 		}
 

--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -113,7 +113,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 	protected function addCurrentDocument() {
 
 		// Load current document.
-		if (!empty($this->piVars['id']) && t3lib_div::testInt($this->piVars['id'])) {
+		if (!empty($this->piVars['id']) && tx_dlf_helper::testInt($this->piVars['id'])) {
 
 			$this->loadDocument();
 
@@ -516,7 +516,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 			// Add filter query for in-document searching.
 			if ($this->conf['searchIn'] == 'document' || $this->conf['searchIn'] == 'all') {
 
-				if (!empty($this->piVars['id']) && t3lib_div::testInt($this->piVars['id'])) {
+				if (!empty($this->piVars['id']) && tx_dlf_helper::testInt($this->piVars['id'])) {
 
 					$params['fq'][] = 'uid:'.$this->piVars['id'].' OR partof:'.$this->piVars['id'];
 
@@ -529,7 +529,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 			// Add filter query for in-collection searching.
 			if ($this->conf['searchIn'] == 'collection' || $this->conf['searchIn'] == 'all') {
 
-				if (!empty($this->piVars['collection']) && t3lib_div::testInt($this->piVars['collection'])) {
+				if (!empty($this->piVars['collection']) && tx_dlf_helper::testInt($this->piVars['collection'])) {
 
 					$index_name = tx_dlf_helper::getIndexName($this->piVars['collection'], 'tx_dlf_collections', $this->conf['pages']);
 

--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -76,7 +76,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 		$entryArray['ITEM_STATE'] = 'NO';
 
 		// Build menu links based on the $entry['points'] array.
-		if (!empty($entry['points']) && t3lib_div::testInt($entry['points'])) {
+		if (!empty($entry['points']) && tx_dlf_helper::testInt($entry['points'])) {
 
 			$entryArray['_OVERRIDE_HREF'] = $this->pi_linkTP_keepPIvars_url(array ('page' => $entry['points']), TRUE, FALSE, $this->conf['targetPid']);
 
@@ -223,7 +223,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 		$menuArray = array ();
 
 		// Does the document have physical pages or is it an external file?
-		if ($this->doc->physicalPages || !t3lib_div::testInt($this->doc->uid)) {
+		if ($this->doc->physicalPages || !tx_dlf_helper::testInt($this->doc->uid)) {
 
 			// Get all logical units the current page is a part of.
 			if (!empty($this->piVars['page']) && $this->doc->physicalPages) {

--- a/dlf/plugins/toolbox/class.tx_dlf_toolbox.php
+++ b/dlf/plugins/toolbox/class.tx_dlf_toolbox.php
@@ -76,7 +76,7 @@ class tx_dlf_toolbox extends tx_dlf_plugin {
 		// Build data array.
 		$data = array ();
 
-		if (t3lib_div::testInt($this->piVars['id'])) {
+		if (tx_dlf_helper::testInt($this->piVars['id'])) {
 
 			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
 				'*',

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -70,9 +70,9 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			$this->piVars['page'] = t3lib_div::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+			$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
 
-			$this->piVars['double'] = t3lib_div::intInRange($this->piVars['double'], 0, 1, 0);
+			$this->piVars['double'] = tx_dlf_helper::intInRange($this->piVars['double'], 0, 1, 0);
 
 		}
 


### PR DESCRIPTION
t3lib_div:testInt and t3lib_div:intInRange are deprecated as of TYPO3 4.6 and are removed in TYPO3 6.0
