### PR TITLE
Fix German translation of "periodical"

### DIFF
--- a/dlf/modules/newclient/locallang.xml
+++ b/dlf/modules/newclient/locallang.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <!--
   Copyright notice
-  
+
   (c) 2011 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
   All rights reserved
-  
+
   This script is part of the TYPO3 project. The TYPO3 project is
   free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
-  
+
   The GNU General Public License can be found at
   http://www.gnu.org/copyleft/gpl.html.
-  
+
   This script is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   This copyright notice MUST APPEAR in all copies of the script!
 -->
 <T3locallang>
@@ -153,7 +153,7 @@
 			<label index="ornament">Buchschmuck</label>
 			<label index="paper">Vortrag</label>
 			<label index="paste_down">Spiegel</label>
-			<label index="periodical">Peridica</label>
+			<label index="periodical">Periodikum</label>
 			<label index="preface">Vorwort</label>
 			<label index="preprint">Vorabdruck</label>
 			<label index="printers_mark">Druckermarke</label>


### PR DESCRIPTION
"Peridica" does not look like an existing word. This was "Periodica" before commit 11cfc4320ccbcbc442dd2feef9a89c18ae4462a4, but the plural form is not used for the other translations. Maybe "Zeitschrift" would also fit.

Some whitespace at line endings was removed by my editor.

Signed-off-by: Stefan Weil sw@weilnetz.de
