### PR TITLE
require_once of pi_base class is not necessary since TYPO3 4.3 due to au...

### DIFF
--- a/dlf/plugins/search/class.tx_dlf_search_suggest.php
+++ b/dlf/plugins/search/class.tx_dlf_search_suggest.php
@@ -26,8 +26,6 @@
  * [CLASS/FUNCTION INDEX of SCRIPT]
  */
 
-require_once (PATH_tslib.'class.tslib_pibase.php');
-
 /**
  * Search suggestions for the plugin 'DLF: Search' of the 'dlf' extension.
  *


### PR DESCRIPTION
...toloader
