### PR TITLE
Improve protection of constructor in static classes

### DIFF
--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -1351,9 +1351,9 @@ class tx_dlf_helper {
 	/**
 	 * This is a static class, thus no instances should be created
 	 *
-	 * @access	protected
+	 * @access private
 	 */
-	protected function __construct() {}
+	private function __construct() {}
 
 }
 

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -716,9 +716,9 @@ class tx_dlf_indexing {
 	/**
 	 * This is a static class, thus no instances should be created
 	 *
-	 * @access	protected
+	 * @access private
 	 */
-	protected function __construct() {}
+	private function __construct() {}
 
 }
 


### PR DESCRIPTION
The 'protected' visibility would still allow using the constructor
in inherited classes. Using 'private' gives a better protection than
using 'protected'.

Signed-off-by: Stefan Weil sw@weilnetz.de
