### PR TITLE
Fix automated addition of basic configuration (bibliographic metadata)

### DIFF
--- a/dlf/modules/newclient/index.php
+++ b/dlf/modules/newclient/index.php
@@ -142,7 +142,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 				'is_sortable' => $values['is_sortable'],
 				'is_facet' => $values['is_facet'],
 				'is_listed' => $values['is_listed'],
-				'autocomplete' => $value['autocomplete'],
+				'autocomplete' => $values['autocomplete'],
 			);
 
 			$i++;


### PR DESCRIPTION
When adding a new client for the first time (empty configuration),
Goobi.Presentation offers to add the missing configuration but fails
with a database error (Column 'autocomplete' cannot be null).

Fix the typo which caused that error.

Signed-off-by: Stefan Weil sw@weilnetz.de
