### PR TITLE
Replace deprecated function t3lib_div::array_merge_recursive_overrule

### DIFF
--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -54,6 +54,28 @@ class tx_dlf_helper {
 	protected static $locallang = array ();
 
 	/**
+	 * Implements array_merge_recursive_overrule() in a cross-version way.
+	 *
+	 * This code is a copy from realurl, written by Dmitry Dulepov <dmitry.dulepov@gmail.com>.
+	 *
+	 * @param array $array1
+	 * @param array $array2
+	 * @return array
+	 */
+	static public function array_merge_recursive_overrule($array1, $array2) {
+		if (class_exists('\\TYPO3\\CMS\\Core\\Utility\\ArrayUtility')) {
+			/** @noinspection PhpUndefinedClassInspection PhpUndefinedNamespaceInspection */
+			\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($array1, $array2);
+		}
+		else {
+			/** @noinspection PhpDeprecationInspection */
+			$array1 = t3lib_div::array_merge_recursive_overrule($array1, $array2);
+		}
+
+		return $array1;
+	}
+
+	/**
 	 * Searches the array recursively for a given value and returns the corresponding key if successful
 	 * @see http://php.net/array_search
 	 *

--- a/dlf/common/class.tx_dlf_plugin.php
+++ b/dlf/common/class.tx_dlf_plugin.php
@@ -83,7 +83,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 		if (!empty($flexFormConf)) {
 
-			$conf = t3lib_div::array_merge_recursive_overrule($flexFormConf, $conf);
+			$conf = tx_dlf_helper::array_merge_recursive_overrule($flexFormConf, $conf);
 
 		}
 
@@ -92,7 +92,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 		if (is_array($pluginConf)) {
 
-			$conf = t3lib_div::array_merge_recursive_overrule($pluginConf, $conf);
+			$conf = tx_dlf_helper::array_merge_recursive_overrule($pluginConf, $conf);
 
 		}
 
@@ -101,7 +101,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 		if (is_array($generalConf)) {
 
-			$conf = t3lib_div::array_merge_recursive_overrule($generalConf, $conf);
+			$conf = tx_dlf_helper::array_merge_recursive_overrule($generalConf, $conf);
 
 		}
 
@@ -110,7 +110,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 		if (is_array($extConf)) {
 
-			$conf = t3lib_div::array_merge_recursive_overrule($extConf, $conf);
+			$conf = tx_dlf_helper::array_merge_recursive_overrule($extConf, $conf);
 
 		}
 
@@ -119,7 +119,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 		if (is_array($varsConf)) {
 
-			$conf = t3lib_div::array_merge_recursive_overrule($varsConf, $conf);
+			$conf = tx_dlf_helper::array_merge_recursive_overrule($varsConf, $conf);
 
 		}
 
@@ -263,7 +263,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 			}
 
-			$this->piVars = t3lib_div::array_merge_recursive_overrule($this->conf['_DEFAULT_PI_VARS.'], is_array($this->piVars) ? $this->piVars : array ());
+			$this->piVars = tx_dlf_helper::array_merge_recursive_overrule($this->conf['_DEFAULT_PI_VARS.'], is_array($this->piVars) ? $this->piVars : array());
 
 		}
 

--- a/dlf/plugins/collection/class.tx_dlf_collection.php
+++ b/dlf/plugins/collection/class.tx_dlf_collection.php
@@ -214,7 +214,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
 					unset($piVars['DATA']);
 
-					$additionalParams = t3lib_div::array_merge_recursive_overrule($piVars, $additionalParams);
+					$additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
 
 				}
 

--- a/dlf/plugins/navigation/class.tx_dlf_navigation.php
+++ b/dlf/plugins/navigation/class.tx_dlf_navigation.php
@@ -315,7 +315,7 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 
 			unset($piVars['DATA']);
 
-			$overrulePIvars = t3lib_div::array_merge_recursive_overrule($piVars, $overrulePIvars);
+			$overrulePIvars = tx_dlf_helper::array_merge_recursive_overrule($piVars, $overrulePIvars);
 
 		}
 

--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -302,7 +302,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 		$TSconfig['special.']['limit'] = max(intval($this->conf['limitFacets']), 1);
 
-		$TSconfig = t3lib_div::array_merge_recursive_overrule($this->conf['facetsConf.'], $TSconfig);
+		$TSconfig = tx_dlf_helper::array_merge_recursive_overrule($this->conf['facetsConf.'], $TSconfig);
 
 		return $this->cObj->HMENU($TSconfig);
 

--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -189,7 +189,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 
 		$TSconfig['special.']['userFunc'] = 'tx_dlf_toc->makeMenuArray';
 
-		$TSconfig = t3lib_div::array_merge_recursive_overrule($this->conf['menuConf.'], $TSconfig);
+		$TSconfig = tx_dlf_helper::array_merge_recursive_overrule($this->conf['menuConf.'], $TSconfig);
 
 		$markerArray['###TOCMENU###'] = $this->cObj->HMENU($TSconfig);
 

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -54,7 +54,7 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		$this->init($conf);
 
 		// Merge configuration with conf array of toolbox.
-		$this->conf = t3lib_div::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+		$this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
 
 		// Load current document.
 		$this->loadDocument();


### PR DESCRIPTION
That function was deprecated in TYPO3 6.2. Add a helper function which
calls the correct function depending on the TYPO3 version.

This approach was copied from the TYPO3 extension realurl.

Signed-off-by: Stefan Weil sw@weilnetz.de
