### PR TITLE
tools/fulltext: Fix copy+paste errors for year and description

### DIFF
--- a/dlf/plugins/toolbox/tools/fulltext/locallang.xml
+++ b/dlf/plugins/toolbox/tools/fulltext/locallang.xml
@@ -2,7 +2,7 @@
 <!--
   Copyright notice
 
-  (c) 2011 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
+  (c) 2015 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
   All rights reserved
 
   This script is part of the TYPO3 project. The TYPO3 project is
@@ -24,7 +24,7 @@
 <T3locallang>
 	<meta type="array">
 		<type>module</type>
-		<description>Language labels for tool tx_dlf_toolsPdf</description>
+		<description>Language labels for tool tx_dlf_toolsFulltext</description>
 	</meta>
 	<data type="array">
 		<languageKey index="default" type="array">


### PR DESCRIPTION
This code was copied from dlf/plugins/toolbox/tools/pdf/locallang.xml
without fixing the copyright year and the module description.

Fix both.

Signed-off-by: Stefan Weil sw@weilnetz.de
