### PR TITLE
tools/fulltext: Replace deprecated function

### DIFF
--- a/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
+++ b/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
@@ -50,7 +50,7 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
 		$this->init($conf);
 
 		// Merge configuration with conf array of toolbox.
-		$this->conf = t3lib_div::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+		$this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
 
 		// Load current document.
 		$this->loadDocument();


### PR DESCRIPTION
t3lib_div::array_merge_recursive_overrule was deprecated in TYPO3 6.2.
Commit c3d61e8c25589b02c2a865874c57f12027da754e had replaced that
function, but the new fulltext code still used the old function.

Signed-off-by: Stefan Weil sw@weilnetz.de
