### PR TITLE
tx_dlf_pageview: Add missing dependency for OpenLayers (fix regression)

### DIFF
--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -65,6 +65,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			'OpenLayers/Control/OverviewMap.js'
 		),
 		'PanPanel' => array (
+			'OpenLayers/Control/Button.js',
 			'OpenLayers/Control/Pan.js',
 			'OpenLayers/Control/Panel.js',
 			'OpenLayers/Control/PanPanel.js'
@@ -77,6 +78,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			'OpenLayers/Control/PanZoomBar.js'
 		),
 		'ZoomPanel' => array (
+			'OpenLayers/Control/Button.js',
 			'OpenLayers/Control/Panel.js',
 			'OpenLayers/Control/ZoomIn.js',
 			'OpenLayers/Control/ZoomOut.js',


### PR DESCRIPTION
Since commit d339b72e17532e96cb69dccd3f70a27c759876a7, the pageview of
Goobi.Presentation is broken (see issue #52).

OpenLayers/Control/Pan.js, OpenLayers/Control/ZoomIn.js,
OpenLayers/Control/ZoomOut.js and OpenLayers/Control/ZoomToMaxExtent.js
require OpenLayers/Control/Button.js.

Without it, neither the controls for zooming nor the page image are shown.

Signed-off-by: Stefan Weil sw@weilnetz.de
