### PR TITLE
remove ext_update from ext_autoload.php

### DIFF
--- a/dlf/ext_autoload.php
+++ b/dlf/ext_autoload.php
@@ -25,7 +25,6 @@
 $extensionPath = t3lib_extMgm::extPath('dlf');
 
 return array (
-	'ext_update' => $extensionPath.'class.ext_update.php',
 	'tx_dlf_cli' => $extensionPath.'cli/class.tx_dlf_cli.php',
 	'tx_dlf_document' => $extensionPath.'common/class.tx_dlf_document.php',
 	'tx_dlf_format' => $extensionPath.'common/class.tx_dlf_format.php',


### PR DESCRIPTION
Adding the ext_update class inside dlf:ext_autoload.php breaks _all_ update
scripts of other extensions in TYPO3 > 6.0.

The error message points to the problem:

"class ext_update for this run does already exist, requiring impossible".

ext_update is available in plenty extensions. We must not preload it for
the dlf extension.
