### PR TITLE
Remove compatibility code for TYPO3 < 6.2

### DIFF
--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -845,17 +845,7 @@ class tx_dlf_helper {
 	 */
 	public static function intInRange($theInt, $min, $max = 2000000000, $zeroValue = 0) {
 
-		if (t3lib_utility_VersionNumber::convertVersionNumberToInteger(TYPO3_version) >= 6000000) {
-
-			// TYPO3 > 6.0
-			return t3lib_utility_Math::forceIntegerInRange($theInt, $min, $max, $zeroValue);
-
-		} else {
-
-			// TYPO3 4.5 - 4.7
-			return \TYPO3\CMS\Core\Utility\GeneralUtility::intInRange($theInt, $min, $max, $zeroValue);
-
-		}
+		return t3lib_utility_Math::forceIntegerInRange($theInt, $min, $max, $zeroValue);
 
 	}
 
@@ -1123,17 +1113,7 @@ class tx_dlf_helper {
 	 */
 	public static function testInt($theInt) {
 
-		if (t3lib_utility_VersionNumber::convertVersionNumberToInteger(TYPO3_version) >= 6000000) {
-
-			// TYPO3 > 6.0
-			return t3lib_utility_Math::canBeInterpretedAsInteger($theInt);
-
-		} else {
-
-			// TYPO3 4.5 - 4.7
-			return \TYPO3\CMS\Core\Utility\GeneralUtility::testInt($theInt);
-
-		}
+		return t3lib_utility_Math::canBeInterpretedAsInteger($theInt);
 
 	}
 

--- a/dlf/ext_tables.php
+++ b/dlf/ext_tables.php
@@ -220,11 +220,6 @@ $TCA['tx_dlf_libraries'] = array (
 // Register static typoscript.
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'typoscript/', 'Basic Configuration');
 
-// Register plugins.
-if (version_compare(TYPO3_branch, '6.1', '<')) {
-	\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tt_content');
-}
-
 // Plugin "collection".
 $TCA['tt_content']['types']['list']['subtypes_excludelist'][$_EXTKEY.'_collection'] = 'layout,select_key,pages,recursive';
 

--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -341,10 +341,6 @@ class tx_dlf_em {
 			// Set allowed exclude fields.
 			foreach ($settings['tables_modify'] as $table) {
 
-				if (version_compare(TYPO3_branch, '6.1', '<')) {
-					\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA($table);
-				}
-
 				foreach ($GLOBALS['TCA'][$table]['columns'] as $field => $fieldConf) {
 
 					if (!empty($fieldConf['exclude'])) {

--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -359,28 +359,14 @@ class tx_dlf_em {
 
 		}
 
-		// be_groups:inc_access_lists was removed in TYPO3 6.2.
-		$hasIncAccessList =
-			(t3lib_utility_VersionNumber::convertVersionNumberToInteger(TYPO3_version) < 6002000);
-
 		// Check if group "_cli_dlf" exists and is not disabled.
-		if ($hasIncAccessList) {
-			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'uid,non_exclude_fields,tables_select,tables_modify,inc_access_lists,' .
-					$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled'],
-				'be_groups',
-				'title=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('_cli_dlf', 'be_groups') .
-					\TYPO3\CMS\Backend\Utility\BackendUtility::deleteClause('be_groups')
-			);
-		} else {
-			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'uid,non_exclude_fields,tables_select,tables_modify,' .
-					$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled'],
-				'be_groups',
-				'title=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('_cli_dlf', 'be_groups') .
-					\TYPO3\CMS\Backend\Utility\BackendUtility::deleteClause('be_groups')
-			);
-		}
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'uid,non_exclude_fields,tables_select,tables_modify,' .
+				$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled'],
+			'be_groups',
+			'title=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('_cli_dlf', 'be_groups') .
+				\TYPO3\CMS\Backend\Utility\BackendUtility::deleteClause('be_groups')
+		);
 
 		if ($GLOBALS['TYPO3_DB']->sql_num_rows($result) > 0) {
 
@@ -397,7 +383,6 @@ class tx_dlf_em {
 			if (count(array_diff($settings['non_exclude_fields'], $resArray['non_exclude_fields'])) == 0
 					&& count(array_diff($settings['tables_select'], $resArray['tables_select'])) == 0
 					&& count(array_diff($settings['tables_modify'], $resArray['tables_modify'])) == 0
-					&& (!$hasIncAccessList || $resArray['inc_access_lists'] == 1)
 					&& $resArray[$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled']] == 0) {
 
 				$grpUid = $resArray['uid'];
@@ -422,22 +407,12 @@ class tx_dlf_em {
 					$tables_modify = array_unique(array_merge($settings['tables_modify'], $resArray['tables_modify']));
 
 					// Try to configure usergroup.
-					if ($hasIncAccessList) {
-						$data['be_groups'][$resArray['uid']] = array(
-							'non_exclude_fields' => implode(',', $non_exclude_fields),
-							'tables_select' => implode(',', $tables_select),
-							'tables_modify' => implode(',', $tables_modify),
-							'inc_access_lists' => 1,
-							$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled'] => 0
-						);
-					} else {
-						$data['be_groups'][$resArray['uid']] = array(
-							'non_exclude_fields' => implode(',', $non_exclude_fields),
-							'tables_select' => implode(',', $tables_select),
-							'tables_modify' => implode(',', $tables_modify),
-							$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled'] => 0
-						);
-					}
+					$data['be_groups'][$resArray['uid']] = array(
+						'non_exclude_fields' => implode(',', $non_exclude_fields),
+						'tables_select' => implode(',', $tables_select),
+						'tables_modify' => implode(',', $tables_modify),
+						$GLOBALS['TCA']['be_groups']['ctrl']['enablecolumns']['disabled'] => 0
+					);
 
 					tx_dlf_helper::processDBasAdmin($data);
 
@@ -487,26 +462,14 @@ class tx_dlf_em {
 				// Try to create usergroup.
 				$tempUid = uniqid('NEW');
 
-				if ($hasIncAccessList) {
-					$data['be_groups'][$tempUid] = array(
-						'pid' => 0,
-						'title' => '_cli_dlf',
-						'description' => $GLOBALS['LANG']->getLL('cliUserGroup.grpDescription'),
-						'non_exclude_fields' => implode(',', $settings['non_exclude_fields']),
-						'tables_select' => implode(',', $settings['tables_select']),
-						'tables_modify' => implode(',', $settings['tables_modify']),
-						'inc_access_lists' => 1
-					);
-				} else {
-					$data['be_groups'][$tempUid] = array(
-						'pid' => 0,
-						'title' => '_cli_dlf',
-						'description' => $GLOBALS['LANG']->getLL('cliUserGroup.grpDescription'),
-						'non_exclude_fields' => implode(',', $settings['non_exclude_fields']),
-						'tables_select' => implode(',', $settings['tables_select']),
-						'tables_modify' => implode(',', $settings['tables_modify'])
-					);
-				}
+				$data['be_groups'][$tempUid] = array(
+					'pid' => 0,
+					'title' => '_cli_dlf',
+					'description' => $GLOBALS['LANG']->getLL('cliUserGroup.grpDescription'),
+					'non_exclude_fields' => implode(',', $settings['non_exclude_fields']),
+					'tables_select' => implode(',', $settings['tables_select']),
+					'tables_modify' => implode(',', $settings['tables_modify'])
+				);
 
 				$substUid = tx_dlf_helper::processDBasAdmin($data);
 

--- a/dlf/modules/newclient/index.php
+++ b/dlf/modules/newclient/index.php
@@ -104,11 +104,6 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 		// Include metadata definition file.
 		include_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey).'modules/'.$this->modPath.'metadata.inc.php');
 
-		// Load table configuration array to get default field values.
-		if (version_compare(TYPO3_branch, '6.1', '<')) {
-			\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tx_dlf_metadata');
-		}
-
 		$i = 0;
 
 		// Build data array.


### PR DESCRIPTION
It is no longer needed because only TYPO3 6.2 and newer is now supported.
