### PR TITLE
Replace deprecated class template

### DIFF
--- a/dlf/common/class.tx_dlf_module.php
+++ b/dlf/common/class.tx_dlf_module.php
@@ -118,7 +118,7 @@ abstract class tx_dlf_module extends \TYPO3\CMS\Backend\Module\BaseScriptClass {
 
 		$this->pageInfo = \TYPO3\CMS\Backend\Utility\BackendUtility::readPageAccess($this->id, $this->perms_clause);
 
-		$this->doc = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('template');
+		$this->doc = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Backend\\Template\\DocumentTemplate');
 
 		$this->doc->setModuleTemplate('EXT:'.$this->extKey.'/modules/'.$this->modPath.'template.tmpl');
 


### PR DESCRIPTION
It was deprecated with TYPO3 6.0.

Signed-off-by: Stefan Weil sw@weilnetz.de
