### PR TITLE
Replace deprecated class t3lib_div

### DIFF
--- a/dlf/class.ext_update.php
+++ b/dlf/class.ext_update.php
@@ -179,7 +179,7 @@ class ext_update {
 
 				if (!empty($substUids)) {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('update.metadataConfigOkay', TRUE),
 						$GLOBALS['LANG']->getLL('update.metadataConfig', TRUE),
@@ -189,7 +189,7 @@ class ext_update {
 
 				} else {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('update.metadataConfigNotOkay', TRUE),
 						$GLOBALS['LANG']->getLL('update.metadataConfig', TRUE),

--- a/dlf/cli/class.tx_dlf_cli.php
+++ b/dlf/cli/class.tx_dlf_cli.php
@@ -179,7 +179,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/cli
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/cli/class.tx_dlf_cli.php']);
 }
 
-$SOBE = t3lib_div::makeInstance('tx_dlf_cli');
+$SOBE = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_cli');
 
 $SOBE->main();
 

--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -332,7 +332,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->getFileLocation('.$id.')] There is no file node with @ID "'.$id.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getFileLocation('.$id.')] There is no file node with @ID "'.$id.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -637,7 +637,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->getMetadata('.$id.', '.$_cPid.')] Invalid PID "'.$cPid.'" for metadata definitions', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getMetadata('.$id.', '.$_cPid.')] Invalid PID "'.$cPid.'" for metadata definitions', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -700,7 +700,7 @@ final class tx_dlf_document {
 					$class = $this->formats[$this->dmdSec[$dmdId]['type']]['class'];
 
 					// Get the metadata from class.
-					if (class_exists($class) && ($obj = t3lib_div::makeInstance($class)) instanceof tx_dlf_format) {
+					if (class_exists($class) && ($obj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance($class)) instanceof tx_dlf_format) {
 
 						$obj->extractMetadata($this->dmdSec[$dmdId]['xml'], $metadata);
 
@@ -708,7 +708,7 @@ final class tx_dlf_document {
 
 						if (TYPO3_DLOG) {
 
-							t3lib_div::devLog('[tx_dlf_document->getMetadata('.$id.', '.$_cPid.')] Invalid class/method "'.$class.'->extractMetadata()" for metadata format "'.$this->dmdSec[$dmdId]['type'].'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+							\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getMetadata('.$id.', '.$_cPid.')] Invalid class/method "'.$class.'->extractMetadata()" for metadata format "'.$this->dmdSec[$dmdId]['type'].'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 						}
 
@@ -720,7 +720,7 @@ final class tx_dlf_document {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_document->getMetadata('.$id.', '.$_cPid.')] Unsupported metadata format "'.$this->dmdSec[$dmdId]['type'].'" in dmdSec with @ID "'.$dmdId.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getMetadata('.$id.', '.$_cPid.')] Unsupported metadata format "'.$this->dmdSec[$dmdId]['type'].'" in dmdSec with @ID "'.$dmdId.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 				}
 
@@ -883,7 +883,7 @@ final class tx_dlf_document {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_document->getTitle('.$_uid.', ['.($recursive ? 'TRUE' : 'FALSE').'])] No document with UID "'.$uid.'" found or document not accessible', self::$extKey, SYSLOG_SEVERITY_WARNING);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getTitle('.$_uid.', ['.($recursive ? 'TRUE' : 'FALSE').'])] No document with UID "'.$uid.'" found or document not accessible', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 				}
 
@@ -893,7 +893,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->getTitle('.$_uid.', ['.($recursive ? 'TRUE' : 'FALSE').'])] Invalid UID "'.$uid.'" for document', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getTitle('.$_uid.', ['.($recursive ? 'TRUE' : 'FALSE').'])] Invalid UID "'.$uid.'" for document', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -952,7 +952,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->init()] No METS part found in document with UID "'.$this->uid.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->init()] No METS part found in document with UID "'.$this->uid.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -972,7 +972,7 @@ final class tx_dlf_document {
 	protected function load($location) {
 
 		// Load XML file.
-		if (t3lib_div::isValidUrl($location)
+		if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl($location)
 			// There is a bug in filter_var($var, FILTER_VALIDATE_URL) in PHP < 5.3.3 which causes
 			// the function to validate URLs containing whitespaces and invalidate URLs containing
 			// hyphens. (see https://bugs.php.net/bug.php?id=51192)
@@ -1008,7 +1008,7 @@ final class tx_dlf_document {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_document->load('.$location.')] Could not load XML file from "'.$location.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->load('.$location.')] Could not load XML file from "'.$location.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -1018,7 +1018,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->load('.$location.')] Invalid file location "'.$location.'" for document loading', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->load('.$location.')] Invalid file location "'.$location.'" for document loading', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1092,7 +1092,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->registerNamespaces(['.get_class($obj).'])] Given object is neither a SimpleXMLElement nor a DOMXPath instance', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->registerNamespaces(['.get_class($obj).'])] Given object is neither a SimpleXMLElement nor a DOMXPath instance', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1130,7 +1130,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Saving a document is only allowed in the backend', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Saving a document is only allowed in the backend', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1154,7 +1154,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Invalid PID "'.$pid.'" for document saving', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Invalid PID "'.$pid.'" for document saving', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1180,7 +1180,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] No record identifier found to avoid duplication', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] No record identifier found to avoid duplication', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1211,7 +1211,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Backend user "_cli_dlf" not found or disabled', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Backend user "_cli_dlf" not found or disabled', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1239,7 +1239,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Could not identify document/structure type', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Could not identify document/structure type', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -1302,7 +1302,7 @@ final class tx_dlf_document {
 
 				if (!defined('TYPO3_cliMode')) {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.newCollection'), $collection, $substUid[$collNewUid])),
 						tx_dlf_helper::getLL('flash.attention', TRUE),
@@ -1381,7 +1381,7 @@ final class tx_dlf_document {
 
 			if (!defined('TYPO3_cliMode')) {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.newLibrary'), $metadata['owner'][0], $owner)),
 					tx_dlf_helper::getLL('flash.attention', TRUE),
@@ -1535,7 +1535,7 @@ final class tx_dlf_document {
 
 		if (!defined('TYPO3_cliMode')) {
 
-			$message = t3lib_div::makeInstance(
+			$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.documentSaved'), $metadata['title'][0], $this->uid)),
 				tx_dlf_helper::getLL('flash.done', TRUE),
@@ -1556,7 +1556,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Invalid UID "'.$core.'" for Solr core', self::$extKey, SYSLOG_SEVERITY_NOTICE);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Invalid UID "'.$core.'" for Solr core', self::$extKey, SYSLOG_SEVERITY_NOTICE);
 
 			}
 
@@ -1654,7 +1654,7 @@ final class tx_dlf_document {
 			// Get configured USE attributes.
 			$extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
 
-			$useGrps = t3lib_div::trimExplode(',', $extConf['fileGrps']);
+			$useGrps = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $extConf['fileGrps']);
 
 			if (!empty($extConf['fileGrpThumbs'])) {
 
@@ -1729,7 +1729,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->getMetadataArray()] Invalid PID "'.$cPid.'" for metadata definitions', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getMetadataArray()] Invalid PID "'.$cPid.'" for metadata definitions', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -2027,7 +2027,7 @@ final class tx_dlf_document {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_document->_getThumbnail()] Invalid PID "'.$cPid.'" for structure definitions', self::$extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->_getThumbnail()] Invalid PID "'.$cPid.'" for structure definitions', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -2044,7 +2044,7 @@ final class tx_dlf_document {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_document->_getThumbnail()] No fileGrp for thumbnails specified', self::$extKey, SYSLOG_SEVERITY_WARNING);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->_getThumbnail()] No fileGrp for thumbnails specified', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 				}
 
@@ -2104,7 +2104,7 @@ final class tx_dlf_document {
 
 			} elseif (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->_getThumbnail()] No structure of type "'.$metadata['type'][0].'" found in database', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->_getThumbnail()] No structure of type "'.$metadata['type'][0].'" found in database', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -2338,7 +2338,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->__construct('.$uid.', '.$pid.')] No document with UID "'.$uid.'" found or document not accessible', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->__construct('.$uid.', '.$pid.')] No document with UID "'.$uid.'" found or document not accessible', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -2363,7 +2363,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->__get('.$var.')] There is no getter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->__get('.$var.')] There is no getter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -2395,7 +2395,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->__set('.$var.', '.$value.')] There is no setter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->__set('.$var.', '.$value.')] There is no setter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -2475,7 +2475,7 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_document->__wakeup()] Could not load XML after deserialization', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->__wakeup()] Could not load XML after deserialization', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 

--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -69,7 +69,7 @@ class tx_dlf_helper {
 		}
 		else {
 			/** @noinspection PhpDeprecationInspection */
-			$array1 = t3lib_div::array_merge_recursive_overrule($array1, $array2);
+			$array1 = \TYPO3\CMS\Core\Utility\GeneralUtility::array_merge_recursive_overrule($array1, $array2);
 		}
 
 		return $array1;
@@ -245,7 +245,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] PHP extension "mcrypt" not available', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] PHP extension "mcrypt" not available', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -257,7 +257,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] Invalid parameters given for decryption', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] Invalid parameters given for decryption', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -269,7 +269,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] No encryption key set in TYPO3 configuration', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] No encryption key set in TYPO3 configuration', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -289,7 +289,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] Invalid hash "'.$hash.'" given for decryption', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->decrypt('.$encrypted.', '.$hash.')] Invalid hash "'.$hash.'" given for decryption', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -318,7 +318,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->encrypt('.$string.')] PHP extension "mcrypt" not available', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->encrypt('.$string.')] PHP extension "mcrypt" not available', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -330,7 +330,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->encrypt('.$string.')] No encryption key set in TYPO3 configuration', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->encrypt('.$string.')] No encryption key set in TYPO3 configuration', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -362,7 +362,7 @@ class tx_dlf_helper {
 		if (TYPO3_MODE === 'FE' || TYPO3_MODE === 'BE') {
 
 			// Initialize backend session with CLI user's rights.
-			$userObj = t3lib_div::makeInstance('t3lib_beUserAuth');
+			$userObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('t3lib_beUserAuth');
 
 			$userObj->dontSetCookie = TRUE;
 
@@ -378,7 +378,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getBeUser()] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getBeUser()] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -404,7 +404,7 @@ class tx_dlf_helper {
 
 				return $GLOBALS['TSFE']->fe_user;
 
-			} elseif (t3lib_div::_GP('eID') !== NULL) {
+			} elseif (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('eID') !== NULL) {
 
 				return tslib_eidtools::initFeUser();
 
@@ -414,7 +414,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getFeUser()] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getFeUser()] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -441,7 +441,7 @@ class tx_dlf_helper {
 
 			foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::$extKey.'/'.$scriptRelPath]['hookClass'] as $classRef) {
 
-				$hookObjects[] = &t3lib_div::getUserObj($classRef);
+				$hookObjects[] = &\TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj($classRef);
 
 			}
 
@@ -476,7 +476,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getIndexName('.$_uid.', '.$table.', '.$_pid.')] Invalid UID "'.$uid.'" or table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getIndexName('.$_uid.', '.$table.', '.$_pid.')] Invalid UID "'.$uid.'" or table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -515,7 +515,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getIndexName('.$_uid.', '.$table.', '.$_pid.')] No "index_name" with UID "'.$uid.'" and PID "'.$pid.'" found in table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getIndexName('.$_uid.', '.$table.', '.$_pid.')] No "index_name" with UID "'.$uid.'" and PID "'.$pid.'" found in table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -547,7 +547,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getIdFromIndexName('.$_index_name.', '.$table.', '.$_pid.')] Invalid UID "'.$index_name.'" or table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getIdFromIndexName('.$_index_name.', '.$table.', '.$_pid.')] Invalid UID "'.$index_name.'" or table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -586,7 +586,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getIdFromIndexName('.$_index_name.', '.$table.', '.$_pid.')] No UID for given "index_name" "'.$index_name.'" and PID "'.$pid.'" found in table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getIdFromIndexName('.$_index_name.', '.$table.', '.$_pid.')] No UID for given "index_name" "'.$index_name.'" and PID "'.$pid.'" found in table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -650,7 +650,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getLanguageName('.$code.')] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getLanguageName('.$code.')] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -666,7 +666,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getLanguageName('.$code.')] Language code "'.$code.'" not found in ISO-639 table', self::$extKey, SYSLOG_SEVERITY_NOTICE);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getLanguageName('.$code.')] Language code "'.$code.'" not found in ISO-639 table', self::$extKey, SYSLOG_SEVERITY_NOTICE);
 
 			}
 
@@ -705,7 +705,7 @@ class tx_dlf_helper {
 
 			} elseif (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getLL('.$key.', '.$default.', ['.($hsc ? 'TRUE' : 'FALSE').'])] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getLL('.$key.', '.$default.', ['.($hsc ? 'TRUE' : 'FALSE').'])] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -724,7 +724,7 @@ class tx_dlf_helper {
 
 			} elseif (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getLL('.$key.', '.$default.', ['.($hsc ? 'TRUE' : 'FALSE').'])] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getLL('.$key.', '.$default.', ['.($hsc ? 'TRUE' : 'FALSE').'])] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -801,7 +801,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->getURN('.$base.', '.$id.')] Invalid chars in given parameters', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->getURN('.$base.', '.$id.')] Invalid chars in given parameters', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -853,7 +853,7 @@ class tx_dlf_helper {
 		} else {
 
 			// TYPO3 4.5 - 4.7
-			return t3lib_div::intInRange($theInt, $min, $max, $zeroValue);
+			return \TYPO3\CMS\Core\Utility\GeneralUtility::intInRange($theInt, $min, $max, $zeroValue);
 
 		}
 
@@ -895,7 +895,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->loadFromSession('.$_key.')] Invalid key "'.$key.'" for session data retrieval', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->loadFromSession('.$_key.')] Invalid key "'.$key.'" for session data retrieval', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -916,7 +916,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->loadFromSession('.$_key.')] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->loadFromSession('.$_key.')] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -953,7 +953,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->loadJQuery()] JQuery not available', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->loadJQuery()] JQuery not available', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -978,7 +978,7 @@ class tx_dlf_helper {
 	public static function processDB(array $data = array (), array $cmd = array (), $reverseOrder = FALSE, $be_user = FALSE) {
 
 		// Instantiate TYPO3 core engine.
-		$tce = t3lib_div::makeInstance('t3lib_TCEmain');
+		$tce = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('t3lib_TCEmain');
 
 		// Set some configuration variables.
 		$tce->stripslashes_values = FALSE;
@@ -1043,7 +1043,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->processDBasAdmin([data->data], [data->cmd], ['.($reverseOrder ? 'TRUE' : 'FALSE').'])] Current backend user has no admin privileges', self::$extKey, SYSLOG_SEVERITY_ERROR, array ('data' => $data, 'cmd' => $cmd));
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->processDBasAdmin([data->data], [data->cmd], ['.($reverseOrder ? 'TRUE' : 'FALSE').'])] Current backend user has no admin privileges', self::$extKey, SYSLOG_SEVERITY_ERROR, array ('data' => $data, 'cmd' => $cmd));
 
 			}
 
@@ -1075,7 +1075,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->saveToSession([data], '.$_key.')] Invalid key "'.$key.'" for session data saving', self::$extKey, SYSLOG_SEVERITY_WARNING, $value);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->saveToSession([data], '.$_key.')] Invalid key "'.$key.'" for session data saving', self::$extKey, SYSLOG_SEVERITY_WARNING, $value);
 
 			}
 
@@ -1102,7 +1102,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->saveToSession([data], '.$_key.')] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR, $data);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->saveToSession([data], '.$_key.')] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR, $data);
 
 			}
 
@@ -1131,7 +1131,7 @@ class tx_dlf_helper {
 		} else {
 
 			// TYPO3 4.5 - 4.7
-			return t3lib_div::testInt($theInt);
+			return \TYPO3\CMS\Core\Utility\GeneralUtility::testInt($theInt);
 
 		}
 
@@ -1165,7 +1165,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->translate('.$_index_name.', '.$table.', '.$_pid.')] Invalid PID "'.$pid.'" for translation', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->translate('.$_index_name.', '.$table.', '.$_pid.')] Invalid PID "'.$pid.'" for translation', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -1266,7 +1266,7 @@ class tx_dlf_helper {
 
 					if (TYPO3_DLOG) {
 
-						t3lib_div::devLog('[tx_dlf_helper->translate('.$_index_name.', '.$table.', '.$_pid.')] No translation with PID "'.$pid.'" available in table "'.$table.'" or translation not accessible', self::extKey, SYSLOG_SEVERITY_NOTICE);
+						\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->translate('.$_index_name.', '.$table.', '.$_pid.')] No translation with PID "'.$pid.'" available in table "'.$table.'" or translation not accessible', self::extKey, SYSLOG_SEVERITY_NOTICE);
 
 					}
 
@@ -1276,7 +1276,7 @@ class tx_dlf_helper {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_helper->translate('.$_index_name.', '.$table.', '.$_pid.')] No translations available for table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->translate('.$_index_name.', '.$table.', '.$_pid.')] No translations available for table "'.$table.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 				}
 
@@ -1333,7 +1333,7 @@ class tx_dlf_helper {
 
 			} else {
 
-				$t3lib_pageSelect = t3lib_div::makeInstance('t3lib_pageSelect');
+				$t3lib_pageSelect = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('t3lib_pageSelect');
 
 				$GLOBALS['TSFE']->includeTCA();
 
@@ -1349,7 +1349,7 @@ class tx_dlf_helper {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_helper->whereClause('.$table.', ['.($showHidden ? 'TRUE' : 'FALSE').'])] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_helper->whereClause('.$table.', ['.($showHidden ? 'TRUE' : 'FALSE').'])] Unexpected TYPO3_MODE "'.TYPO3_MODE.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -128,7 +128,7 @@ class tx_dlf_indexing {
 
 					if (TYPO3_DLOG) {
 
-						t3lib_div::devLog('[tx_dlf_indexing->add(['.$doc->uid.'], '.$core.')] Could not load parent document with UID "'.$doc->parentId.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+						\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->add(['.$doc->uid.'], '.$core.')] Could not load parent document with UID "'.$doc->parentId.'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 					}
 
@@ -179,7 +179,7 @@ class tx_dlf_indexing {
 
 					if (!$errors) {
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.documentIndexed'), $resArray['title'], $doc->uid)),
 							tx_dlf_helper::getLL('flash.done', TRUE),
@@ -189,7 +189,7 @@ class tx_dlf_indexing {
 
 					} else {
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.documentNotIndexed'), $resArray['title'], $doc->uid)),
 							tx_dlf_helper::getLL('flash.error', TRUE),
@@ -209,7 +209,7 @@ class tx_dlf_indexing {
 
 				if (!defined('TYPO3_cliMode')) {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						tx_dlf_helper::getLL('flash.solrException', TRUE).'<br />'.htmlspecialchars($e->getMessage()),
 						tx_dlf_helper::getLL('flash.error', TRUE),
@@ -223,7 +223,7 @@ class tx_dlf_indexing {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_indexing->add(['.$doc->uid.'], '.$core.')] Apache Solr threw exception: "'.$e->getMessage().'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->add(['.$doc->uid.'], '.$core.')] Apache Solr threw exception: "'.$e->getMessage().'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -235,7 +235,7 @@ class tx_dlf_indexing {
 
 			if (!defined('TYPO3_cliMode')) {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					tx_dlf_helper::getLL('flash.solrNoConnection', TRUE),
 					tx_dlf_helper::getLL('flash.warning', TRUE),
@@ -249,7 +249,7 @@ class tx_dlf_indexing {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_indexing->add(['.$doc->uid.'], '.$core.')] Could not connect to Apache Solr server', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->add(['.$doc->uid.'], '.$core.')] Could not connect to Apache Solr server', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -304,7 +304,7 @@ class tx_dlf_indexing {
 
 					if (!defined('TYPO3_cliMode')) {
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							tx_dlf_helper::getLL('flash.solrException', TRUE).'<br />'.htmlspecialchars($e->getMessage()),
 							tx_dlf_helper::getLL('flash.error', TRUE),
@@ -318,7 +318,7 @@ class tx_dlf_indexing {
 
 					if (TYPO3_DLOG) {
 
-						t3lib_div::devLog('[tx_dlf_indexing->delete('.$_uid.')] Apache Solr threw exception: "'.$e->getMessage().'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
+						\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->delete('.$_uid.')] Apache Solr threw exception: "'.$e->getMessage().'"', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 					}
 
@@ -330,7 +330,7 @@ class tx_dlf_indexing {
 
 				if (!defined('TYPO3_cliMode')) {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						tx_dlf_helper::getLL('flash.solrNoConnection', TRUE),
 						tx_dlf_helper::getLL('flash.error', TRUE),
@@ -344,7 +344,7 @@ class tx_dlf_indexing {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_indexing->delete('.$_uid.')] Could not connect to Apache Solr server', self::$extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->delete('.$_uid.')] Could not connect to Apache Solr server', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -354,7 +354,7 @@ class tx_dlf_indexing {
 
 			if (!defined('TYPO3_cliMode')) {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.documentDeleted'), $title, $uid)),
 					tx_dlf_helper::getLL('flash.done', TRUE),
@@ -372,7 +372,7 @@ class tx_dlf_indexing {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_indexing->delete('.$_uid.')] Invalid UID "'.$uid.'" for document deletion', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->delete('.$_uid.')] Invalid UID "'.$uid.'" for document deletion', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -404,7 +404,7 @@ class tx_dlf_indexing {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_indexing->getIndexFieldName('.$index_name.', '.$_pid.')] Invalid PID "'.$pid.'" for metadata configuration', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_indexing->getIndexFieldName('.$index_name.', '.$_pid.')] Invalid PID "'.$pid.'" for metadata configuration', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -545,7 +545,7 @@ class tx_dlf_indexing {
 			// Load class.
 			if (!class_exists('Apache_Solr_Document')) {
 
-				require_once(t3lib_div::getFileAbsFileName('EXT:'.self::$extKey.'/lib/SolrPhpClient/Apache/Solr/Document.php'));
+				require_once(\TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName('EXT:'.self::$extKey.'/lib/SolrPhpClient/Apache/Solr/Document.php'));
 
 			}
 
@@ -634,7 +634,7 @@ class tx_dlf_indexing {
 
 				if (!defined('TYPO3_cliMode')) {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						tx_dlf_helper::getLL('flash.solrException', TRUE).'<br />'.htmlspecialchars($e->getMessage()),
 						tx_dlf_helper::getLL('flash.error', TRUE),

--- a/dlf/common/class.tx_dlf_list.php
+++ b/dlf/common/class.tx_dlf_list.php
@@ -154,7 +154,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->current()] Invalid position "'.$this->position.'" for list element', $this->extKey, SYSLOG_SEVERITY_NOTICE);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->current()] Invalid position "'.$this->position.'" for list element', $this->extKey, SYSLOG_SEVERITY_NOTICE);
 
 			}
 
@@ -322,7 +322,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->getRecord([data])] No UID of list element to fetch full record', $this->extKey, SYSLOG_SEVERITY_NOTICE, $element);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->getRecord([data])] No UID of list element to fetch full record', $this->extKey, SYSLOG_SEVERITY_NOTICE, $element);
 
 			}
 
@@ -372,7 +372,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->move('.$_position.', '.$_steps.')] Invalid position "'.$position.'" for element moving', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->move('.$_position.', '.$_steps.')] Invalid position "'.$position.'" for element moving', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -387,7 +387,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->move('.$_position.', '.$_steps.')] Invalid steps "'.$steps.'" for moving element at position "'.$position.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->move('.$_position.', '.$_steps.')] Invalid steps "'.$steps.'" for moving element at position "'.$position.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -481,7 +481,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->offsetGet('.$offset.')] Invalid offset "'.$offset.'" for list element', $this->extKey, SYSLOG_SEVERITY_NOTICE);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->offsetGet('.$offset.')] Invalid offset "'.$offset.'" for list element', $this->extKey, SYSLOG_SEVERITY_NOTICE);
 
 			}
 
@@ -541,7 +541,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->remove('.$_position.')] Invalid position "'.$position.'" for element removing', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->remove('.$_position.')] Invalid position "'.$position.'" for element removing', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -715,7 +715,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->sort('.$by.', ['.($asc ? 'TRUE' : 'FALSE').'])] Sorted list elements do not match unsorted elements', $this->extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->sort('.$by.', ['.($asc ? 'TRUE' : 'FALSE').'])] Sorted list elements do not match unsorted elements', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -861,7 +861,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->__get('.$var.')] There is no getter function for property "'.$var.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->__get('.$var.')] There is no getter function for property "'.$var.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -893,7 +893,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, t3lib_Singleton {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_list->__set('.$var.', [data])] There is no setter function for property "'.$var.'"', $this->extKey, SYSLOG_SEVERITY_WARNING, $value);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->__set('.$var.', [data])] There is no setter function for property "'.$var.'"', $this->extKey, SYSLOG_SEVERITY_WARNING, $value);
 
 			}
 

--- a/dlf/common/class.tx_dlf_module.php
+++ b/dlf/common/class.tx_dlf_module.php
@@ -118,7 +118,7 @@ abstract class tx_dlf_module extends t3lib_SCbase {
 
 		$this->pageInfo = t3lib_BEfunc::readPageAccess($this->id, $this->perms_clause);
 
-		$this->doc = t3lib_div::makeInstance('template');
+		$this->doc = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('template');
 
 		$this->doc->setModuleTemplate('EXT:'.$this->extKey.'/modules/'.$this->modPath.'template.tmpl');
 
@@ -130,7 +130,7 @@ abstract class tx_dlf_module extends t3lib_SCbase {
 
 		$this->doc->form = '<form action="" method="post" enctype="multipart/form-data">';
 
-		$this->data = t3lib_div::_GPmerged($this->prefixId);
+		$this->data = \TYPO3\CMS\Core\Utility\GeneralUtility::_GPmerged($this->prefixId);
 
 	}
 

--- a/dlf/common/class.tx_dlf_plugin.php
+++ b/dlf/common/class.tx_dlf_plugin.php
@@ -156,7 +156,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 				// Destroy the incomplete object.
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_plugin->loadDocument()] Failed to load document with UID "'.$this->piVars['id'].'"', $this->extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_plugin->loadDocument()] Failed to load document with UID "'.$this->piVars['id'].'"', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -198,7 +198,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_plugin->loadDocument()] Failed to load document with record ID "'.$this->piVars['recordId'].'"', $this->extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_plugin->loadDocument()] Failed to load document with record ID "'.$this->piVars['recordId'].'"', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -208,7 +208,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_plugin->loadDocument()] Invalid UID "'.$this->piVars['id'].'" or PID "'.$this->conf['pages'].'" for document loading', $this->extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_plugin->loadDocument()] Invalid UID "'.$this->piVars['id'].'" or PID "'.$this->conf['pages'].'" for document loading', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -304,7 +304,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 	 */
 	protected function parseTS($string = '') {
 
-		$parser = t3lib_div::makeInstance('t3lib_TSparser');
+		$parser = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('t3lib_TSparser');
 
 		$parser->parse($string);
 

--- a/dlf/common/class.tx_dlf_solr.php
+++ b/dlf/common/class.tx_dlf_solr.php
@@ -123,7 +123,7 @@ class tx_dlf_solr {
 		// Load class.
 		if (!class_exists('Apache_Solr_Service')) {
 
-			require_once(t3lib_div::getFileAbsFileName('EXT:'.self::$extKey.'/lib/SolrPhpClient/Apache/Solr/Service.php'));
+			require_once(\TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName('EXT:'.self::$extKey.'/lib/SolrPhpClient/Apache/Solr/Service.php'));
 
 		}
 
@@ -166,7 +166,7 @@ class tx_dlf_solr {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_solr->getInstance('.$_core.')] Invalid core name "'.$core.'" for Apache Solr', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_solr->getInstance('.$_core.')] Invalid core name "'.$core.'" for Apache Solr', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -197,7 +197,7 @@ class tx_dlf_solr {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_solr->getInstance('.$_core.')] Could not connect to Apache Solr server', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_solr->getInstance('.$_core.')] Could not connect to Apache Solr server', self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 
@@ -434,7 +434,7 @@ class tx_dlf_solr {
 		}
 
 		// Save list of documents.
-		$list = t3lib_div::makeInstance('tx_dlf_list');
+		$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 		$list->reset();
 
@@ -574,7 +574,7 @@ class tx_dlf_solr {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_solr->__get('.$var.')] There is no getter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_solr->__get('.$var.')] There is no getter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -606,7 +606,7 @@ class tx_dlf_solr {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_solr->__set('.$var.', [data])] There is no setter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING, $value);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_solr->__set('.$var.', [data])] There is no setter function for property "'.$var.'"', self::$extKey, SYSLOG_SEVERITY_WARNING, $value);
 
 			}
 
@@ -632,7 +632,7 @@ class tx_dlf_solr {
 		// Load class.
 		if (!class_exists('Apache_Solr_Service')) {
 
-			require_once(t3lib_div::getFileAbsFileName('EXT:'.self::$extKey.'/lib/SolrPhpClient/Apache/Solr/Service.php'));
+			require_once(\TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName('EXT:'.self::$extKey.'/lib/SolrPhpClient/Apache/Solr/Service.php'));
 
 		}
 
@@ -655,7 +655,7 @@ class tx_dlf_solr {
 		$path = trim($conf['solrPath'], '/').'/'.$core;
 
 		// Instantiate Apache_Solr_Service class.
-		$this->service = t3lib_div::makeInstance('Apache_Solr_Service', $host, $port, $path);
+		$this->service = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('Apache_Solr_Service', $host, $port, $path);
 
 		// Check if connection is established.
 		if ($this->service->ping() !== FALSE) {

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -97,7 +97,7 @@ if (TYPO3_MODE === 'FE') {
 
 		$conf['pages'] = $pidCondition[0];
 
-		$docType = t3lib_div::makeInstance('tx_dlf_doctype');
+		$docType = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_doctype');
 
 		switch($pidCondition[1]){
 			case "periodical":

--- a/dlf/ext_tables.php
+++ b/dlf/ext_tables.php
@@ -222,7 +222,7 @@ $TCA['tx_dlf_libraries'] = array (
 
 // Register plugins.
 if (version_compare(TYPO3_branch, '6.1', '<')) {
-	t3lib_div::loadTCA('tt_content');
+	\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tt_content');
 }
 
 // Plugin "collection".

--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -101,7 +101,7 @@ class tx_dlf_em {
 
 			if (is_array($status)) {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					sprintf($GLOBALS['LANG']->getLL('solr.status'), (string) $status[0]),
 					$GLOBALS['LANG']->getLL('solr.connected'),
@@ -117,7 +117,7 @@ class tx_dlf_em {
 
 		}
 
-		$message = t3lib_div::makeInstance(
+		$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 			't3lib_FlashMessage',
 			sprintf($GLOBALS['LANG']->getLL('solr.error'), $url),
 			$GLOBALS['LANG']->getLL('solr.notConnected'),
@@ -174,7 +174,7 @@ class tx_dlf_em {
 
 				$usrUid = $resArray['uid'];
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('cliUserGroup.usrOkayMsg'),
 					$GLOBALS['LANG']->getLL('cliUserGroup.usrOkay'),
@@ -205,7 +205,7 @@ class tx_dlf_em {
 
 						$usrUid = $resArray['uid'];
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							$GLOBALS['LANG']->getLL('cliUserGroup.usrConfiguredMsg'),
 							$GLOBALS['LANG']->getLL('cliUserGroup.usrConfigured'),
@@ -215,7 +215,7 @@ class tx_dlf_em {
 
 					} else {
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							$GLOBALS['LANG']->getLL('cliUserGroup.usrNotConfiguredMsg'),
 							$GLOBALS['LANG']->getLL('cliUserGroup.usrNotConfigured'),
@@ -227,7 +227,7 @@ class tx_dlf_em {
 
 				} else {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('cliUserGroup.usrNotConfiguredMsg'),
 						$GLOBALS['LANG']->getLL('cliUserGroup.usrNotConfigured'),
@@ -261,7 +261,7 @@ class tx_dlf_em {
 
 					$usrUid = $substUid[$tempUid];
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('cliUserGroup.usrCreatedMsg'),
 						$GLOBALS['LANG']->getLL('cliUserGroup.usrCreated'),
@@ -271,7 +271,7 @@ class tx_dlf_em {
 
 				} else {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('cliUserGroup.usrNotCreatedMsg'),
 						$GLOBALS['LANG']->getLL('cliUserGroup.usrNotCreated'),
@@ -283,7 +283,7 @@ class tx_dlf_em {
 
 			} else {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('cliUserGroup.usrNotCreatedMsg'),
 					$GLOBALS['LANG']->getLL('cliUserGroup.usrNotCreated'),
@@ -342,7 +342,7 @@ class tx_dlf_em {
 			foreach ($settings['tables_modify'] as $table) {
 
 				if (version_compare(TYPO3_branch, '6.1', '<')) {
-					t3lib_div::loadTCA($table);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA($table);
 				}
 
 				foreach ($GLOBALS['TCA'][$table]['columns'] as $field => $fieldConf) {
@@ -402,7 +402,7 @@ class tx_dlf_em {
 
 				$grpUid = $resArray['uid'];
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('cliUserGroup.grpOkayMsg'),
 					$GLOBALS['LANG']->getLL('cliUserGroup.grpOkay'),
@@ -446,7 +446,7 @@ class tx_dlf_em {
 
 						$grpUid = $resArray['uid'];
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							$GLOBALS['LANG']->getLL('cliUserGroup.grpConfiguredMsg'),
 							$GLOBALS['LANG']->getLL('cliUserGroup.grpConfigured'),
@@ -456,7 +456,7 @@ class tx_dlf_em {
 
 					} else {
 
-						$message = t3lib_div::makeInstance(
+						$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							$GLOBALS['LANG']->getLL('cliUserGroup.grpNotConfiguredMsg'),
 							$GLOBALS['LANG']->getLL('cliUserGroup.grpNotConfigured'),
@@ -468,7 +468,7 @@ class tx_dlf_em {
 
 				} else {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('cliUserGroup.grpNotConfiguredMsg'),
 						$GLOBALS['LANG']->getLL('cliUserGroup.grpNotConfigured'),
@@ -515,7 +515,7 @@ class tx_dlf_em {
 
 					$grpUid = $substUid[$tempUid];
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('cliUserGroup.grpCreatedMsg'),
 						$GLOBALS['LANG']->getLL('cliUserGroup.grpCreated'),
@@ -525,7 +525,7 @@ class tx_dlf_em {
 
 				} else {
 
-					$message = t3lib_div::makeInstance(
+					$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						$GLOBALS['LANG']->getLL('cliUserGroup.grpNotCreatedMsg'),
 						$GLOBALS['LANG']->getLL('cliUserGroup.grpNotCreated'),
@@ -537,7 +537,7 @@ class tx_dlf_em {
 
 			} else {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('cliUserGroup.grpNotCreatedMsg'),
 					$GLOBALS['LANG']->getLL('cliUserGroup.grpNotCreated'),
@@ -582,7 +582,7 @@ class tx_dlf_em {
 		// Check if CLI dispatcher is executable.
 		if (is_executable(PATH_typo3.'cli_dispatch.phpsh')) {
 
-			$message = t3lib_div::makeInstance(
+			$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('cliUserGroup.cliOkayMsg'),
 				$GLOBALS['LANG']->getLL('cliUserGroup.cliOkay'),
@@ -592,7 +592,7 @@ class tx_dlf_em {
 
 		} else {
 
-			$message = t3lib_div::makeInstance(
+			$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('cliUserGroup.cliNotOkayMsg'),
 				$GLOBALS['LANG']->getLL('cliUserGroup.cliNotOkay'),
@@ -674,7 +674,7 @@ class tx_dlf_em {
 
 			if (!empty($substUid)) {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('metadataFormats.nsCreatedMsg'),
 					$GLOBALS['LANG']->getLL('metadataFormats.nsCreated'),
@@ -684,7 +684,7 @@ class tx_dlf_em {
 
 			} else {
 
-				$message = t3lib_div::makeInstance(
+				$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					$GLOBALS['LANG']->getLL('metadataFormats.nsNotCreatedMsg'),
 					$GLOBALS['LANG']->getLL('metadataFormats.nsNotCreated'),
@@ -696,7 +696,7 @@ class tx_dlf_em {
 
 		} else {
 
-			$message = t3lib_div::makeInstance(
+			$message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				$GLOBALS['LANG']->getLL('metadataFormats.nsOkayMsg'),
 				$GLOBALS['LANG']->getLL('metadataFormats.nsOkay'),
@@ -725,7 +725,7 @@ class tx_dlf_em {
 		$GLOBALS['LANG']->includeLLFile('EXT:dlf/locallang.xml');
 
 		// Get current configuration.
-		$this->conf = array_merge((array) unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']), (array) t3lib_div::_POST('data'));
+		$this->conf = array_merge((array) unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']), (array) \TYPO3\CMS\Core\Utility\GeneralUtility::_POST('data'));
 
 	}
 

--- a/dlf/hooks/class.tx_dlf_tceforms.php
+++ b/dlf/hooks/class.tx_dlf_tceforms.php
@@ -79,7 +79,7 @@ class tx_dlf_tceforms {
 
 		if ($params['row']['pi_flexform']) {
 
-			$pi_flexform = t3lib_div::xml2array($params['row']['pi_flexform']);
+			$pi_flexform = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
 
 			$pages = $pi_flexform['data']['sDEF']['lDEF']['pages']['vDEF'];
 
@@ -134,7 +134,7 @@ class tx_dlf_tceforms {
 
 		if ($params['row']['pi_flexform']) {
 
-			$pi_flexform = t3lib_div::xml2array($params['row']['pi_flexform']);
+			$pi_flexform = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
 
 			$pages = $pi_flexform['data']['sDEF']['lDEF']['pages']['vDEF'];
 
@@ -189,7 +189,7 @@ class tx_dlf_tceforms {
 
 		if ($params['row']['pi_flexform']) {
 
-			$pi_flexform = t3lib_div::xml2array($params['row']['pi_flexform']);
+			$pi_flexform = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
 
 			$pages = $pi_flexform['data']['sDEF']['lDEF']['pages']['vDEF'];
 
@@ -244,7 +244,7 @@ class tx_dlf_tceforms {
 
 		if ($params['row']['pi_flexform']) {
 
-			$pi_flexform = t3lib_div::xml2array($params['row']['pi_flexform']);
+			$pi_flexform = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
 
 			$pages = $pi_flexform['data']['sDEF']['lDEF']['pages']['vDEF'];
 
@@ -299,7 +299,7 @@ class tx_dlf_tceforms {
 
 		if ($params['row']['pi_flexform']) {
 
-			$pi_flexform = t3lib_div::xml2array($params['row']['pi_flexform']);
+			$pi_flexform = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
 
 			$pages = $pi_flexform['data']['sDEF']['lDEF']['pages']['vDEF'];
 

--- a/dlf/hooks/class.tx_dlf_tcemain.php
+++ b/dlf/hooks/class.tx_dlf_tcemain.php
@@ -178,7 +178,7 @@ class tx_dlf_tcemain {
 
 					if (TYPO3_DLOG) {
 
-						t3lib_div::devLog('[tx_dlf_tcemain->processDatamap_postProcessFieldArray('.$status.', '.$table.', '.$id.', [data], ['.get_class($pObj).'])] Could not create new Apache Solr core "dlfCore'.$coreNumber.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $fieldArray);
+						\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_tcemain->processDatamap_postProcessFieldArray('.$status.', '.$table.', '.$id.', [data], ['.get_class($pObj).'])] Could not create new Apache Solr core "dlfCore'.$coreNumber.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $fieldArray);
 
 					}
 
@@ -286,7 +286,7 @@ class tx_dlf_tcemain {
 
 						if (TYPO3_DLOG) {
 
-							t3lib_div::devLog('[tx_dlf_tcemain->processDatamap_postProcessFieldArray('.$status.', '.$table.', '.$id.', [data], ['.get_class($pObj).'])] Prevented change of "index_name" for UID "'.$id.'" in table "'.$table.'"', $this->extKey, SYSLOG_SEVERITY_NOTICE, $fieldArray);
+							\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_tcemain->processDatamap_postProcessFieldArray('.$status.', '.$table.', '.$id.', [data], ['.get_class($pObj).'])] Prevented change of "index_name" for UID "'.$id.'" in table "'.$table.'"', $this->extKey, SYSLOG_SEVERITY_NOTICE, $fieldArray);
 
 						}
 
@@ -364,7 +364,7 @@ class tx_dlf_tcemain {
 
 									if (TYPO3_DLOG) {
 
-										t3lib_div::devLog('[tx_dlf_tcemain->processDatamap_afterDatabaseOperations('.$status.', '.$table.', '.$id.', [data], ['.get_class($pObj).'])] Failed to re-index document with UID "'.$id.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $fieldArray);
+										\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_tcemain->processDatamap_afterDatabaseOperations('.$status.', '.$table.', '.$id.', [data], ['.get_class($pObj).'])] Failed to re-index document with UID "'.$id.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $fieldArray);
 
 									}
 
@@ -449,7 +449,7 @@ class tx_dlf_tcemain {
 
 							if (TYPO3_DLOG) {
 
-								t3lib_div::devLog('[tx_dlf_tcemain->processCmdmap_postProcess('.$command.', '.$table.', '.$id.', '.$value.', ['.get_class($pObj).'])] Failed to re-index document with UID "'.$id.'"', $this->extKey, SYSLOG_SEVERITY_ERROR);
+								\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_tcemain->processCmdmap_postProcess('.$command.', '.$table.', '.$id.', '.$value.', ['.get_class($pObj).'])] Failed to re-index document with UID "'.$id.'"', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 							}
 

--- a/dlf/modules/indexing/index.php
+++ b/dlf/modules/indexing/index.php
@@ -188,7 +188,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 		}
 
 		// Give feedback about progress.
-		$_message = t3lib_div::makeInstance(
+		$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 			't3lib_FlashMessage',
 			htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.documentsToGo'), count($this->list))),
 			tx_dlf_helper::getLL('flash.running', TRUE),
@@ -199,7 +199,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 		$this->markerArray['CONTENT'] .= $_message->render();
 
 		// Start next loop.
-		$this->markerArray['CONTENT'] .= '<script type="text/javascript">window.location.href=unescape("'.t3lib_div::rawUrlEncodeJS(t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'indexLoop', $this->prefixId => array ('core' => $this->data['core']), 'random' => uniqid())))).'");</script>';
+		$this->markerArray['CONTENT'] .= '<script type="text/javascript">window.location.href=unescape("'.\TYPO3\CMS\Core\Utility\GeneralUtility::rawUrlEncodeJS(\TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'indexLoop', $this->prefixId => array ('core' => $this->data['core']), 'random' => uniqid())))).'");</script>';
 
 		$this->printContent();
 
@@ -243,7 +243,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 
 						} else {
 
-							$_message = t3lib_div::makeInstance(
+							$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 								't3lib_FlashMessage',
 								htmlspecialchars(sprintf(tx_dlf_helper::getLL('flash.FileNotLoaded'), $title, $uid)),
 								tx_dlf_helper::getLL('flash.error', TRUE),
@@ -300,7 +300,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 
 						}
 
-						$this->list = t3lib_div::makeInstance('tx_dlf_list', $elements);
+						$this->list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list', $elements);
 
 						// Start index looping.
 						if (count($this->list) > 0) {
@@ -319,7 +319,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 					$GLOBALS['BE_USER']->fetchUserSession();
 
 					// Get document list from user's session.
-					$this->list = t3lib_div::makeInstance('tx_dlf_list');
+					$this->list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 					// Continue index looping.
 					if (count($this->list) > 0 && isset($this->data['core'])) {
@@ -328,7 +328,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 
 					} else {
 
-						$_message = t3lib_div::makeInstance(
+						$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 							't3lib_FlashMessage',
 							tx_dlf_helper::getLL('flash.seeLog', TRUE),
 							tx_dlf_helper::getLL('flash.done', TRUE),
@@ -405,7 +405,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/mod
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/modules/indexing/index.php']);
 }
 
-$SOBE = t3lib_div::makeInstance('tx_dlf_modIndexing');
+$SOBE = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_modIndexing');
 
 $SOBE->main();
 

--- a/dlf/modules/newclient/index.php
+++ b/dlf/modules/newclient/index.php
@@ -69,14 +69,14 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
 			// Add current page to mountpoints.
-			if (!t3lib_div::inList($resArray['db_mountpoints'], $this->id)) {
+			if (!\TYPO3\CMS\Core\Utility\GeneralUtility::inList($resArray['db_mountpoints'], $this->id)) {
 
 				$data['be_groups'][$resArray['uid']]['db_mountpoints'] = $resArray['db_mountpoints'].','.$this->id;
 
 				tx_dlf_helper::processDBasAdmin($data);
 
 				// Fine.
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					tx_dlf_helper::getLL('flash.usergroupAddedMsg'),
 					tx_dlf_helper::getLL('flash.usergroupAdded', TRUE),
@@ -106,7 +106,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 		// Load table configuration array to get default field values.
 		if (version_compare(TYPO3_branch, '6.1', '<')) {
-			t3lib_div::loadTCA('tx_dlf_metadata');
+			\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tx_dlf_metadata');
 		}
 
 		$i = 0;
@@ -155,7 +155,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		if (count($_ids) == $i) {
 
 			// Fine.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				tx_dlf_helper::getLL('flash.metadataAddedMsg'),
 				tx_dlf_helper::getLL('flash.metadataAdded', TRUE),
@@ -166,7 +166,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		} else {
 
 			// Something went wrong.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				tx_dlf_helper::getLL('flash.metadataNotAddedMsg'),
 				tx_dlf_helper::getLL('flash.metadataNotAdded', TRUE),
@@ -202,7 +202,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		if (count($_ids) == 1) {
 
 			// Fine.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				tx_dlf_helper::getLL('flash.solrcoreAddedMsg'),
 				tx_dlf_helper::getLL('flash.solrcoreAdded', TRUE),
@@ -213,7 +213,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		} else {
 
 			// Something went wrong.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				tx_dlf_helper::getLL('flash.solrcoreNotAddedMsg'),
 				tx_dlf_helper::getLL('flash.solrcoreNotAdded', TRUE),
@@ -259,7 +259,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		if (count($_ids) == count($structures)) {
 
 			// Fine.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				tx_dlf_helper::getLL('flash.structureAddedMsg'),
 				tx_dlf_helper::getLL('flash.structureAdded', TRUE),
@@ -270,7 +270,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		} else {
 
 			// Something went wrong.
-			$_message = t3lib_div::makeInstance(
+			$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 				't3lib_FlashMessage',
 				tx_dlf_helper::getLL('flash.structureNotAddedMsg'),
 				tx_dlf_helper::getLL('flash.structureNotAdded', TRUE),
@@ -301,7 +301,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			// Check if page is sysfolder.
 			if ($this->pageInfo['doktype'] != 254) {
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					tx_dlf_helper::getLL('flash.wrongPageTypeMsg'),
 					tx_dlf_helper::getLL('flash.wrongPageType', TRUE),
@@ -346,7 +346,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
 
 				// Fine.
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					tx_dlf_helper::getLL('flash.structureOkayMsg'),
 					tx_dlf_helper::getLL('flash.structureOkay', TRUE),
@@ -357,9 +357,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			} else {
 
 				// Configuration missing.
-				$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addStructure')));
+				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addStructure')));
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					sprintf(tx_dlf_helper::getLL('flash.structureNotOkayMsg'), $_url),
 					tx_dlf_helper::getLL('flash.structureNotOkay', TRUE),
@@ -381,7 +381,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
 
 				// Fine.
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					tx_dlf_helper::getLL('flash.metadataOkayMsg'),
 					tx_dlf_helper::getLL('flash.metadataOkay', TRUE),
@@ -392,9 +392,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			} else {
 
 				// Configuration missing.
-				$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addMetadata')));
+				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addMetadata')));
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					sprintf(tx_dlf_helper::getLL('flash.metadataNotOkayMsg'), $_url),
 					tx_dlf_helper::getLL('flash.metadataNotOkay', TRUE),
@@ -417,10 +417,10 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 				$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-				if (t3lib_div::inList($resArray['db_mountpoints'], $this->id)) {
+				if (\TYPO3\CMS\Core\Utility\GeneralUtility::inList($resArray['db_mountpoints'], $this->id)) {
 
 					// Fine.
-					$_message = t3lib_div::makeInstance(
+					$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						tx_dlf_helper::getLL('flash.usergroupOkayMsg'),
 						tx_dlf_helper::getLL('flash.usergroupOkay', TRUE),
@@ -431,9 +431,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 				} else {
 
 					// Configuration missing.
-					$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addAccessRights')));
+					$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addAccessRights')));
 
-					$_message = t3lib_div::makeInstance(
+					$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						sprintf(tx_dlf_helper::getLL('flash.usergroupNotOkayMsg'), $_url),
 						tx_dlf_helper::getLL('flash.usergroupNotOkay', TRUE),
@@ -446,7 +446,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			} else {
 
 				// Usergoup missing.
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					tx_dlf_helper::getLL('flash.usergroupMissingMsg'),
 					tx_dlf_helper::getLL('flash.usergroupMissing', TRUE),
@@ -472,7 +472,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 				if ($resArray['pid']) {
 
 					// Fine.
-					$_message = t3lib_div::makeInstance(
+					$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						tx_dlf_helper::getLL('flash.solrcoreOkayMsg'),
 						tx_dlf_helper::getLL('flash.solrcoreOkay', TRUE),
@@ -483,9 +483,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 				} else {
 
 					// Default core available, but this is deprecated.
-					$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addSolrcore')));
+					$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addSolrcore')));
 
-					$_message = t3lib_div::makeInstance(
+					$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 						't3lib_FlashMessage',
 						sprintf(tx_dlf_helper::getLL('flash.solrcoreDeprecatedMsg'), $_url),
 						tx_dlf_helper::getLL('flash.solrcoreDeprecatedOkay', TRUE),
@@ -498,9 +498,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 			} else {
 
 				// Solr core missing.
-				$_url = t3lib_div::locationHeaderUrl(t3lib_div::linkThisScript(array ('id' => $this->id, 'CMD' => 'addSolrcore')));
+				$_url = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\GeneralUtility::linkThisScript(array ('id' => $this->id, 'CMD' => 'addSolrcore')));
 
-				$_message = t3lib_div::makeInstance(
+				$_message = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 					't3lib_FlashMessage',
 					sprintf(tx_dlf_helper::getLL('flash.solrcoreMissingMsg'), $_url),
 					tx_dlf_helper::getLL('flash.solrcoreMissing', TRUE),
@@ -531,7 +531,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/mod
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/modules/newclient/index.php']);
 }
 
-$SOBE = t3lib_div::makeInstance('tx_dlf_modNewclient');
+$SOBE = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_modNewclient');
 
 $SOBE->main();
 

--- a/dlf/plugins/collection/class.tx_dlf_collection.php
+++ b/dlf/plugins/collection/class.tx_dlf_collection.php
@@ -68,7 +68,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_collection->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_collection->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
 
 			}
 
@@ -222,7 +222,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 				$conf = array (
 					'useCacheHash' => 1,
 					'parameter' => $GLOBALS['TSFE']->id,
-					'additionalParams' => t3lib_div::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
+					'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
 				);
 
 				// Link collection's title to list view.
@@ -418,7 +418,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 		}
 
 		// Save list of documents.
-		$list = t3lib_div::makeInstance('tx_dlf_list');
+		$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 		$list->reset();
 
@@ -429,10 +429,10 @@ class tx_dlf_collection extends tx_dlf_plugin {
 		$list->save();
 
 		// Clean output buffer.
-		t3lib_div::cleanOutputBuffers();
+		\TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
 
 		// Send headers.
-		header('Location: '.t3lib_div::locationHeaderUrl($this->cObj->typoLink_URL(array ('parameter' => $this->conf['targetPid']))));
+		header('Location: '.\TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->cObj->typoLink_URL(array ('parameter' => $this->conf['targetPid']))));
 
 		// Flush output buffer and end script processing.
 		ob_end_flush();

--- a/dlf/plugins/feeds/class.tx_dlf_feeds.php
+++ b/dlf/plugins/feeds/class.tx_dlf_feeds.php
@@ -68,7 +68,7 @@ class tx_dlf_feeds extends tx_dlf_plugin {
 
 		$channel->appendChild($rss->createElement('title', htmlspecialchars($this->conf['title'], ENT_NOQUOTES, 'UTF-8')));
 
-		$channel->appendChild($rss->createElement('link', htmlspecialchars(t3lib_div::locationHeaderUrl($this->pi_linkTP_keepPIvars_url()), ENT_NOQUOTES, 'UTF-8')));
+		$channel->appendChild($rss->createElement('link', htmlspecialchars(\TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->pi_linkTP_keepPIvars_url()), ENT_NOQUOTES, 'UTF-8')));
 
 		if (!empty($this->conf['description'])) {
 
@@ -98,7 +98,7 @@ class tx_dlf_feeds extends tx_dlf_plugin {
 		$channel->appendChild($rss->createElement('generator', htmlspecialchars($this->conf['useragent'], ENT_NOQUOTES, 'UTF-8')));
 
 		// Add item elements.
-		if (!$this->conf['excludeOther'] || empty($this->piVars['collection']) || t3lib_div::inList($this->conf['collections'], $this->piVars['collection'])) {
+		if (!$this->conf['excludeOther'] || empty($this->piVars['collection']) || \TYPO3\CMS\Core\Utility\GeneralUtility::inList($this->conf['collections'], $this->piVars['collection'])) {
 
 			$additionalWhere = '';
 
@@ -184,7 +184,7 @@ class tx_dlf_feeds extends tx_dlf_plugin {
 					$linkConf = array (
 						'parameter' => $this->conf['targetPid'],
 						'forceAbsoluteUrl' => 1,
-						'additionalParams' => t3lib_div::implodeArrayForUrl($this->prefixId, array ('id' => $resArray['uid']), '', TRUE, FALSE)
+						'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, array ('id' => $resArray['uid']), '', TRUE, FALSE)
 					);
 
 					$item->appendChild($rss->createElement('link', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8')));
@@ -218,7 +218,7 @@ class tx_dlf_feeds extends tx_dlf_plugin {
 		$content = $rss->saveXML();
 
 		// Clean output buffer.
-		t3lib_div::cleanOutputBuffers();
+		\TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
 
 		// Send headers.
 		header('HTTP/1.1 200 OK');

--- a/dlf/plugins/listview/class.tx_dlf_listview.php
+++ b/dlf/plugins/listview/class.tx_dlf_listview.php
@@ -205,7 +205,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 					$conf = array (
 						'useCacheHash' => 1,
 						'parameter' => $this->conf['targetPid'],
-						'additionalParams' => t3lib_div::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
+						'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
 					);
 
 					$value = $this->cObj->typoLink(htmlspecialchars($value), $conf);
@@ -404,7 +404,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 						$conf = array (
 							'useCacheHash' => 1,
 							'parameter' => $this->conf['targetPid'],
-							'additionalParams' => t3lib_div::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
+							'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
 						);
 
 						$value = $this->cObj->typoLink(htmlspecialchars($value), $conf);
@@ -524,7 +524,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 		$this->setCache(FALSE);
 
 		// Load the list.
-		$this->list = t3lib_div::makeInstance('tx_dlf_list');
+		$this->list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 		// Sort the list if applicable.
 		if ((!empty($this->piVars['order']) && $this->piVars['order'] != $this->list->metadata['options']['order'])

--- a/dlf/plugins/metadata/class.tx_dlf_metadata.php
+++ b/dlf/plugins/metadata/class.tx_dlf_metadata.php
@@ -168,7 +168,7 @@ class tx_dlf_metadata extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_metadata->main('.$content.', [data])] No metadata found for document with UID "'.$this->doc->uid.'"', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_metadata->main('.$content.', [data])] No metadata found for document with UID "'.$this->doc->uid.'"', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
 
 			}
 

--- a/dlf/plugins/navigation/class.tx_dlf_navigation.php
+++ b/dlf/plugins/navigation/class.tx_dlf_navigation.php
@@ -50,7 +50,7 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 		if (!empty($this->conf['targetPid'])) {
 
 			// Load the list.
-			$list = t3lib_div::makeInstance('tx_dlf_list');
+			$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 			if (count($list) > 0) {
 
@@ -324,7 +324,7 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 			'useCacheHash' => 1,
 			'parameter' => $GLOBALS['TSFE']->id,
 			'ATagParams' => $aTagParams,
-			'additionalParams' => t3lib_div::implodeArrayForUrl($this->prefixId, $overrulePIvars, '', TRUE, FALSE),
+			'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $overrulePIvars, '', TRUE, FALSE),
 			'title' => $label
 		);
 

--- a/dlf/plugins/oai/class.tx_dlf_oai.php
+++ b/dlf/plugins/oai/class.tx_dlf_oai.php
@@ -98,7 +98,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 			// Deletion failed.
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -152,9 +152,9 @@ class tx_dlf_oai extends tx_dlf_plugin {
 		// Set only allowed parameters.
 		foreach ($allowedParams as $param) {
 
-			if (t3lib_div::_GP($param)) {
+			if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param)) {
 
-				$this->piVars[$param] = t3lib_div::_GP($param);
+				$this->piVars[$param] = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param);
 
 			}
 
@@ -364,7 +364,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_oai->getMetsData([data])] No METS part found in document with location "'.$location.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $metadata);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->getMetsData([data])] No METS part found in document with location "'.$location.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $metadata);
 
 				}
 
@@ -374,7 +374,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_oai->getMetsData([data])] Could not load XML file from "'.$location.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $metadata);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->getMetsData([data])] Could not load XML file from "'.$location.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $metadata);
 
 			}
 
@@ -433,12 +433,12 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 			}
 
-			$stylesheet = t3lib_div::locationHeaderUrl($this->conf['stylesheet']);
+			$stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->conf['stylesheet']);
 
 		} else {
 
 			// Use default stylesheet if no custom stylesheet is given.
-			$stylesheet = t3lib_div::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
+			$stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
 
 		}
 
@@ -528,7 +528,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 		$content = $this->oai->saveXML();
 
 		// Clean output buffer.
-		t3lib_div::cleanOutputBuffers();
+		\TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
 
 		// Send headers.
 		header('HTTP/1.1 200 OK');
@@ -727,7 +727,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_oai->resume()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->resume()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 				}
 
@@ -925,7 +925,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_oai->verbIdentify()] Incomplete plugin configuration',
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbIdentify()] Incomplete plugin configuration',
 						  $this->extKey, SYSLOG_SEVERITY_NOTICE);
 
 			}
@@ -954,7 +954,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "' .
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "' .
 						  $this->conf['pages'] . '"', $this->extKey, SYSLOG_SEVERITY_NOTICE);
 
 			}
@@ -1227,7 +1227,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 			if (!$complete) {
 
 				// Save result set as list object.
-				$resultSet = t3lib_div::makeInstance('tx_dlf_list');
+				$resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 				$resultSet->reset();
 
@@ -1267,7 +1267,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 					if (TYPO3_DLOG) {
 
-						t3lib_div::devLog('[tx_dlf_oai->verbListIdentifiers()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
+						\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbListIdentifiers()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 					}
 
@@ -1632,7 +1632,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 			if (!$complete) {
 
 				// Save result set as list object.
-				$resultSet = t3lib_div::makeInstance('tx_dlf_list');
+				$resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 				$resultSet->reset();
 
@@ -1672,7 +1672,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 					if (TYPO3_DLOG) {
 
-						t3lib_div::devLog('[tx_dlf_oai->verbListRecords()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
+						\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbListRecords()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
 
 					}
 

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -97,7 +97,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		$linkConf = array (
 			'useCacheHash' => 1,
 			'parameter' => $this->conf['targetPid'],
-			'additionalParams' => t3lib_div::implodeArrayForUrl($this->prefixId, $piVars, '', TRUE, FALSE),
+			'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $piVars, '', TRUE, FALSE),
 			'title' => $markerArray['###PAGINATION###']
 		);
 
@@ -231,7 +231,7 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_pagegrid->main('.$content.', [data])] No template subpart for list entry found', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_pagegrid->main('.$content.', [data])] No template subpart for list entry found', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
 
 			}
 

--- a/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
@@ -52,20 +52,20 @@ class tx_dlf_fulltext_eid extends tslib_pibase {
 	 */
 	public function main($content = '', $conf = array ()) {
 
-		$this->cObj = t3lib_div::makeInstance('tslib_cObj');
+		$this->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tslib_cObj');
 
 		// Load translation files.
-		$LANG = t3lib_div::makeInstance('language');
+		$LANG = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('language');
 
 		$this->extKey = 'dlf';
 
 		$this->scriptRelPath = 'plugins/pageview/class.tx_dlf_fulltext_eid.php';
 
-		$this->LLkey = t3lib_div::_GP('L') ? t3lib_div::_GP('L') : 'default';
+		$this->LLkey = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('L') ? \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('L') : 'default';
 
 		$this->pi_loadLL();
 
-		$url = t3lib_div::_GP('url');
+		$url = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('url');
 
 		$fulltextData = file_get_contents($url);
 
@@ -85,7 +85,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plu
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php']);
 }
 
-$cObj = t3lib_div::makeInstance('tx_dlf_fulltext_eid');
+$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_fulltext_eid');
 
 $cObj->main();
 

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -303,7 +303,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		$imageUrl = '';
 
 		// Get @USE value of METS fileGrp.
-		$fileGrps = t3lib_div::trimExplode(',', $this->conf['fileGrps']);
+		$fileGrps = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['fileGrps']);
 
 		while ($fileGrp = @array_pop($fileGrps)) {
 
@@ -318,7 +318,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_pageview->getImageUrl('.$page.')] File not found in fileGrp "'.$fileGrp.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_pageview->getImageUrl('.$page.')] File not found in fileGrp "'.$fileGrp.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 				}
 
@@ -346,7 +346,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		// Get @USE value of METS fileGrp.
 
 		// we need USE="FULLTEXT"
-		$fileGrpFulltext = t3lib_div::trimExplode(',', $this->conf['fileGrpFulltext']);
+		$fileGrpFulltext = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['fileGrpFulltext']);
 
 		while ($fileGrpFulltext = @array_pop($fileGrpFulltext)) {
 
@@ -366,7 +366,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_pageview->getImageUrl('.$page.')] File not found in fileGrp "'.$fileGrp.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_pageview->getImageUrl('.$page.')] File not found in fileGrp "'.$fileGrp.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 				}
 

--- a/dlf/plugins/search/class.tx_dlf_search.php
+++ b/dlf/plugins/search/class.tx_dlf_search.php
@@ -72,7 +72,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_search->addAutocompleteJS()] No metadata fields configured for search suggestions', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_search->addAutocompleteJS()] No metadata fields configured for search suggestions', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -90,7 +90,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 	protected function addCurrentCollection() {
 
 		// Load current collection.
-		$list = t3lib_div::makeInstance('tx_dlf_list');
+		$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 		if (!empty($list->metadata['options']['source']) && $list->metadata['options']['source'] == 'collection') {
 
@@ -130,7 +130,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 	protected function addCurrentDocument() {
 
 		// Load current list object.
-		$list = t3lib_div::makeInstance('tx_dlf_list');
+		$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 		// Load current document.
 		if (!empty($this->piVars['id']) && tx_dlf_helper::testInt($this->piVars['id'])) {
@@ -229,7 +229,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 		// Get field selector options.
 		$fieldSelectorOptions = '';
 
-		$searchFields = t3lib_div::trimExplode(',', $this->conf['extendedFields'], TRUE);
+		$searchFields = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['extendedFields'], TRUE);
 
 		foreach ($searchFields as $searchField) {
 
@@ -267,7 +267,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_search->addFacetsMenu()] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_search->addFacetsMenu()] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 
@@ -285,7 +285,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 		// Get facets from plugin configuration.
 		$facets = array ();
 
-		foreach (t3lib_div::trimExplode(',', $this->conf['facets'], TRUE) as $facet) {
+		foreach (\TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['facets'], TRUE) as $facet) {
 
 			$facets[$facet.'_faceting'] = tx_dlf_helper::translate($facet, 'tx_dlf_metadata', $this->conf['pages']);
 
@@ -414,7 +414,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_search->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_search->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
 
 			}
 
@@ -445,7 +445,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 			// Set last query if applicable.
 			$lastQuery = '';
 
-			$list = t3lib_div::makeInstance('tx_dlf_list');
+			$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 			if (!empty($list->metadata['options']['source']) && $list->metadata['options']['source'] == 'search') {
 
@@ -489,7 +489,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 				if (TYPO3_DLOG) {
 
-					t3lib_div::devLog('[tx_dlf_search->main('.$content.', [data])] Apache Solr not available', $this->extKey, SYSLOG_SEVERITY_ERROR, $conf);
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_search->main('.$content.', [data])] Apache Solr not available', $this->extKey, SYSLOG_SEVERITY_ERROR, $conf);
 
 				}
 
@@ -525,7 +525,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 				$allowedOperators = array ('AND', 'OR', 'NOT');
 
-				$allowedFields = t3lib_div::trimExplode(',', $this->conf['extendedFields'], TRUE);
+				$allowedFields = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['extendedFields'], TRUE);
 
 				for ($i = 0; $i < count($this->piVars['extQuery']); $i++) {
 
@@ -606,19 +606,19 @@ class tx_dlf_search extends tx_dlf_plugin {
 			$results->save();
 
 			// Clean output buffer.
-			t3lib_div::cleanOutputBuffers();
+			\TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
 
 			// Keep some plugin variables.
 			$linkConf['parameter'] = $this->conf['targetPid'];
 
 			if (!empty($this->piVars['order'])) {
 
-				$linkConf['additionalParams'] = t3lib_div::implodeArrayForUrl($this->prefixId, array ('order' => $this->piVars['order'], 'asc' => (!empty($this->piVars['asc']) ? '1' : '0')), '', TRUE, FALSE);
+				$linkConf['additionalParams'] = \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, array ('order' => $this->piVars['order'], 'asc' => (!empty($this->piVars['asc']) ? '1' : '0')), '', TRUE, FALSE);
 
 			}
 
 			// Send headers.
-			header('Location: '.t3lib_div::locationHeaderUrl($this->cObj->typoLink_URL($linkConf)));
+			header('Location: '.\TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->cObj->typoLink_URL($linkConf)));
 
 			// Flush output buffer and end script processing.
 			ob_end_flush();
@@ -652,7 +652,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 		);
 
 		// Extract query and filter from last search.
-		$list = t3lib_div::makeInstance('tx_dlf_list');
+		$list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
 
 		if (!empty($list->metadata['options']['source'])) {
 
@@ -673,7 +673,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_search->makeFacetsMenuArray('.$content.', [data])] Apache Solr not available', $this->extKey, SYSLOG_SEVERITY_ERROR, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_search->makeFacetsMenuArray('.$content.', [data])] Apache Solr not available', $this->extKey, SYSLOG_SEVERITY_ERROR, $conf);
 
 			}
 

--- a/dlf/plugins/search/class.tx_dlf_search_suggest.php
+++ b/dlf/plugins/search/class.tx_dlf_search_suggest.php
@@ -51,15 +51,15 @@ class tx_dlf_search_suggest extends tslib_pibase {
 	 */
 	public function main($content = '', $conf = array ()) {
 
-		if (t3lib_div::_GP('encrypted') != '' && t3lib_div::_GP('hashed') != '') {
+		if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('encrypted') != '' && \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('hashed') != '') {
 
-			$core = tx_dlf_helper::decrypt(t3lib_div::_GP('encrypted'), t3lib_div::_GP('hashed'));
+			$core = tx_dlf_helper::decrypt(\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('encrypted'), \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('hashed'));
 
 		}
 
 		if (!empty($core)) {
 
-			$url = trim(tx_dlf_solr::getSolrUrl($core), '/').'/suggest/?q='.tx_dlf_solr::escapeQuery(t3lib_div::_GP('q'));
+			$url = trim(tx_dlf_solr::getSolrUrl($core), '/').'/suggest/?q='.tx_dlf_solr::escapeQuery(\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q'));
 
 			if ($stream = fopen($url, 'r')) {
 
@@ -81,7 +81,7 @@ if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plu
 	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/search/class.tx_dlf_search_suggest.php']);
 }
 
-$cObj = t3lib_div::makeInstance('tx_dlf_search_suggest');
+$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_search_suggest');
 
 $cObj->main();
 

--- a/dlf/plugins/statistics/class.tx_dlf_statistics.php
+++ b/dlf/plugins/statistics/class.tx_dlf_statistics.php
@@ -60,7 +60,7 @@ class tx_dlf_statistics extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_statistics->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_statistics->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
 
 			}
 

--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -160,7 +160,7 @@ class tx_dlf_toc extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_toc->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_toc->main('.$content.', [data])] Incomplete plugin configuration', $this->extKey, SYSLOG_SEVERITY_WARNING, $conf);
 
 			}
 

--- a/dlf/plugins/toolbox/class.tx_dlf_toolbox.php
+++ b/dlf/plugins/toolbox/class.tx_dlf_toolbox.php
@@ -86,7 +86,7 @@ class tx_dlf_toolbox extends tx_dlf_plugin {
 
 			$tool = trim($tool);
 
-			$cObj = t3lib_div::makeInstance('tslib_cObj');
+			$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tslib_cObj');
 
 			$cObj->data = $data;
 

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -135,7 +135,7 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		}
 
 		if (TYPO3_DLOG && empty($page1Link) && empty($page2Link)) {
-			t3lib_div::devLog('[tx_dlf_toolsPdf->getPageLink()] ' .
+			\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_toolsPdf->getPageLink()] ' .
 					  'File not found in fileGrp "' .
 					  $this->conf['fileGrpDownload'] . '"',
 					  $this->extKey,
@@ -197,7 +197,7 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 
 			if (TYPO3_DLOG) {
 
-				t3lib_div::devLog('[tx_dlf_toolsPdf->getWorkLink()] File not found in fileGrp "'.$this->conf['fileGrpDownload'].'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_toolsPdf->getWorkLink()] File not found in fileGrp "'.$this->conf['fileGrpDownload'].'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
 
 			}
 


### PR DESCRIPTION
It was deprecated with TYPO3 6.0.

Signed-off-by: Stefan Weil sw@weilnetz.de
