### PR TITLE
Two small code fixes

### DIFF
--- a/dlf/cli/class.tx_dlf_cli.php
+++ b/dlf/cli/class.tx_dlf_cli.php
@@ -115,7 +115,7 @@ class tx_dlf_cli extends t3lib_cli {
 		);
 
 		// Run parent constructor.
-		parent::t3lib_cli();
+		parent::__construct();
 
 	}
 

--- a/dlf/plugins/search/setup.txt
+++ b/dlf/plugins/search/setup.txt
@@ -15,7 +15,7 @@ plugin.tx_dlf_search.facetsConf {
 		ACT < .NO
 		ACT.wrapItemAndSub = <li class="tx-dlf-search-act">|</li>
 		ACTIFSUB < .NO
-		ACTIFSUB.wrapItemAndSub = <li class="tx-dlf-search-act" tx-dlf-search-ifsub>|</li>
+		ACTIFSUB.wrapItemAndSub = <li class="tx-dlf-search-act tx-dlf-search-ifsub">|</li>
 	}
 	2 < .1
 	2 {


### PR DESCRIPTION
One of them is needed for newer versions of TYPO3 (especially for the current LTS version 6.2). We did not test it with old TYPO3 LTS 4.5, but I expect that it will work there, too.
Another bug was detected while we validated the generated HTML code.
