### PR TITLE
tx_dlf_pageview: Fix function signature (reported by PhpStorm)

### DIFF
--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -411,10 +411,9 @@ dlfViewer.prototype.init = function() {
 /**
  * Show Popup with OCR results
  *
- * @param {Object} feature
- * @param {Object} bounds
+ * @param {Object} text
  */
-dlfViewer.prototype.showPopupDiv = function(text, bounds){
+dlfViewer.prototype.showPopupDiv = function(text) {
 
 	var popupHTML = '<div class="ocrText">' + text.replace(/\n/g, '<br />') + '</div>';
 


### PR DESCRIPTION
The function showPopupDiv is called with only a single argument.
Obviously the second argument "bounds" is unused, so simply
remove it.

A similar problem is reported for function loadALTO, but there
the second argument is used, so that one remains unfixed.

Signed-off-by: Stefan Weil sw@weilnetz.de
