### PR TITLE
plugins/toolbox: Fix class name used for PDF page downloads

### DIFF
--- a/dlf/plugins/toolbox/tools/pdf/template.tmpl
+++ b/dlf/plugins/toolbox/tools/pdf/template.tmpl
@@ -21,6 +21,6 @@
   This copyright notice MUST APPEAR in all copies of the script!
 -->
 <!-- ###TEMPLATE### -->
-<span class="tx-dlf-tools-pdf-site">###PAGE###</span>
+<span class="tx-dlf-tools-pdf-page">###PAGE###</span>
 <span class="tx-dlf-tools-pdf-work">###WORK###</span>
 <!-- ###TEMPLATE### -->


### PR DESCRIPTION
tx-dlf-tools-pdf-site does not look reasonable.
Maybe tx-dlf-tools-pdf-side was intended, but tx-dlf-tools-pdf-page
is even better.

Users who used the old class name will have to fix their installation,
so some remark in the release notes is necessary.
