### PR TITLE
Fix facet limit

### DIFF
--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -649,6 +649,9 @@ class tx_dlf_search extends tx_dlf_plugin {
 		$search['params']['facet'] = 'true';
 
 		$search['params']['facet.field'] = array_keys($this->conf['facets']);
+		
+		//override SOLR default value for facet.limit of 100 
+		$search['params']['facet.limit'] = $this->conf['limitFacets'];
 
 		// Perform search.
 		$results = $solr->service->search($search['query'], 0, $this->conf['limit'], $search['params']);

--- a/dlf/plugins/search/flexform.xml
+++ b/dlf/plugins/search/flexform.xml
@@ -164,7 +164,7 @@
 								<eval>num,int</eval>
 								<range>
 									<lower>1</lower>
-									<upper>100</upper>
+									<upper>50000</upper>
 								</range>
 								<default>15</default>
 							</config>

--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -273,7 +273,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 				'tx_dlf_documents,tx_dlf_structures',
 				$whereClause,
 				'',
-				'CAST(tx_dlf_documents.volume_sorting AS UNSIGNED)',
+				'tx_dlf_documents.volume_sorting',
 				''
 			);
 

--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -273,7 +273,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 				'tx_dlf_documents,tx_dlf_structures',
 				$whereClause,
 				'',
-				'tx_dlf_documents.volume_sorting',
+				'CAST(tx_dlf_documents.volume_sorting AS UNSIGNED)',
 				''
 			);
 


### PR DESCRIPTION
If you want to make for example an alphabetical index of persons, you
need all entries of the selected facet "persons". If you set
"limitFacets" in the typo3 backend, the maximum value is 100. I think it
is inconseqent to offer the possibility to set this value - but only
until 100.
If you need more than 100 entries for a facet, you have to set
facet.limit of SOLR because by default facet.limit=100.
