### PR TITLE
result of sorted volumes is wrong

### DIFF
--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -273,7 +273,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 				'tx_dlf_documents,tx_dlf_structures',
 				$whereClause,
 				'',
-				'tx_dlf_documents.volume_sorting',
+				'CAST(tx_dlf_documents.volume_sorting AS UNSIGNED)',
 				''
 			);
 


### PR DESCRIPTION
The attribute order of mods:part hast to be a positive integer.
As I can see the belonging database field is
tx_dlf_documents.volume_sorting - but it is of the type tinytext.
As a consequence the result of sorted volumes is wrong like this:
[...]/390/40/400/450/50/500/[...]
So I use "CAST ... AS UNSIGNED" to get a correct volume list but it
would be better to change the data type of the affected database field.
