### PR TITLE
Include the backend module pagetree in a different way

### DIFF
--- a/dlf/ext_tables.php
+++ b/dlf/ext_tables.php
@@ -387,6 +387,7 @@ if (TYPO3_MODE == 'BE')	{
 
 	t3lib_extMgm::addLLrefForTCAdescr('_MOD_txdlfmodules_txdlfnewclient','EXT:dlf/modules/newclient/locallang_mod.xml');
 
+	t3lib_extMgm::addNavigationComponent('txdlfmodules', 'typo3-pagetree');
 }
 
 ?>

--- a/dlf/modules/conf.php
+++ b/dlf/modules/conf.php
@@ -30,18 +30,6 @@ $MCONF['script'] = '_DISPATCH';
 
 $MCONF['defaultMod'] = 'txdlfindexing';
 
-// Check path to typo3/ directory (depending on local/global installation of extension)
-// TODO: This is quite ugly and should be changed to something nicer!
-if (file_exists(dirname(__FILE__).'/../../../../'.TYPO3_mainDir.'alt_db_navframe.php')) {
-
-	$MCONF['navFrameScript'] = '../../../../'.TYPO3_mainDir.'alt_db_navframe.php';
-
-} elseif (file_exists(dirname(__FILE__).'/../../../alt_db_navframe.php')) {
-
-	$MCONF['navFrameScript'] = '../../../alt_db_navframe.php';
-
-}
-
 $MLANG['default']['tabs_images']['tab'] = '../res/icons/txdlfmodules.png';
 
 $MLANG['default']['ll_ref'] = 'LLL:EXT:dlf/modules/locallang_mod.xml';


### PR DESCRIPTION
Backend modules below the WEB-module always include the common
TYPO3-pagetree.

As Goobi.Presentation has its own main module we have to add the pagetree
manually. This is done with t3lib_extMgm::addNavigationComponent which is
working in all supported TYPO3 versions from 4.5 to 6.2.
