### PR TITLE
Avoid calling deprecated method t3lib_div::loadTCA for TYPO3 6.1 and new...

### DIFF
--- a/dlf/ext_tables.php
+++ b/dlf/ext_tables.php
@@ -221,7 +221,9 @@ $TCA['tx_dlf_libraries'] = array (
 t3lib_extMgm::addStaticFile($_EXTKEY, 'typoscript/', 'Basic Configuration');
 
 // Register plugins.
-t3lib_div::loadTCA('tt_content');
+if (version_compare(TYPO3_branch, '6.1', '<')) {
+	t3lib_div::loadTCA('tt_content');
+}
 
 // Plugin "collection".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_collection'] = 'layout,select_key,pages,recursive';

--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -341,7 +341,9 @@ class tx_dlf_em {
 			// Set allowed exclude fields.
 			foreach ($settings['tables_modify'] as $table) {
 
-				t3lib_div::loadTCA($table);
+				if (version_compare(TYPO3_branch, '6.1', '<')) {
+					t3lib_div::loadTCA($table);
+				}
 
 				foreach ($GLOBALS['TCA'][$table]['columns'] as $field => $fieldConf) {
 

--- a/dlf/modules/newclient/index.php
+++ b/dlf/modules/newclient/index.php
@@ -105,7 +105,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		include_once(t3lib_extMgm::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
 
 		// Load table configuration array to get default field values.
-		t3lib_div::loadTCA('tx_dlf_metadata');
+		if (version_compare(TYPO3_branch, '6.1', '<')) {
+			t3lib_div::loadTCA('tx_dlf_metadata');
+		}
 
 		$i = 0;
 


### PR DESCRIPTION
...er

t3lib_div::loadTCA was deprecated in TYPO3 6.1. It is now an empty
method. Don't use it with TYPO3 6.1 or later versions because that
would fill the deprecation log of TYPO3 (if it is enabled).

Signed-off-by: Stefan Weil sw@weilnetz.de

See also
http://forum.typo3.org/index.php/t/199177/
https://forge.typo3.org/issues/47835
