### PR TITLE
Replace deprecated class t3lib_extMgm

### DIFF
--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -612,11 +612,11 @@ class tx_dlf_helper {
 
 		if (preg_match('/^[a-z]{3}$/', $isoCode)) {
 
-			$file = t3lib_extMgm::extPath(self::$extKey).'lib/ISO-639/iso-639-2b.xml';
+			$file = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath(self::$extKey).'lib/ISO-639/iso-639-2b.xml';
 
 		} elseif (preg_match('/^[a-z]{2}$/', $isoCode)) {
 
-			$file = t3lib_extMgm::extPath(self::$extKey).'lib/ISO-639/iso-639-1.xml';
+			$file = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath(self::$extKey).'lib/ISO-639/iso-639-1.xml';
 
 		} else {
 
@@ -693,7 +693,7 @@ class tx_dlf_helper {
 		// Load common locallang file.
 		if (empty(self::$locallang)) {
 
-			$file = t3lib_extMgm::extPath(self::$extKey, 'common/locallang.xml');
+			$file = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath(self::$extKey, 'common/locallang.xml');
 
 			if (TYPO3_MODE === 'FE') {
 
@@ -936,9 +936,9 @@ class tx_dlf_helper {
 	public static function loadJQuery() {
 
 		// Ensure extension "t3jquery" is available.
-		if (t3lib_extMgm::isLoaded('t3jquery')) {
+		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3jquery')) {
 
-			require_once(t3lib_extMgm::extPath('t3jquery').'class.tx_t3jquery.php');
+			require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('t3jquery').'class.tx_t3jquery.php');
 
 		}
 

--- a/dlf/common/class.tx_dlf_module.php
+++ b/dlf/common/class.tx_dlf_module.php
@@ -122,7 +122,7 @@ abstract class tx_dlf_module extends t3lib_SCbase {
 
 		$this->doc->setModuleTemplate('EXT:'.$this->extKey.'/modules/'.$this->modPath.'template.tmpl');
 
-		$this->doc->getPageRenderer()->addCssFile(t3lib_extMgm::extRelPath($this->extKey) . 'res/backend.css');
+		$this->doc->getPageRenderer()->addCssFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($this->extKey) . 'res/backend.css');
 
 		$this->doc->backPath = $GLOBALS['BACK_PATH'];
 

--- a/dlf/ext_autoload.php
+++ b/dlf/ext_autoload.php
@@ -22,7 +22,7 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-$extensionPath = t3lib_extMgm::extPath('dlf');
+$extensionPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('dlf');
 
 return array (
 	'tx_dlf_cli' => $extensionPath.'cli/class.tx_dlf_cli.php',

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -25,39 +25,39 @@
 if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
 
 // Register plugins.
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/collection/class.tx_dlf_collection.php', '_collection', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/collection/class.tx_dlf_collection.php', '_collection', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/feeds/class.tx_dlf_feeds.php', '_feeds', 'list_type', FALSE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/feeds/class.tx_dlf_feeds.php', '_feeds', 'list_type', FALSE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/listview/class.tx_dlf_listview.php', '_listview', 'list_type', FALSE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/listview/class.tx_dlf_listview.php', '_listview', 'list_type', FALSE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/metadata/class.tx_dlf_metadata.php', '_metadata', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/metadata/class.tx_dlf_metadata.php', '_metadata', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/navigation/class.tx_dlf_navigation.php', '_navigation', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/navigation/class.tx_dlf_navigation.php', '_navigation', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/oai/class.tx_dlf_oai.php', '_oai', 'list_type', FALSE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/oai/class.tx_dlf_oai.php', '_oai', 'list_type', FALSE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/pagegrid/class.tx_dlf_pagegrid.php', '_pagegrid', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/pagegrid/class.tx_dlf_pagegrid.php', '_pagegrid', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/pageview/class.tx_dlf_pageview.php', '_pageview', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/pageview/class.tx_dlf_pageview.php', '_pageview', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/search/class.tx_dlf_search.php', '_search', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/search/class.tx_dlf_search.php', '_search', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/statistics/class.tx_dlf_statistics.php', '_statistics', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/statistics/class.tx_dlf_statistics.php', '_statistics', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toc/class.tx_dlf_toc.php', '_toc', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toc/class.tx_dlf_toc.php', '_toc', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/class.tx_dlf_toolbox.php', '_toolbox', 'list_type', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/class.tx_dlf_toolbox.php', '_toolbox', 'list_type', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/validator/class.tx_dlf_validator.php', '_validator', 'list_type', FALSE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/validator/class.tx_dlf_validator.php', '_validator', 'list_type', FALSE);
 
 // Register tools for toolbox plugin.
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', TRUE);
 
-t3lib_extMgm::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php', '_toolsFulltext', '', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php', '_toolsFulltext', '', TRUE);
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][t3lib_extMgm::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][t3lib_extMgm::getCN($_EXTKEY).'_toolsFulltext'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsFulltext';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsFulltext'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsFulltext';
 
 // Register hooks.
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = 'EXT:'.$_EXTKEY.'/hooks/class.tx_dlf_tcemain.php:tx_dlf_tcemain';

--- a/dlf/ext_tables.php
+++ b/dlf/ext_tables.php
@@ -40,8 +40,8 @@ $TCA['tx_dlf_documents'] = array (
 			'endtime' => 'endtime',
 			'fe_group' => 'fe_group',
 		),
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfdocuments.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfdocuments.png',
 		'rootLevel'	=> 0,
 		'dividers2tabs' => 2,
 		'searchFields' => 'title,volume,author,year,place,uid,prod_id,location,oai_id,opac_id,union_id,urn',
@@ -66,8 +66,8 @@ $TCA['tx_dlf_structures'] = array (
 		'enablecolumns' => array (
 			'disabled' => 'hidden',
 		),
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfstructures.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfstructures.png',
 		'rootLevel'	=> 0,
 		'dividers2tabs' => 2,
 		'searchFields' => 'label,index_name,oai_name',
@@ -93,8 +93,8 @@ $TCA['tx_dlf_metadata'] = array (
 		'enablecolumns' => array (
 			'disabled' => 'hidden',
 		),
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfmetadata.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfmetadata.png',
 		'rootLevel'	=> 0,
 		'dividers2tabs' => 2,
 		'searchFields' => 'label,index_name',
@@ -113,8 +113,8 @@ $TCA['tx_dlf_metadataformat'] = array (
 		'cruser_id' => 'cruser_id',
 		'default_sortby' => 'ORDER BY encoded',
 		'delete'	=> 'deleted',
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfmetadata.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfmetadata.png',
 		'rootLevel'	=> 0,
 		'dividers2tabs' => 2,
 		'searchFields' => 'encoded',
@@ -134,8 +134,8 @@ $TCA['tx_dlf_formats'] = array (
 		'cruser_id' => 'cruser_id',
 		'default_sortby' => 'ORDER BY type',
 		'delete'	=> 'deleted',
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfformats.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfformats.png',
 		'rootLevel'	=> 1,
 		'dividers2tabs' => 2,
 		'searchFields' => 'type,class',
@@ -154,8 +154,8 @@ $TCA['tx_dlf_solrcores'] = array (
 		'cruser_id' => 'cruser_id',
 		'default_sortby' => 'ORDER BY label',
 		'delete'	=> 'deleted',
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfsolrcores.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfsolrcores.png',
 		'rootLevel'	=> -1,
 		'dividers2tabs' => 2,
 		'searchFields' => 'label,index_name',
@@ -183,8 +183,8 @@ $TCA['tx_dlf_collections'] = array (
 			'disabled' => 'hidden',
 			'fe_group' => 'fe_group',
 		),
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlfcollections.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlfcollections.png',
 		'rootLevel'	=> 0,
 		'dividers2tabs' => 2,
 		'searchFields' => 'label,index_name,oai_name,fe_cruser_id',
@@ -206,8 +206,8 @@ $TCA['tx_dlf_libraries'] = array (
 		'transOrigDiffSourceField' => 'l18n_diffsource',
 		'default_sortby' => 'ORDER BY label',
 		'delete'	=> 'deleted',
-		'dynamicConfigFile' => t3lib_extMgm::extPath($_EXTKEY).'tca.php',
-		'iconfile'	=> t3lib_extMgm::extRelPath($_EXTKEY).'res/icons/txdlflibraries.png',
+		'dynamicConfigFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'tca.php',
+		'iconfile'	=> \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY).'res/icons/txdlflibraries.png',
 		'rootLevel'	=> 0,
 		'dividers2tabs' => 2,
 		'searchFields' => 'label,website,contact',
@@ -218,7 +218,7 @@ $TCA['tx_dlf_libraries'] = array (
 );
 
 // Register static typoscript.
-t3lib_extMgm::addStaticFile($_EXTKEY, 'typoscript/', 'Basic Configuration');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'typoscript/', 'Basic Configuration');
 
 // Register plugins.
 if (version_compare(TYPO3_branch, '6.1', '<')) {
@@ -230,121 +230,121 @@ $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_collectio
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_collection'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_collection', $_EXTKEY.'_collection'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_collection', $_EXTKEY.'_collection'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_collection', 'FILE:EXT:'.$_EXTKEY.'/plugins/collection/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_collection', 'FILE:EXT:'.$_EXTKEY.'/plugins/collection/flexform.xml');
 
 // Plugin "feeds".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_feeds'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_feeds'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_feeds', $_EXTKEY.'_feeds'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_feeds', $_EXTKEY.'_feeds'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_feeds', 'FILE:EXT:'.$_EXTKEY.'/plugins/feeds/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_feeds', 'FILE:EXT:'.$_EXTKEY.'/plugins/feeds/flexform.xml');
 
 // Plugin "listview".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_listview'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_listview'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_listview', $_EXTKEY.'_listview'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_listview', $_EXTKEY.'_listview'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_listview', 'FILE:EXT:'.$_EXTKEY.'/plugins/listview/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_listview', 'FILE:EXT:'.$_EXTKEY.'/plugins/listview/flexform.xml');
 
 // Plugin "metadata".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_metadata'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_metadata'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_metadata', $_EXTKEY.'_metadata'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_metadata', $_EXTKEY.'_metadata'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_metadata', 'FILE:EXT:'.$_EXTKEY.'/plugins/metadata/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_metadata', 'FILE:EXT:'.$_EXTKEY.'/plugins/metadata/flexform.xml');
 
 // Plugin "navigation".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_navigation'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_navigation'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_navigation', $_EXTKEY.'_navigation'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_navigation', $_EXTKEY.'_navigation'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_navigation', 'FILE:EXT:'.$_EXTKEY.'/plugins/navigation/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_navigation', 'FILE:EXT:'.$_EXTKEY.'/plugins/navigation/flexform.xml');
 
 // Plugin "oai".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_oai'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_oai'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_oai', $_EXTKEY.'_oai'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_oai', $_EXTKEY.'_oai'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_oai', 'FILE:EXT:'.$_EXTKEY.'/plugins/oai/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_oai', 'FILE:EXT:'.$_EXTKEY.'/plugins/oai/flexform.xml');
 
 // Plugin "pagegrid".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_pagegrid'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_pagegrid'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_pagegrid', $_EXTKEY.'_pagegrid'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_pagegrid', $_EXTKEY.'_pagegrid'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_pagegrid', 'FILE:EXT:'.$_EXTKEY.'/plugins/pagegrid/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_pagegrid', 'FILE:EXT:'.$_EXTKEY.'/plugins/pagegrid/flexform.xml');
 
 // Plugin "pageview".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_pageview'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_pageview'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_pageview', $_EXTKEY.'_pageview'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_pageview', $_EXTKEY.'_pageview'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_pageview', 'FILE:EXT:'.$_EXTKEY.'/plugins/pageview/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_pageview', 'FILE:EXT:'.$_EXTKEY.'/plugins/pageview/flexform.xml');
 
 // Plugin "search".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_search'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_search'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_search', $_EXTKEY.'_search'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_search', $_EXTKEY.'_search'), 'list_type');
 
-t3lib_extMgm::addStaticFile($_EXTKEY, 'plugins/search/', 'Search Facets');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'plugins/search/', 'Search Facets');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_search', 'FILE:EXT:'.$_EXTKEY.'/plugins/search/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_search', 'FILE:EXT:'.$_EXTKEY.'/plugins/search/flexform.xml');
 
 // Plugin "statistics".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_statistics'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_statistics'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_statistics', $_EXTKEY.'_statistics'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_statistics', $_EXTKEY.'_statistics'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_statistics', 'FILE:EXT:'.$_EXTKEY.'/plugins/statistics/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_statistics', 'FILE:EXT:'.$_EXTKEY.'/plugins/statistics/flexform.xml');
 
 // Plugin "table of contents".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_toc'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_toc'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_toc', $_EXTKEY.'_toc'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_toc', $_EXTKEY.'_toc'), 'list_type');
 
-t3lib_extMgm::addStaticFile($_EXTKEY, 'plugins/toc/', 'Table of Contents');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'plugins/toc/', 'Table of Contents');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_toc', 'FILE:EXT:'.$_EXTKEY.'/plugins/toc/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_toc', 'FILE:EXT:'.$_EXTKEY.'/plugins/toc/flexform.xml');
 
 // Plugin "toolbox".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_toolbox'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_toolbox'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_toolbox', $_EXTKEY.'_toolbox'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_toolbox', $_EXTKEY.'_toolbox'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_toolbox', 'FILE:EXT:'.$_EXTKEY.'/plugins/toolbox/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_toolbox', 'FILE:EXT:'.$_EXTKEY.'/plugins/toolbox/flexform.xml');
 
 // Plugin "validator".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_validator'] = 'layout,select_key,pages,recursive';
 
 $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY.'_validator'] = 'pi_flexform';
 
-t3lib_extMgm::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_validator', $_EXTKEY.'_validator'), 'list_type');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('LLL:EXT:dlf/locallang.xml:tt_content.dlf_validator', $_EXTKEY.'_validator'), 'list_type');
 
-t3lib_extMgm::addPiFlexFormValue($_EXTKEY.'_validator', 'FILE:EXT:'.$_EXTKEY.'/plugins/validator/flexform.xml');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($_EXTKEY.'_validator', 'FILE:EXT:'.$_EXTKEY.'/plugins/validator/flexform.xml');
 
 // Register modules.
 if (TYPO3_MODE == 'BE')	{
@@ -377,19 +377,19 @@ if (TYPO3_MODE == 'BE')	{
 	}
 
 	// Main "dlf" module.
-	t3lib_extMgm::addModule('txdlfmodules', '', '', t3lib_extMgm::extPath($_EXTKEY).'modules/');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addModule('txdlfmodules', '', '', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'modules/');
 
 	// Module "indexing".
-	t3lib_extMgm::addModule('txdlfmodules', 'txdlfindexing', '', t3lib_extMgm::extPath($_EXTKEY).'modules/indexing/');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addModule('txdlfmodules', 'txdlfindexing', '', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'modules/indexing/');
 
-	t3lib_extMgm::addLLrefForTCAdescr('_MOD_txdlfmodules_txdlfindexing','EXT:dlf/modules/indexing/locallang_mod.xml');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('_MOD_txdlfmodules_txdlfindexing','EXT:dlf/modules/indexing/locallang_mod.xml');
 
 	// Module "newclient".
-	t3lib_extMgm::addModule('txdlfmodules', 'txdlfnewclient', '', t3lib_extMgm::extPath($_EXTKEY).'modules/newclient/');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addModule('txdlfmodules', 'txdlfnewclient', '', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY).'modules/newclient/');
 
-	t3lib_extMgm::addLLrefForTCAdescr('_MOD_txdlfmodules_txdlfnewclient','EXT:dlf/modules/newclient/locallang_mod.xml');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('_MOD_txdlfmodules_txdlfnewclient','EXT:dlf/modules/newclient/locallang_mod.xml');
 
-	t3lib_extMgm::addNavigationComponent('txdlfmodules', 'typo3-pagetree');
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addNavigationComponent('txdlfmodules', 'typo3-pagetree');
 }
 
 ?>

--- a/dlf/modules/newclient/index.php
+++ b/dlf/modules/newclient/index.php
@@ -102,7 +102,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 	protected function cmdAddMetadata() {
 
 		// Include metadata definition file.
-		include_once(t3lib_extMgm::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
+		include_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
 
 		// Load table configuration array to get default field values.
 		if (version_compare(TYPO3_branch, '6.1', '<')) {
@@ -237,7 +237,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 	protected function cmdAddStructure() {
 
 		// Include structure definition file.
-		include_once(t3lib_extMgm::extPath($this->extKey).'modules/'.$this->modPath.'structures.inc.php');
+		include_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey).'modules/'.$this->modPath.'structures.inc.php');
 
 		// Build data array.
 		foreach ($structures as $index_name => $values) {

--- a/dlf/plugins/collection/class.tx_dlf_collection.php
+++ b/dlf/plugins/collection/class.tx_dlf_collection.php
@@ -231,7 +231,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 				// Add feed link if applicable.
 				if (!empty($this->conf['targetFeed'])) {
 
-					$img = '<img src="'.t3lib_extMgm::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+					$img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
 
 					$markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $resArray['uid'])), FALSE, $this->conf['targetFeed']);
 

--- a/dlf/plugins/oai/class.tx_dlf_oai.php
+++ b/dlf/plugins/oai/class.tx_dlf_oai.php
@@ -425,9 +425,9 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 				list ($extKey, $filePath) = explode('/', substr($this->conf['stylesheet'], 4), 2);
 
-				if (t3lib_extMgm::isLoaded($extKey)) {
+				if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
 
-					$this->conf['stylesheet'] = t3lib_extMgm::siteRelPath($extKey).$filePath;
+					$this->conf['stylesheet'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($extKey).$filePath;
 
 				}
 
@@ -438,7 +438,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 		} else {
 
 			// Use default stylesheet if no custom stylesheet is given.
-			$stylesheet = t3lib_div::locationHeaderUrl(t3lib_extMgm::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
+			$stylesheet = t3lib_div::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
 
 		}
 

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -79,7 +79,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 
 		} else {
 
-			$thumbnailFile = t3lib_extMgm::siteRelPath($this->extKey).'plugins/pagegrid/placeholder.jpg';
+			$thumbnailFile = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/pagegrid/placeholder.jpg';
 
 		}
 

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -125,7 +125,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		// Get localization for OpenLayers.
 		if ($GLOBALS['TSFE']->lang) {
 
-			$langFile = t3lib_extMgm::extPath($this->extKey, 'lib/OpenLayers/lib/OpenLayers/Lang/'.strtolower($GLOBALS['TSFE']->lang).'.js');
+			$langFile = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey, 'lib/OpenLayers/lib/OpenLayers/Lang/'.strtolower($GLOBALS['TSFE']->lang).'.js');
 
 			if (file_exists($langFile)) {
 
@@ -247,7 +247,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 		// Add OpenLayers library.
 		$output[] = '
-		<script type="text/javascript" src="'.t3lib_extMgm::siteRelPath($this->extKey).'lib/OpenLayers/lib/OpenLayers.js"></script>';
+		<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'lib/OpenLayers/lib/OpenLayers.js"></script>';
 
 		return implode("\n", $output);
 
@@ -272,7 +272,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 		// Add viewer library.
 		$output[] = '
-		<script type="text/javascript" src="'.t3lib_extMgm::siteRelPath($this->extKey).'plugins/pageview/tx_dlf_pageview.js"></script>';
+		<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/pageview/tx_dlf_pageview.js"></script>';
 
 		// Add viewer configuration.
 		$output[] = '

--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -64,7 +64,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 			// Add javascript to page header.
 			if (tx_dlf_helper::loadJQuery()) {
 
-				$GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_search_suggest'] = '<script type="text/javascript" src="'.t3lib_extMgm::siteRelPath($this->extKey).'plugins/search/tx_dlf_search_suggest.js"></script>';
+				$GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_search_suggest'] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/search/tx_dlf_search_suggest.js"></script>';
 
 			}
 


### PR DESCRIPTION
It was deprecated with TYPO3 6.0 and removed in TYPO3 7.0.
The replacement \TYPO3\CMS\Core\Utility\ExtensionManagementUtility
was added 3 years ago with TYPO3 6.0, so this patch removes
compatibility with pre 6.0 versions.

Signed-off-by: Stefan Weil sw@weilnetz.de
