### PR TITLE
Make the toolbox, gridview and pageview plugins cacheable

### DIFF
--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -47,12 +47,12 @@ t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/statistics/class.tx_dlf_statistics.
 
 t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toc/class.tx_dlf_toc.php', '_toc', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/class.tx_dlf_toolbox.php', '_toolbox', 'list_type', FALSE);
+t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/class.tx_dlf_toolbox.php', '_toolbox', 'list_type', TRUE);
 
 t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/validator/class.tx_dlf_validator.php', '_validator', 'list_type', FALSE);
 
 // Register tools for toolbox plugin.
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', FALSE);
+t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', TRUE);
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][t3lib_extMgm::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
 

--- a/dlf/plugins/navigation/class.tx_dlf_navigation.php
+++ b/dlf/plugins/navigation/class.tx_dlf_navigation.php
@@ -86,7 +86,7 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 			'forceAbsoluteUrl' => 1
 		);
 
-		$output = '<form action="'.$this->cObj->typoLink_URL($linkConf).'" method="get"><div><input type="hidden" name="id" value="'.$GLOBALS['TSFE']->id.'" /><input type="hidden" name="no_cache" value="1" />';
+		$output = '<form action="'.$this->cObj->typoLink_URL($linkConf).'" method="get"><div><input type="hidden" name="id" value="'.$GLOBALS['TSFE']->id.'" />';
 
 		// Add plugin variables.
 		foreach ($this->piVars as $piVar => $value) {

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -200,9 +200,6 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 
 		$this->init($conf);
 
-		// Don't cache the output.
-		$this->setCache(FALSE);
-
 		$this->loadDocument();
 
 		if ($this->doc === NULL || $this->doc->numPages < 1 || empty($this->conf['fileGrpThumbs'])) {

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -294,9 +294,6 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 		$this->init($conf);
 
-		// Disable caching for this plugin.
-		$this->setCache(FALSE);
-
 		// Load current document.
 		$this->loadDocument();
 

--- a/dlf/plugins/toolbox/class.tx_dlf_toolbox.php
+++ b/dlf/plugins/toolbox/class.tx_dlf_toolbox.php
@@ -52,9 +52,6 @@ class tx_dlf_toolbox extends tx_dlf_plugin {
 
 		$this->init($conf);
 
-		// Turn cache off.
-		$this->setCache(FALSE);
-
 		// Quit without doing anything if required variable is not set.
 		if (empty($this->piVars['id'])) {
 

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -56,9 +56,6 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		// Merge configuration with conf array of toolbox.
 		$this->conf = t3lib_div::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
 
-		// Turn cache off.
-		$this->setCache(FALSE);
-
 		// Load current document.
 		$this->loadDocument();
 


### PR DESCRIPTION
It is not necessary to register these plugins as uncached USER_INT plugins. 
