### PR TITLE
OAI plugin: Fix value of dc:type

### DIFF
--- a/dlf/plugins/oai/class.tx_dlf_oai.php
+++ b/dlf/plugins/oai/class.tx_dlf_oai.php
@@ -222,7 +222,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:format', 'application/mets+xml'));
 
-		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:type', 'text'));
+		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:type', 'Text'));
 
 		if (!empty($metadata['partof'])) {
 


### PR DESCRIPTION
See http://dublincore.org/documents/2010/10/11/dcmi-type-vocabulary/.
The type must be "Text", not "text".

Signed-off-by: Stefan Weil sw@weilnetz.de
