### PR TITLE
Fix interface to \TYPO3\CMS\Core\Messaging\FlashMessageQueue

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1310,7 +1310,7 @@ final class tx_dlf_document {
 						TRUE
 					);
 
-					\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+					tx_dlf_helper::addMessage($message);
 
 				}
 
@@ -1389,7 +1389,7 @@ final class tx_dlf_document {
 					TRUE
 				);
 
-				\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+				tx_dlf_helper::addMessage($message);
 
 			}
 
@@ -1543,7 +1543,7 @@ final class tx_dlf_document {
 				TRUE
 			);
 
-			\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+			tx_dlf_helper::addMessage($message);
 
 		}
 

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -199,7 +199,7 @@ class tx_dlf_indexing {
 
 					}
 
-					\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+					tx_dlf_helper::addMessage($message);
 
 				}
 
@@ -217,7 +217,7 @@ class tx_dlf_indexing {
 						TRUE
 					);
 
-					\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+					tx_dlf_helper::addMessage($message);
 
 				}
 
@@ -243,7 +243,7 @@ class tx_dlf_indexing {
 					TRUE
 				);
 
-				\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+				tx_dlf_helper::addMessage($message);
 
 			}
 
@@ -312,7 +312,7 @@ class tx_dlf_indexing {
 							TRUE
 						);
 
-						\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+						tx_dlf_helper::addMessage($message);
 
 					}
 
@@ -338,7 +338,7 @@ class tx_dlf_indexing {
 						TRUE
 					);
 
-					\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+					tx_dlf_helper::addMessage($message);
 
 				}
 
@@ -362,7 +362,7 @@ class tx_dlf_indexing {
 					TRUE
 				);
 
-				\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+				tx_dlf_helper::addMessage($message);
 
 			}
 
@@ -642,7 +642,7 @@ class tx_dlf_indexing {
 						TRUE
 					);
 
-					\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($message);
+					tx_dlf_helper::addMessage($message);
 
 				}
 

--- a/dlf/modules/indexing/index.php
+++ b/dlf/modules/indexing/index.php
@@ -251,7 +251,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 								TRUE
 							);
 
-							\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+							tx_dlf_helper::addMessage($_message);
 
 						}
 
@@ -336,7 +336,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 							TRUE
 						);
 
-						\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+						tx_dlf_helper::addMessage($_message);
 
 					}
 
@@ -345,7 +345,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
 			}
 
 
-			$this->markerArray['CONTENT'] .= \TYPO3\CMS\Core\Messaging\FlashMessageQueue::renderFlashMessages();
+			$this->markerArray['CONTENT'] .= tx_dlf_helper::renderFlashMessages();
 
 			switch ($this->MOD_SETTINGS['function']) {
 

--- a/dlf/modules/newclient/index.php
+++ b/dlf/modules/newclient/index.php
@@ -84,7 +84,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 					FALSE
 				);
 
-				\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+				tx_dlf_helper::addMessage($_message);
 
 			}
 
@@ -171,7 +171,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 		}
 
-		\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+		tx_dlf_helper::addMessage($_message);
 
 	}
 
@@ -218,7 +218,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 		}
 
-		\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+		tx_dlf_helper::addMessage($_message);
 
 	}
 
@@ -275,7 +275,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 		}
 
-		\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+		tx_dlf_helper::addMessage($_message);
 
 	}
 
@@ -304,9 +304,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 					FALSE
 				);
 
-				\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+				tx_dlf_helper::addMessage($_message);
 
-				$this->markerArray['CONTENT'] .= \TYPO3\CMS\Core\Messaging\FlashMessageQueue::renderFlashMessages();
+				$this->markerArray['CONTENT'] .= tx_dlf_helper::renderFlashMessages();
 
 				$this->printContent();
 
@@ -364,7 +364,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 			}
 
-			\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+			tx_dlf_helper::addMessage($_message);
 
 			// Check for existing metadata configuration.
 			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
@@ -399,7 +399,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 			}
 
-			\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+			tx_dlf_helper::addMessage($_message);
 
 			// Check the access conditions for the command line indexer's user.
 			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
@@ -451,7 +451,7 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 			}
 
-			\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+			tx_dlf_helper::addMessage($_message);
 
 			// Check for existing Solr core.
 			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
@@ -505,9 +505,9 @@ class tx_dlf_modNewclient extends tx_dlf_module {
 
 			}
 
-			\TYPO3\CMS\Core\Messaging\FlashMessageQueue::addMessage($_message);
+			tx_dlf_helper::addMessage($_message);
 
-			$this->markerArray['CONTENT'] .= \TYPO3\CMS\Core\Messaging\FlashMessageQueue::renderFlashMessages();
+			$this->markerArray['CONTENT'] .= tx_dlf_helper::renderFlashMessages();
 
 		} else {
 


### PR DESCRIPTION
The methods addMessage and renderFlashMessage supported static calls
which were deprecated in TYPO3 6.1 and removed in TYPO3 6.3 and later
versions.

In addition, renderFlashMessage escapes html code since TYPO3 7.4
which is not what is needed for Goobi.Presentation.

Signed-off-by: Stefan Weil sw@weilnetz.de
