### PR TITLE
OAI plugin: Improve error handling for missing configuration

### DIFF
--- a/dlf/plugins/oai/class.tx_dlf_oai.php
+++ b/dlf/plugins/oai/class.tx_dlf_oai.php
@@ -973,7 +973,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 			}
 
-			exit;
+			return $this->error('Incomplete plugin configuration');
 
 		}
 


### PR DESCRIPTION
An OAI request with verb=Identity silently fails when configuration data is missing.
Change this and tell the user more about the problem.

Signed-off-by: Stefan Weil sw@weilnetz.de
