### PR TITLE
Replace deprecated class t3lib_TSparser

### DIFF
--- a/dlf/common/class.tx_dlf_plugin.php
+++ b/dlf/common/class.tx_dlf_plugin.php
@@ -304,7 +304,7 @@ abstract class tx_dlf_plugin extends tslib_pibase {
 	 */
 	protected function parseTS($string = '') {
 
-		$parser = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('t3lib_TSparser');
+		$parser = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\TypoScript\\Parser\\TypoScriptParser');
 
 		$parser->parse($string);
 


### PR DESCRIPTION
It was deprecated with TYPO3 6.0.

Signed-off-by: Stefan Weil sw@weilnetz.de
