### PR TITLE
Add highlight feature of fulltext blocks in ALTO format

### DIFF
--- a/dlf/ext_autoload.php
+++ b/dlf/ext_autoload.php
@@ -56,6 +56,7 @@ return array (
 	'tx_dlf_toc' => $extensionPath.'plugins/toc/class.tx_dlf_toc.php',
 	'tx_dlf_toolbox' => $extensionPath.'plugins/toolbox/class.tx_dlf_toolbox.php',
 	'tx_dlf_toolsPdf' => $extensionPath.'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php',
+	'tx_dlf_toolsFulltext' => $extensionPath.'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php',
 	'tx_dlf_validator' => $extensionPath.'plugins/validator/class.tx_dlf_validator.php',
 	'tx_dlf_doctype' => $extensionPath.'plugins/doctype/class.tx_dlf_doctype.php'
 );

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -54,6 +54,8 @@ t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/validator/class.tx_dlf_validator.ph
 // Register tools for toolbox plugin.
 t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', TRUE);
 
+t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php', '_toolsFulltext', '', TRUE);
+
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][t3lib_extMgm::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
 
 // Register hooks.

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -68,6 +68,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys'][$_EXTKEY] = array
 
 // Register AJAX eID handlers.
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_suggest'] = 'EXT:'.$_EXTKEY.'/plugins/search/class.tx_dlf_search_suggest.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_fulltext_eid'] = 'EXT:'.$_EXTKEY.'/plugins/pageview/class.tx_dlf_fulltext_eid.php';
 
 
 if (TYPO3_MODE === 'FE') {

--- a/dlf/plugins/pageview/OpenLayers_Format_Alto.js
+++ b/dlf/plugins/pageview/OpenLayers_Format_Alto.js
@@ -68,7 +68,7 @@ OpenLayers.Format.ALTO = OpenLayers.Class(OpenLayers.Format.XML, {
         // Loop throught the following node types in this order and
         // process the nodes found
         //~ var types = ["TextBlock", "TextLine", "String"];
-        var types = ["PrintSpace", "TextBlock",  "String"];
+        var types = ["PrintSpace", "TextBlock", "TextLine", "String", "SP", "HYP"];
 
         for(var i=0, len=types.length; i<len; ++i) {
             var type = types[i];

--- a/dlf/plugins/pageview/OpenLayers_Format_Alto.js
+++ b/dlf/plugins/pageview/OpenLayers_Format_Alto.js
@@ -1,0 +1,195 @@
+/**
+/**
+ * @requires OpenLayers/Format/XML.js
+ *
+ */
+OpenLayers.Format.ALTO = OpenLayers.Class(OpenLayers.Format.XML, {
+
+    /**
+     * Property: namespaces
+     * {Object} Mapping of namespace aliases to namespace URIs.
+     */
+    namespaces: {
+        alto: "http://www.loc.gov/standards/alto/ns-v2#",
+        xsi: "http://www.w3.org/2001/XMLSchema-instance"
+    },
+
+    /**
+     * Property: features
+     * {Array} Array of features
+     *
+     */
+    features: null,
+
+	initialize: function(options) {
+
+        OpenLayers.Format.XML.prototype.initialize.apply(this, [options]);
+
+    },
+
+    /**
+     * APIMethod: read
+     * Read data from a string, and return a list of features.
+     *
+     * Parameters:
+     * data    - {String} or {DOMElement} data to read/parse.
+     *
+     * Returns:
+     * {Array(<OpenLayers.Feature.Vector>)} List of features.
+     */
+    read: function(data) {
+        this.features = [];
+
+        // Set default options
+        var options = {
+            depth: 0,
+        };
+
+        return this.parseData(data, options);
+    },
+
+   /**
+     * Method: parseData
+     * Read data from a string, and return a list of features.
+     *
+     * Parameters:
+     * data    - {String} or {DOMElement} data to read/parse.
+     * options - {Object} Hash of options
+     *
+     * Returns:
+     * {Array(<OpenLayers.Feature.Vector>)} List of features.
+     */
+    parseData: function(data, options) {
+
+        if(typeof data == "string") {
+            data = OpenLayers.Format.XML.prototype.read.apply(this, [data]);
+        }
+
+        // Loop throught the following node types in this order and
+        // process the nodes found
+        //~ var types = ["TextBlock", "TextLine", "String"];
+        var types = ["PrintSpace", "TextBlock",  "String"];
+
+        for(var i=0, len=types.length; i<len; ++i) {
+            var type = types[i];
+
+            var nodes = this.getElementsByTagNameNS(data, this.namespaces.alto, type);
+
+            // skip to next type if no nodes are found
+            if(nodes.length == 0) {
+                continue;
+            }
+
+            switch (type) {
+
+                // Get Printspace
+                case "PrintSpace":
+                   this.parseTextBlock(nodes, options);
+                    //~ var geometry = this.parsePrintSpace(nodes);
+
+					// can't we scale already here?
+                    //~ tx_dlf_viewer.setOrigImage(geometry[0], geometry[1]);
+
+                    break;
+
+                // Fetch external links
+                case "TextBlock":
+                   this.parseTextBlock(nodes, options);
+                    break;
+
+                // parse style information
+                case "TextLine":
+                    this.parseTextBlock(nodes, options);
+					//~ this.parseStyles(nodes, options);
+                    break;
+
+                case "String":
+                    this.parseTextBlock(nodes, options);
+                        //~ this.parseStyleMaps(nodes, options);
+                    break;
+
+            }
+
+        }
+        //~ console.dir(this.features);
+
+        return this.features;
+    },
+
+   /**
+     * Method: parseTextBlock
+     * Finds TextBlocks of Alto files
+     *
+     * Parameters:
+     * nodes   - {Array} of {DOMElement} data to read/parse.
+     * options - {Object} Hash of options
+     *
+     */
+    parsePrintSpace: function(nodes) {
+
+		var geometry = [];
+
+		geometry.push(parseInt(nodes[0].getAttribute("WIDTH")));
+		geometry.push(parseInt(nodes[0].getAttribute("HEIGHT")));
+
+        return geometry;
+
+    },
+
+   /**
+     * Method: parseTextBlock
+     * Finds TextBlocks of Alto files
+     *
+     * Parameters:
+     * nodes   - {Array} of {DOMElement} data to read/parse.
+     * options - {Object} Hash of options
+     *
+     */
+    parseTextBlock: function(nodes, options) {
+
+		var features = [];
+
+		for (var i = 0; i < nodes.length; i++) {
+
+			features.push(this.parseFeature(nodes[i]));
+
+        }
+
+        // add new features to existing feature list
+        this.features = this.features.concat(features);
+
+    },
+
+
+	/**
+	 * Method: parseFeature
+	 * This function is the core of the GML parsing code in OpenLayers.
+	 *    It creates the geometries that are then attached to the returned
+	 *    feature, and calls parseAttributes() to get attribute data out.
+	 *
+	 * Parameters:
+	 * node - {DOMElement} A GML feature node.
+	 */
+    parseFeature: function(node) {
+
+		var type = node.nodeName;
+
+		// save String attribute if present
+		var word = node.getAttribute("CONTENT");
+
+		//extracting the coordinates
+		var coords = [];
+
+		coords['x1'] = parseInt(node.getAttribute("HPOS"));
+		coords['y1'] = parseInt(node.getAttribute("VPOS"));
+		coords['x2'] = parseInt(node.getAttribute("WIDTH")) + coords['x1'];
+		coords['y2'] = parseInt(node.getAttribute("HEIGHT")) + coords['y1'];
+
+		var feature = {type:type, coords:coords, word:word};
+
+        return feature;
+    },
+
+    CLASS_NAME: "OpenLayers.Format.ALTO"
+
+});

--- a/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
@@ -1,0 +1,92 @@
+<?php
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2015 Alexander Bigga <alexander.bigga@slub-dresden.de>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+
+/**
+ * Plugin 'DFG-Viewer: SRU Client eID script' for the 'dfgviewer' extension.
+ *
+ * @author	Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @copyright	Copyright (c) 2015, Alexander Bigga, SLUB Dresden
+ * @package	TYPO3
+ * @subpackage	tx_dlf
+ * @access	public
+ */
+class tx_dlf_fulltext_eid extends tslib_pibase {
+
+	/**
+	 *
+	 */
+	public $cObj;
+
+
+	/**
+	 * The main method of the eID-Script
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	void
+	 */
+	public function main($content = '', $conf = array ()) {
+
+		$this->cObj = t3lib_div::makeInstance('tslib_cObj');
+
+		// Load translation files.
+		$LANG = t3lib_div::makeInstance('language');
+
+		$this->extKey = 'dlf';
+
+		$this->scriptRelPath = 'plugins/pageviewer/class.tx_dlf_fulltext_eid.php';
+
+		$this->LLkey = t3lib_div::_GP('L') ? t3lib_div::_GP('L') : 'default';
+
+		$this->pi_loadLL();
+
+		$url = t3lib_div::_GP('url');
+
+		$fulltextData = file_get_contents($url);
+
+		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
+		header('Cache-Control: no-cache, must-revalidate');
+		header('Pragma: no-cache');
+		header('Content-Length: '.strlen($fulltextData));
+		header('Content-Type: text/xml');
+
+		echo $fulltextData;
+
+	}
+
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php']);
+}
+
+$cObj = t3lib_div::makeInstance('tx_dlf_fulltext_eid');
+
+$cObj->main();
+
+?>

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -150,6 +150,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			'OpenLayers/Lang/'.$this->lang.'.js',
 			'OpenLayers/Events.js',
 			'OpenLayers/Events/buttonclick.js',
+			'OpenLayers/Events/featureclick.js',
 			'OpenLayers/Animation.js',
 			'OpenLayers/Tween.js',
 			'OpenLayers/Projection.js',
@@ -180,6 +181,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		// Load required OpenLayers components.
 		$componentsFulltexts = array (
 			// Geometry layer --> dfgviewer
+			'OpenLayers/Control/SelectFeature.js',
 			'OpenLayers/Control/DrawFeature.js',
 			'OpenLayers/Handler/Feature.js',
 			'OpenLayers/Handler/RegularPolygon.js',
@@ -197,6 +199,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			'OpenLayers/Renderer.js',
 			'OpenLayers/Renderer/Elements.js',
 			'OpenLayers/Renderer/SVG.js',
+			'OpenLayers/Renderer/Canvas.js',
 			'OpenLayers/StyleMap.js',
 			'OpenLayers/Style.js',
 			// XML Parser.

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -47,6 +47,14 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 	protected $controls = array ();
 
 	/**
+	 * Flag if fulltexts are present
+	 *
+	 * @var	boolean
+	 * @access protected
+	 */
+	protected $hasFulltexts = false;
+
+	/**
 	 * Holds the dependencies of the control features
 	 *
 	 * @var	array
@@ -167,6 +175,10 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			'OpenLayers/Layer/HTTPRequest.js',
 			'OpenLayers/Layer/Grid.js',
 			'OpenLayers/Layer/Image.js',
+		);
+
+		// Load required OpenLayers components.
+		$componentsFulltexts = array (
 			// Geometry layer --> dfgviewer
 			'OpenLayers/Control/DrawFeature.js',
 			'OpenLayers/Handler/Feature.js',
@@ -204,6 +216,11 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 			$components = array_merge($components, array_diff($this->controlDependency[$control], $components));
 
+		}
+
+		// Add fulltext polygon features.
+		if ($this->hasFulltexts) {
+			$components = array_merge($components, $componentsFulltexts);
 		}
 
 		$output[] = '<script type="text/javascript">';
@@ -246,7 +263,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		tx_dlf_helper::loadJQuery();
 
 		// Add OpenLayers library.
-		$output[] = $this->addOpenLayersJS();
+		$output[] = $this->addOpenLayersJS($fulltexts);
 
 		// Add viewer library.
 		$output[] = '
@@ -331,7 +348,12 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			// Get fulltext link.
 			if (!empty($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrpFulltext])) {
 
-				$imageUrl = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrpFulltext]);
+				$fulltextUrl = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrpFulltext]);
+
+				// Build typolink configuration array.
+				$fulltextUrl =  '/index.php?eID=tx_dlf_fulltext_eid&url='. $fulltextUrl;
+
+				$this->hasFulltexts = true;
 
 				break;
 
@@ -347,7 +369,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 		}
 
-		return $imageUrl;
+		return $fulltextUrl;
 
 	}
 

--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -332,7 +332,7 @@ dlfViewer.prototype.init = function() {
 
 		if (this.fulltexts[i]) {
 
-			fullTextCoordinates[i] = this.loadALTO("http://dfgviewer/?eID=tx_dlf_fulltext_eid&url=" + this.fulltexts[i]);
+			fullTextCoordinates[i] = this.loadALTO(this.fulltexts[i]);
 
 		}
 

--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -328,7 +328,6 @@ dlfViewer.prototype.init = function() {
 
 		}
 
-
 	}
 
 	// Add default controls to controls array.
@@ -371,11 +370,29 @@ dlfViewer.prototype.init = function() {
 	// add polygon layer if any
 	if (this.highlightFields.length) {
 
+		if (! this.highlightLayer) {
+
+			this.highlightLayer = new OpenLayers.Layer.Vector(
+									"HightLight Words"
+								);
+		}
+
 		for (var i in this.highlightFields) {
 
-			var polygon = this.createPolygon(this.highlightFields[i][0], this.highlightFields[i][1], this.highlightFields[i][2], this.highlightFields[i][3], 'String');
+			if (this.origImages[0].scale == 0) {
 
-			this.addPolygonlayer(this.highlightLayer, polygon, 1);
+				// scale may be still zero in this context
+				this.origImages[0] = {
+
+					'scale': this.images[0].width/this.origImages[0].width,
+
+				};
+
+			}
+
+			var polygon = this.createPolygon(0, this.highlightFields[i][0], this.highlightFields[i][1], this.highlightFields[i][2], this.highlightFields[i][3]);
+
+			this.addPolygonlayer(this.highlightLayer, polygon, 'String');
 
 		}
 
@@ -536,8 +553,6 @@ dlfViewer.prototype.addHightlightField = function(x1, y1, x2, y2) {
  */
 dlfViewer.prototype.createPolygon = function(image, x1, y1, x2, y2) {
 
-	//~ alert('image p1 ' + x1 + ' x ' + y1 + ' p2 ' + x2 + ' x ' + y2 + 'offset: ' + offset);
-
 	if (this.origImages.length > 1 && image == 1) {
 
 		var scale = this.origImages[1].scale;
@@ -551,6 +566,8 @@ dlfViewer.prototype.createPolygon = function(image, x1, y1, x2, y2) {
 		var offset = 0;
 
 	}
+
+	//~ alert('image ' + image + ' scale: ' + scale + ' height: ' + height + ' offset: ' + offset);
 
 	var polygon = new OpenLayers.Geometry.Polygon (
 		new OpenLayers.Geometry.LinearRing (
@@ -716,6 +733,7 @@ dlfViewer.prototype.drawBox = function(bounds) {
  * @return	void
  */
 dlfViewer.prototype.setOrigImage = function(i, width, height) {
+
 
 	if (width && height) {
 

--- a/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
+++ b/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
@@ -94,7 +94,7 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
 
 		// Get single page downloads.
 		if (!empty($fullTextFile)) {
-			$markerArray['###FULLTEXT_SELECT###'] = '<a class="select" title="'.$this->pi_getLL('fulltext-select', '', TRUE).'" onclick="tx_dlf_viewer.fulltextSelect();">'.$this->pi_getLL('fulltext-select', '', TRUE).'</a>';
+			$markerArray['###FULLTEXT_SELECT###'] = '<a class="select" title="'.$this->pi_getLL('fulltext-select', '', TRUE).'" onclick="tx_dlf_viewer.toogleFulltextSelect();">'.$this->pi_getLL('fulltext-select', '', TRUE).'</a>';
 		} else {
 			$markerArray['###FULLTEXT_SELECT###'] = $this->pi_getLL('fulltext-select', '', TRUE);
 		}
@@ -108,8 +108,8 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
 
 }
 
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php'])	{
-	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php']);
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php']);
 }
 
 ?>

--- a/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
+++ b/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
@@ -1,0 +1,115 @@
+<?php
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2015 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+/**
+ * Tool 'Fulltext selection' for the plugin 'DLF: Toolbox' of the 'dlf' extension.
+ *
+ * @author	Sebastian Meyer <sebastian.meyer@slub-dresden.de>
+ * @author	Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @package	TYPO3
+ * @subpackage	tx_dlf
+ * @access	public
+ */
+class tx_dlf_toolsFulltext extends tx_dlf_plugin {
+
+	public $scriptRelPath = 'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php';
+
+	/**
+	 * The main method of the PlugIn
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	string		The content that is displayed on the website
+	 */
+	public function main($content, $conf) {
+
+		$this->init($conf);
+
+		// Merge configuration with conf array of toolbox.
+		$this->conf = t3lib_div::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+
+		// Load current document.
+		$this->loadDocument();
+
+		if ($this->doc === NULL || $this->doc->numPages < 1 || empty($this->conf['fileGrpFulltext'])) {
+
+			// Quit without doing anything if required variables are not set.
+			return $content;
+
+		} else {
+
+			// Set default values if not set.
+			// page may be integer or string (pyhsical page attribute)
+			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
+
+				$this->piVars['page'] = tx_dlf_helper::intInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
+
+			} else {
+
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+
+			}
+
+			$this->piVars['double'] = tx_dlf_helper::intInRange($this->piVars['double'], 0, 1, 0);
+
+		}
+
+		// Load template file.
+		if (!empty($this->conf['templateFile'])) {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['templateFile']), '###TEMPLATE###');
+
+		} else {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource('EXT:dlf/plugins/toolbox/tools/fulltext/template.tmpl'), '###TEMPLATE###');
+
+		}
+
+
+		$fullTextFile = $this->doc->physicalPagesInfo[$this->doc->physicalPages[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
+
+		// Get single page downloads.
+		if (!empty($fullTextFile)) {
+			$markerArray['###FULLTEXT_SELECT###'] = '<a class="select" title="'.$this->pi_getLL('fulltext-select', '', TRUE).'" onclick="tx_dlf_viewer.fulltextSelect();">'.$this->pi_getLL('fulltext-select', '', TRUE).'</a>';
+		} else {
+			$markerArray['###FULLTEXT_SELECT###'] = $this->pi_getLL('fulltext-select', '', TRUE);
+		}
+
+
+		$content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+
+		return $this->pi_wrapInBaseClass($content);
+
+	}
+
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php']);
+}
+
+?>

--- a/dlf/plugins/toolbox/tools/fulltext/locallang.xml
+++ b/dlf/plugins/toolbox/tools/fulltext/locallang.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<!--
+  Copyright notice
+
+  (c) 2011 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
+  All rights reserved
+
+  This script is part of the TYPO3 project. The TYPO3 project is
+  free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  The GNU General Public License can be found at
+  http://www.gnu.org/copyleft/gpl.html.
+
+  This script is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  This copyright notice MUST APPEAR in all copies of the script!
+-->
+<T3locallang>
+	<meta type="array">
+		<type>module</type>
+		<description>Language labels for tool tx_dlf_toolsPdf</description>
+	</meta>
+	<data type="array">
+		<languageKey index="default" type="array">
+			<label index="fulltext-select">Select Fulltext</label>
+		</languageKey>
+		<languageKey index="de" type="array">
+			<label index="fulltext-select">Volltext markieren</label>
+		</languageKey>
+	</data>
+</T3locallang>

--- a/dlf/plugins/toolbox/tools/fulltext/template.tmpl
+++ b/dlf/plugins/toolbox/tools/fulltext/template.tmpl
@@ -1,0 +1,25 @@
+<!--
+  Copyright notice
+
+  (c) 2015 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
+  All rights reserved
+
+  This script is part of the TYPO3 project. The TYPO3 project is
+  free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  The GNU General Public License can be found at
+  http://www.gnu.org/copyleft/gpl.html.
+
+  This script is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  This copyright notice MUST APPEAR in all copies of the script!
+-->
+<!-- ###TEMPLATE### -->
+<span class="tx-dlf-tools-fulltext">###FULLTEXT_SELECT###</span>
+<!-- ###TEMPLATE### -->

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -67,7 +67,16 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			$this->piVars['page'] = tx_dlf_helper::intInRange($this->piVars['page'], 1, $this->doc->numPages, 1);
+			// page may be integer or string (pyhsical page attribute)
+			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
+
+				$this->piVars['page'] = tx_dlf_helper::intInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
+
+			} else {
+
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+
+			}
 
 			$this->piVars['double'] = tx_dlf_helper::intInRange($this->piVars['double'], 0, 1, 0);
 


### PR DESCRIPTION
This adds a new feature to Goobi.Presenation. If your METS documents provides fulltexts in ALTO format, the available textblocks are highlighted. By drawing a rectangular polygon you can select the fulltext.

You still need some configuration (Toolbox) and styling to see this feature in progress.
