### PR TITLE
tools/fulltext: Add missing configuration option

### DIFF
--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -57,6 +57,7 @@ t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_tool
 t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php', '_toolsFulltext', '', TRUE);
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][t3lib_extMgm::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][t3lib_extMgm::getCN($_EXTKEY).'_toolsFulltext'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsFulltext';
 
 // Register hooks.
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = 'EXT:'.$_EXTKEY.'/hooks/class.tx_dlf_tcemain.php:tx_dlf_tcemain';

--- a/dlf/locallang.xml
+++ b/dlf/locallang.xml
@@ -134,6 +134,7 @@
 			<label index="tx_dlf_libraries.tab2">Translation</label>
 			<label index="tx_dlf_libraries.tab3">Catalogs</label>
 			<label index="tx_dlf_toolbox.toolsPdf">PDF Download</label>
+			<label index="tx_dlf_toolbox.toolsFulltext">Fulltext</label>
 			<label index="tt_content.dlf_collection">DLF: Collection</label>
 			<label index="tt_content.dlf_feeds">DLF: Feeds</label>
 			<label index="tt_content.dlf_listview">DLF: List View</label>
@@ -311,6 +312,7 @@
 			<label index="tx_dlf_libraries.tab2">Übersetzung</label>
 			<label index="tx_dlf_libraries.tab3">Kataloge</label>
 			<label index="tx_dlf_toolbox.toolsPdf">PDF-Download</label>
+			<label index="tx_dlf_toolbox.toolsFulltext">Volltext</label>
 			<label index="tt_content.dlf_collection">DLF: Kollektion</label>
 			<label index="tt_content.dlf_feeds">DLF: Feeds</label>
 			<label index="tt_content.dlf_listview">DLF: Listenansicht</label>


### PR DESCRIPTION
Without it, fulltext cannot be configured in the toolbox plugin.

Signed-off-by: Stefan Weil sw@weilnetz.de
