### PR TITLE
Disable entity loading like in TYPO3 core

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1027,8 +1027,14 @@ final class tx_dlf_document {
 			// Turn off libxml's error logging.
 			$libxmlErrors = libxml_use_internal_errors(TRUE);
 
+			// Disables the functionality to allow external entities to be loaded when parsing the XML, must be kept
+			$previousValueOfEntityLoader = libxml_disable_entity_loader(TRUE);
+
 			// Load XML from file.
-			$xml = @simplexml_load_file($location);
+			$xml = simplexml_load_string(file_get_contents($location));
+
+			// reset entity loader setting
+			libxml_disable_entity_loader($previousValueOfEntityLoader);
 
 			// Reset libxml's error logging.
 			libxml_use_internal_errors($libxmlErrors);

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -745,8 +745,14 @@ class tx_dlf_indexing {
 				// Turn off libxml's error logging.
 				$libxmlErrors = libxml_use_internal_errors(TRUE);
 
+				// disable entity loading
+				$previousValueOfEntityLoader = libxml_disable_entity_loader(TRUE);
+
 				// Load XML from file.
-				$xml = @simplexml_load_file($file);
+				$xml = simplexml_load_string(file_get_contents($file));
+
+				// reset entity loader setting
+				libxml_disable_entity_loader($previousValueOfEntityLoader);
 
 				// Reset libxml's error logging.
 				libxml_use_internal_errors($libxmlErrors);


### PR DESCRIPTION
With security patch "[SECURITY] XML entity expansion" in TYPO3 6.2 and
7.6 TYPO3/TYPO3.CMS@844369e9be6d6fdb47a7e1d802c38ecfe5f1149e the TYPO3
core disables the entity loading for external resources around every XML
parsing methods.

This not only disables the entity loading but also the loading of external
and local (!) resources completly.

As the setting of libxml_disable_entity_loader() is shared over threads,
the following PHP Warning happens in case of race conditions:

"PHP Warning: DOMDocument::load(): I/O warning : failed to load external
entity"

This patch does the respective change in Goobi.Presentation.
