### PR TITLE
fix #49: check existance of xpath field before querying

### DIFF
--- a/dlf/class.ext_update.php
+++ b/dlf/class.ext_update.php
@@ -74,6 +74,15 @@ class ext_update {
 
 		$uids = array ();
 
+		// check if tx_dlf_metadata.xpath exists anyhow
+		$fieldsInDatabase = $GLOBALS['TYPO3_DB']->admin_get_fields('tx_dlf_metadata');
+
+		if (! in_array('xpath', array_keys($fieldsInDatabase))) {
+
+			return $uids;
+
+		}
+
 		// Get all records with outdated configuration.
 		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
 			'tx_dlf_metadata.uid AS uid',


### PR DESCRIPTION
In dlf < 1.2 the tx_dlf_metadata.xpath field existed. The update script accesses this field in a SQL query. 
This query will fail with an error. This error is shown in the Extension Manager (EM)if SQL-debugging is enabled. 

If EXT:devlog is installed and enabled the EM fails with the error:

<pre>Uncaught TYPO3 Exception: Serialization of 'Closure' is not allowed</pre>
