### PR TITLE
Fix for issue #21

### DIFF
--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -511,6 +511,11 @@ class tx_dlf_search extends tx_dlf_plugin {
 				}
 
 			}
+			else if (empty($this->piVars['fq']) && $query != "*") {
+			
+				$query = tx_dlf_solr::escapeQuery($query);
+			
+			}
 
 			// Set query parameters.
 			$params = array ();


### PR DESCRIPTION
Adds tx_dlf_solr::escapeQuery($query) to main function of class tx_dlf_search to prevent TYPO3/SOLR exception using special characters mentioned within issue #21.
