### PR TITLE
Replace deprecated class tslib_pibase

### DIFF
--- a/dlf/common/class.tx_dlf_plugin.php
+++ b/dlf/common/class.tx_dlf_plugin.php
@@ -35,7 +35,7 @@
  * @access	public
  * @abstract
  */
-abstract class tx_dlf_plugin extends tslib_pibase {
+abstract class tx_dlf_plugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 	public $extKey = 'dlf';
 

--- a/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
@@ -32,7 +32,7 @@
  * @subpackage	tx_dlf
  * @access	public
  */
-class tx_dlf_fulltext_eid extends tslib_pibase {
+class tx_dlf_fulltext_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 	/**
 	 *

--- a/dlf/plugins/search/class.tx_dlf_search_suggest.php
+++ b/dlf/plugins/search/class.tx_dlf_search_suggest.php
@@ -35,7 +35,7 @@
  * @subpackage	tx_dlf
  * @access	public
  */
-class tx_dlf_search_suggest extends tslib_pibase {
+class tx_dlf_search_suggest extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 	public $scriptRelPath = 'plugins/search/class.tx_dlf_search_suggest.php';
 


### PR DESCRIPTION
It was deprecated with TYPO3 6.0.

Signed-off-by: Stefan Weil sw@weilnetz.de
