### PR TITLE
Fix function getPageBrowser

### DIFF
--- a/dlf/plugins/listview/class.tx_dlf_listview.php
+++ b/dlf/plugins/listview/class.tx_dlf_listview.php
@@ -70,7 +70,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 	 *
 	 * @return	string		The rendered page browser ready for output
 	 */
-	protected function getPagebrowser() {
+	protected function getPageBrowser() {
 
 		// Get overall number of pages.
 		$maxPages = intval(ceil(count($this->list) / $this->conf['limit']));

--- a/dlf/plugins/listview/class.tx_dlf_listview.php
+++ b/dlf/plugins/listview/class.tx_dlf_listview.php
@@ -83,16 +83,16 @@ class tx_dlf_listview extends tx_dlf_plugin {
 		}
 
 		// Get separator.
-		$separator = $this->pi_getLL('separator', ' - ');
+		$separator = $this->pi_getLL('separator', ' - ', TRUE);
 
 		// Add link to previous page.
 		if ($this->piVars['pointer'] > 0) {
 
-			$output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;'), array ('pointer' => $this->piVars['pointer'] - 1), TRUE).$separator;
+			$output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;', TRUE), array ('pointer' => $this->piVars['pointer'] - 1), TRUE).$separator;
 
 		} else {
 
-			$output = $this->pi_getLL('prevPage', '&lt;').$separator;
+			$output = $this->pi_getLL('prevPage', '&lt;', TRUE).$separator;
 
 		}
 
@@ -105,11 +105,11 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
 				if ($this->piVars['pointer'] != $i) {
 
-					$output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d'), $i + 1), array ('pointer' => $i), TRUE).$separator;
+					$output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d', TRUE), $i + 1), array ('pointer' => $i), TRUE).$separator;
 
 				} else {
 
-					$output .= sprintf($this->pi_getLL('page', '%d'), $i + 1).$separator;
+					$output .= sprintf($this->pi_getLL('page', '%d', TRUE), $i + 1).$separator;
 
 				}
 
@@ -117,7 +117,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
 			} elseif ($skip == TRUE) {
 
-				$output .= $this->pi_getLL('skip', '...').$separator;
+				$output .= $this->pi_getLL('skip', '...', TRUE).$separator;
 
 				$skip = FALSE;
 
@@ -130,11 +130,11 @@ class tx_dlf_listview extends tx_dlf_plugin {
 		// Add link to next page.
 		if ($this->piVars['pointer'] < $maxPages - 1) {
 
-			$output .= $this->pi_linkTP_keepPIvars($this->pi_getLL('nextPage', '&gt;'), array ('pointer' => $this->piVars['pointer'] + 1), TRUE);
+			$output .= $this->pi_linkTP_keepPIvars($this->pi_getLL('nextPage', '&gt;', TRUE), array ('pointer' => $this->piVars['pointer'] + 1), TRUE);
 
 		} else {
 
-			$output .= $this->pi_getLL('nextPage', '&gt;');
+			$output .= $this->pi_getLL('nextPage', '&gt;', TRUE);
 
 		}
 

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -127,16 +127,16 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		}
 
 		// Get separator.
-		$separator = $this->pi_getLL('separator', ' - ');
+		$separator = $this->pi_getLL('separator', ' - ', TRUE);
 
 		// Add link to previous page.
 		if ($this->piVars['pointer'] > 0) {
 
-			$output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;'), array ('pointer' => $this->piVars['pointer'] - 1, 'page' => NULL), TRUE).$separator;
+			$output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;', TRUE), array ('pointer' => $this->piVars['pointer'] - 1, 'page' => NULL), TRUE).$separator;
 
 		} else {
 
-			$output = $this->pi_getLL('prevPage', '&lt;').$separator;
+			$output = $this->pi_getLL('prevPage', '&lt;', TRUE).$separator;
 
 		}
 
@@ -149,11 +149,11 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 
 				if ($this->piVars['pointer'] != $i) {
 
-					$output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d'), $i + 1), array ('pointer' => $i, 'page' => NULL), TRUE).$separator;
+					$output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d', TRUE), $i + 1), array ('pointer' => $i, 'page' => NULL), TRUE).$separator;
 
 				} else {
 
-					$output .= sprintf($this->pi_getLL('page', '%d'), $i + 1).$separator;
+					$output .= sprintf($this->pi_getLL('page', '%d', TRUE), $i + 1).$separator;
 
 				}
 
@@ -161,7 +161,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 
 			} elseif ($skip == TRUE) {
 
-				$output .= $this->pi_getLL('skip', '...').$separator;
+				$output .= $this->pi_getLL('skip', '...', TRUE).$separator;
 
 				$skip = FALSE;
 
@@ -174,11 +174,11 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		// Add link to next page.
 		if ($this->piVars['pointer'] < $maxPages - 1) {
 
-			$output .= $this->pi_linkTP_keepPIvars($this->pi_getLL('nextPage', '&gt;'), array ('pointer' => $this->piVars['pointer'] + 1, 'page' => NULL), TRUE);
+			$output .= $this->pi_linkTP_keepPIvars($this->pi_getLL('nextPage', '&gt;', TRUE), array ('pointer' => $this->piVars['pointer'] + 1, 'page' => NULL), TRUE);
 
 		} else {
 
-			$output .= $this->pi_getLL('nextPage', '&gt;');
+			$output .= $this->pi_getLL('nextPage', '&gt;', TRUE);
 
 		}
 

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -114,7 +114,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 	 *
 	 * @return	string		The rendered page browser ready for output
 	 */
-	protected function getPagebrowser() {
+	protected function getPageBrowser() {
 
 		// Get overall number of pages.
 		$maxPages = intval(ceil($this->doc->numPages / $this->conf['limit']));


### PR DESCRIPTION
- Fix case in function name.
- Make $this->pi_getLL() use htmlspecialchars() to avoid errors in generated HTML code.

Signed-off-by: Stefan Weil sw@weilnetz.de
