### PR TITLE
Fix search in collection and document

### DIFF
--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -504,6 +504,77 @@ class tx_dlf_helper {
 	}
 
 	/**
+	 * Get the UID for a given "index_name"
+	 *
+	 * @access	public
+	 *
+	 * @param	integer		$index_name: The index_name of the record
+	 * @param	string		$table: Get the "index_name" from this table
+	 * @param	integer		$pid: Get the "index_name" from this page
+	 *
+	 * @return	string		"uid" for the given index_name
+	 */
+	public static function getIdFromIndexName($index_name, $table, $pid = -1) {
+
+		// Save parameters for logging purposes.
+		$_index_name = $index_name;
+
+		$_pid = $pid;
+
+		if (!$index_name || !in_array($table, array ('tx_dlf_collections', 'tx_dlf_libraries', 'tx_dlf_metadata', 'tx_dlf_structures', 'tx_dlf_solrcores'))) {
+
+			if (TYPO3_DLOG) {
+
+				t3lib_div::devLog('[tx_dlf_helper->getIdFromIndexName('.$_index_name.', '.$table.', '.$_pid.')] Invalid UID "'.$index_name.'" or table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+
+			}
+
+			return '';
+
+		}
+
+		$where = '';
+
+		// Should we check for a specific PID, too?
+		if ($pid !== -1) {
+
+			$pid = max(intval($pid), 0);
+
+			$where = ' AND '.$table.'.pid='.$pid;
+
+		}
+
+		// Get index_name from database.
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			$table.'.uid AS uid',
+			$table,
+			$table.'.index_name='.$index_name.$where.self::whereClause($table),
+			'',
+			'',
+			'1'
+		);
+
+		if ($GLOBALS['TYPO3_DB']->sql_num_rows($result) > 0) {
+
+			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+
+			return $resArray['uid'];
+
+		} else {
+
+			if (TYPO3_DLOG) {
+
+				t3lib_div::devLog('[tx_dlf_helper->getIdFromIndexName('.$_index_name.', '.$table.', '.$_pid.')] No UID for given "index_name" "'.$index_name.'" and PID "'.$pid.'" found in table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+
+			}
+
+			return '';
+
+		}
+
+	}
+
+	/**
 	 * Get language name from ISO code
 	 *
 	 * @access	public

--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -421,7 +421,6 @@ class tx_dlf_search extends tx_dlf_plugin {
 			return $content;
 
 		}
-			t3lib_div::devLog('[tx_dlf_search->main('.$content.', [data])] piVars', $this->extKey, SYSLOG_SEVERITY_ERROR, $this->piVars);
 
 		if (!isset($this->piVars['query']) && empty($this->piVars['extQuery'])) {
 

--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -97,6 +97,23 @@ class tx_dlf_search extends tx_dlf_plugin {
 			// Get collection's UID.
 			return '<input type="hidden" name="'.$this->prefixId.'[collection]" value="'.$list->metadata['options']['select'].'" />';
 
+		} else if (!empty($list->metadata['options']['params']['fq'])) {
+
+			// get collection's UID from search metadata
+			foreach ($list->metadata['options']['params']['fq'] as $id => $facet) {
+
+				$facetKeyVal = explode(':', $facet, 2);
+
+				if ($facetKeyVal[0] == 'collection_faceting') {
+
+					$collectionId = tx_dlf_helper::getIdFromIndexName($facetKeyVal[1], 'tx_dlf_collections');
+
+				}
+
+			}
+
+			return '<input type="hidden" name="'.$this->prefixId.'[collection]" value="'.$collectionId.'" />';
+
 		}
 
 		return '';
@@ -112,6 +129,9 @@ class tx_dlf_search extends tx_dlf_plugin {
 	 */
 	protected function addCurrentDocument() {
 
+		// Load current list object.
+		$list = t3lib_div::makeInstance('tx_dlf_list');
+
 		// Load current document.
 		if (!empty($this->piVars['id']) && tx_dlf_helper::testInt($this->piVars['id'])) {
 
@@ -123,6 +143,23 @@ class tx_dlf_search extends tx_dlf_plugin {
 				return '<input type="hidden" name="'.$this->prefixId.'[id]" value="'.($this->doc->parentId > 0 ? $this->doc->parentId : $this->doc->uid).'" />';
 
 			}
+
+		} else if (!empty($list->metadata['options']['params']['fq'])) {
+
+			// get document's UID from search metadata
+			foreach ($list->metadata['options']['params']['fq'] as $id => $facet) {
+
+				$facetKeyVal = explode(':', $facet);
+
+				if ($facetKeyVal[0] == 'uid') {
+
+					$documentId = (int)substr($facetKeyVal[1],0,strpos($facetKeyVal[1], ' '));
+
+				}
+
+			}
+
+			return '<input type="hidden" name="'.$this->prefixId.'[id]" value="'.$documentId.'" />';
 
 		}
 
@@ -330,7 +367,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 			$entryArray['ITEM_STATE'] = 'CUR';
 
 			$state = 'ACTIFSUB';
-			
+
 			//Reset facets
 			if ($this->conf['resetFacets']) {
 				//remove ($count) for selected facet in template
@@ -384,6 +421,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 			return $content;
 
 		}
+			t3lib_div::devLog('[tx_dlf_search->main('.$content.', [data])] piVars', $this->extKey, SYSLOG_SEVERITY_ERROR, $this->piVars);
 
 		if (!isset($this->piVars['query']) && empty($this->piVars['extQuery'])) {
 
@@ -549,7 +587,6 @@ class tx_dlf_search extends tx_dlf_plugin {
 				}
 
 			}
-
 			$solr->params = $params;
 
 			// Perform search.
@@ -649,8 +686,8 @@ class tx_dlf_search extends tx_dlf_plugin {
 		$search['params']['facet'] = 'true';
 
 		$search['params']['facet.field'] = array_keys($this->conf['facets']);
-		
-		//override SOLR default value for facet.limit of 100 
+
+		//override SOLR default value for facet.limit of 100
 		$search['params']['facet.limit'] = $this->conf['limitFacets'];
 
 		// Perform search.


### PR DESCRIPTION
The search plugin supports limiting the search in current document and/or collection. This setting get's lost after the search results are listet. A follow-up search will search in all available documents and collections.

This fix gets the document or collection UID from the available facet search metadata.
