### PR TITLE
Clean code with PhpStorm

### DIFF
--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -613,7 +613,7 @@ dlfViewer.prototype.addPolygonlayer = function(layer, feature, type) {
 					fillOpacity : 0.4,
 					cursor : 'inherit'
 				});
-		};
+		}
 
 		var hoverStyle = new OpenLayers.Style({
 			strokeColor : '#cccccc',

--- a/dlf/plugins/search/tx_dlf_search_suggest.js
+++ b/dlf/plugins/search/tx_dlf_search_suggest.js
@@ -42,7 +42,7 @@ $(
 						hashed: $("input[name='tx_dlf[hashed]']").val()
 					},
 					function(data) {
-						var result = new Array();
+						var result = [];
 						var option = "";
 						$("arr[name='suggestion'] str", data).each(function(i) {
 							option = $(this).text();


### PR DESCRIPTION
- Remove unneeded semicolon at end of switch statement (JavaScript)
- Use simplified initialization of empty array (JavaScript)

Signed-off-by: Stefan Weil sw@weilnetz.de
