### PR TITLE
add plugin for newspaper presentation

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1027,8 +1027,14 @@ final class tx_dlf_document {
 			// Turn off libxml's error logging.
 			$libxmlErrors = libxml_use_internal_errors(TRUE);
 
+			// Disables the functionality to allow external entities to be loaded when parsing the XML, must be kept
+			$previousValueOfEntityLoader = libxml_disable_entity_loader(TRUE);
+
 			// Load XML from file.
-			$xml = @simplexml_load_file($location);
+			$xml = simplexml_load_string(file_get_contents($location));
+
+			// reset entity loader setting
+			libxml_disable_entity_loader($previousValueOfEntityLoader);
 
 			// Reset libxml's error logging.
 			libxml_use_internal_errors($libxmlErrors);

--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1486,6 +1486,16 @@ final class tx_dlf_document {
 
 			}
 
+			// if volume_sorting is still empty, try to use title_sorting finally (e.g. newspaper year anchor)
+			if (empty($metadata['volume_sorting'][0])) {
+
+				if (!empty($metadata['title_sorting'][0])) {
+
+					$metadata['volume_sorting'][0] = $metadata['title_sorting'][0];
+
+				}
+			}
+
 		}
 
 		// Get metadata for lists and sorting.

--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -590,7 +590,7 @@ class tx_dlf_helper {
 		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
 			$table.'.uid AS uid',
 			$table,
-			$table.'.index_name='.$index_name.$where.self::whereClause($table),
+			$table.'.index_name=\''.$index_name.'\''.$where.self::whereClause($table),
 			'',
 			'',
 			'1'

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -745,8 +745,14 @@ class tx_dlf_indexing {
 				// Turn off libxml's error logging.
 				$libxmlErrors = libxml_use_internal_errors(TRUE);
 
+				// disable entity loading
+				$previousValueOfEntityLoader = libxml_disable_entity_loader(TRUE);
+
 				// Load XML from file.
-				$xml = @simplexml_load_file($file);
+				$xml = simplexml_load_string(file_get_contents($file));
+
+				// reset entity loader setting
+				libxml_disable_entity_loader($previousValueOfEntityLoader);
 
 				// Reset libxml's error logging.
 				libxml_use_internal_errors($libxmlErrors);

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -51,6 +51,8 @@ if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/validator/class.tx_dlf_validator.php', '_validator', 'list_type', FALSE);
 
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/newspaper/class.tx_dlf_newspaper.php', '_newspaper', 'list_type', TRUE);
+
 // Register tools for toolbox plugin.
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php', '_toolsFulltext', '', TRUE);
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsFulltext'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsFulltext';

--- a/dlf/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/dlf/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -188,15 +188,17 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
 									foreach($day as $id => $issue) {
 
+										$dayLinkLabel = empty($issue['title']) ? strftime('%x', $currentDayTime) : $issue['title'];
+
 										$linkConf = array (
 											'useCacheHash' => 1,
 											'parameter' => $this->conf['targetPid'],
 											'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($issue['uid']) . '&' . $this->prefixId . '[page]=1',
 											'ATagParams' => 'id=' . $issue['id'],
 										);
-										$dayLinksText[] = $this->cObj->typoLink($id, $linkConf);
+										$dayLinksText[] = $this->cObj->typoLink($dayLinkLabel, $linkConf);
 
-										$allIssues[] = array(strftime('%A, %x', $currentDayTime), $this->cObj->typoLink($id, $linkConf));
+										$allIssues[] = array(strftime('%A, %x', $currentDayTime), $this->cObj->typoLink($dayLinkLabel, $linkConf));
 									}
 								}
 

--- a/dlf/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/dlf/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -1,0 +1,405 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2011 Goobi. Digitalisieren im Verein e.V. <contact@goobi.org>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+/**
+ * Plugin 'DFG-Viewer: Newspaper Calendar' for the 'dfgviewer' extension.
+ *
+ * @author	Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @copyright	Copyright (c) 2016, Alexander Bigga, SLUB Dresden
+ * @package	TYPO3
+ * @subpackage	tx_dlf
+ * @access	public
+ */
+class tx_dlf_newspaper extends tx_dlf_plugin {
+
+	public $extKey = 'dlf';
+
+	public $scriptRelPath = 'plugins/newspaper-calendar/class.tx_dlf_newspaper.php';
+
+	/**
+	 * The main method of the PlugIn
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	string		The content that is displayed on the website
+	 */
+	public function main($content, $conf) {
+
+		// nothing to do here
+
+	}
+
+	/**
+	 * The Calendar Method
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	string		The content that is displayed on the website
+	 */
+	public function calendar($content, $conf) {
+
+		$this->init($conf);
+
+		// Load current document.
+		$this->loadDocument();
+
+		if ($this->doc === NULL) {
+
+			// Quit without doing anything if required variables are not set.
+			return $content;
+
+		}
+
+		// get all children of year anchor
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'tx_dlf_documents.uid AS uid, tx_dlf_documents.title AS title, tx_dlf_documents.year AS year',
+			'tx_dlf_documents',
+			'(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('issue', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
+			'',
+			'title ASC',
+			''
+		);
+
+		// Process results.
+		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+			$issues[] = array (
+				'uid' => $resArray['uid'],
+				'title' => $resArray['title'],
+				'year' => $resArray['year']
+			);
+
+		}
+
+		// 	we need an array of issues with month number as key
+		foreach ($issues as $issue) {
+
+			$calendarIssues[date('n', strtotime($issue['year']))][date('j', strtotime($issue['year']))][] = $issue;
+
+		}
+
+		$allIssuesCount = count($issues);
+
+		// Load template file.
+		if (!empty($this->conf['templateFile'])) {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['templateFile']), '###TEMPLATECALENDAR###');
+
+		} else {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource('EXT:dlf/plugins/newspaper/template.tmpl'), '###TEMPLATECALENDAR###');
+
+		}
+
+		// Get subpart templates
+		$subparts['template'] = $this->template;
+
+		$subparts['month'] = $this->cObj->getSubpart($subparts['template'], '###CALMONTH###');
+
+		$subparts['singleissue'] = $this->cObj->getSubpart($subparts['issuelist'], '###SINGLEISSUE###');
+
+		$year = date('Y', strtotime($issues[0]['year']));
+
+		$subPartContent = '';
+
+		for ($i = 0; $i <= 11; $i++) {
+
+			$markerArray = array (
+				'###DAYMON_NAME###' => strftime('%a', strtotime('last Monday')),
+				'###DAYTUE_NAME###' => strftime('%a', strtotime('last Tuesday')),
+				'###DAYWED_NAME###' => strftime('%a', strtotime('last Wednesday')),
+				'###DAYTHU_NAME###' => strftime('%a', strtotime('last Thursday')),
+				'###DAYFRI_NAME###' => strftime('%a', strtotime('last Friday')),
+				'###DAYSAT_NAME###' => strftime('%a', strtotime('last Saturday')),
+				'###DAYSUN_NAME###' => strftime('%a', strtotime('last Sunday')),
+				'###MONTHNAME###' 	=> strftime('%B', strtotime($year . '-' . ($i + 1) . '-1'))
+			);
+
+			// Get week subpart template
+			$subWeekTemplate = $this->cObj->getSubpart($subparts['month'], '###CALWEEK###');
+			$subWeekPartContent = '';
+
+			$firstOfMonth = strtotime($year . '-' . ($i + 1) . '-1');
+			$lastOfMonth = strtotime('last day of', ($firstOfMonth));
+			$firstOfMonthStart = strtotime('last Monday', $firstOfMonth);
+
+			// max 6 calendar weeks in a month
+			for ($j = 0; $j <= 5; $j++) {
+
+				$firstDayOfWeek = strtotime('+ ' . $j . ' Week', $firstOfMonthStart);
+
+				$weekArray = array(
+					'###DAYMON###' => '&nbsp;',
+					'###DAYTUE###' => '&nbsp;',
+					'###DAYWED###' => '&nbsp;',
+					'###DAYTHU###' => '&nbsp;',
+					'###DAYFRI###' => '&nbsp;',
+					'###DAYSAT###' => '&nbsp;',
+					'###DAYSUN###' => '&nbsp;',
+				);
+
+				// 7 days per week ;-)
+				for ($k = 0; $k <= 6; $k++) {
+
+					$currentDayTime = strtotime('+ '.$k.' Day', $firstDayOfWeek);
+
+					if ( $currentDayTime >= $firstOfMonth && $currentDayTime <= $lastOfMonth ) {
+
+						$dayLinks = '';
+						$dayLinksText = '';
+
+						$currentMonth = date('n', $currentDayTime);
+
+						if (is_array($calendarIssues[$currentMonth])) {
+
+							foreach($calendarIssues[$currentMonth] as $id => $day) {
+
+								if ($id == date('j', $currentDayTime)) {
+
+									$dayLinks = $id;
+
+									foreach($day as $id => $issue) {
+
+										$linkConf = array (
+											'useCacheHash' => 1,
+											'parameter' => $this->conf['targetPid'],
+											'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($issue['uid']) . '&' . $this->prefixId . '[page]=1',
+											'ATagParams' => 'id=' . $issue['id'],
+										);
+										$dayLinksText[] = $this->cObj->typoLink($id, $linkConf);
+
+										$allIssues[] = array(strftime('%A, %x', $currentDayTime), $this->cObj->typoLink($id, $linkConf));
+									}
+								}
+
+							}
+
+							// use title attribute for tooltip
+							if (is_array($dayLinksText)) {
+								$dayLinksList = '<ul>';
+								foreach ($dayLinksText as $link) {
+									$dayLinksList .= '<li>'.$link.'</li>';
+								}
+								$dayLinksList .= '</ul>';
+							}
+
+							$dayLinkDiv = '<div class="issues"><h4>' . strftime('%d', $currentDayTime) . '</h4><div>'.$dayLinksList.'</div></div>';
+						}
+
+						switch (strftime('%u', strtotime('+ '.$k.' Day', $firstDayOfWeek))) {
+							case '1': $weekArray['###DAYMON###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+							case '2': $weekArray['###DAYTUE###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+							case '3': $weekArray['###DAYWED###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+							case '4': $weekArray['###DAYTHU###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+							case '5': $weekArray['###DAYFRI###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+							case '6': $weekArray['###DAYSAT###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+							case '7': $weekArray['###DAYSUN###'] = ((int)$dayLinks === (int)date('j', $currentDayTime)) ? $dayLinkDiv : strftime('%d', $currentDayTime);
+								break;
+						}
+					}
+				}
+				// fill the weeks
+				$subWeekPartContent .= $this->cObj->substituteMarkerArray($subWeekTemplate, $weekArray);
+			}
+
+			// fill the month markers
+			$subPartContent .= $this->cObj->substituteMarkerArray($subparts['month'], $markerArray);
+
+			// fill the week markers
+			$subPartContent = $this->cObj->substituteSubpart($subPartContent, '###CALWEEK###', $subWeekPartContent);
+		}
+
+		// link to years overview
+		$linkConf = array (
+			'useCacheHash' => 1,
+			'parameter' => $this->conf['targetPid'],
+			'additionalParams' => '&' . $this->prefixId . '[id]=' . $this->doc->parentId,
+		);
+		$allYearsLink = $this->cObj->typoLink($this->pi_getLL('allYears', '', TRUE) . ' ' .$this->doc->getTitle($this->doc->parentId), $linkConf);
+
+		// link to this year itself
+		$linkConf = array (
+			'useCacheHash' => 1,
+			'parameter' => $this->conf['targetPid'],
+			'additionalParams' => '&' . $this->prefixId . '[id]=' . $this->doc->uid,
+		);
+		$yearLink = $this->cObj->typoLink($year, $linkConf);
+
+		// prepare list as alternative of the calendar view
+		$issueListTemplate = $this->cObj->getSubpart($subparts['template'], '###ISSUELIST###');
+
+		$subparts['singleissue'] = $this->cObj->getSubpart($issueListTemplate, '###SINGLEISSUE###');
+
+		$allDaysList = array();
+
+		foreach($allIssues as $id => $issue) {
+
+			// only add date output, if not already done (multiple issues per day)
+			if (! in_array($issue[0], $allDaysList)) {
+
+				$allDaysList[] = $issue[0];
+
+				$subPartContentList .= $issue[0];
+
+			}
+
+			$subPartContentList .= $this->cObj->substituteMarker($subparts['singleissue'], '###ITEM###', $issue[1]);
+
+		}
+
+		$issueListTemplate = $this->cObj->substituteSubpart($issueListTemplate, '###SINGLEISSUE###', $subPartContentList);
+
+		$this->template = $this->cObj->substituteSubpart($this->template, '###ISSUELIST###', $issueListTemplate);
+
+		if ($allIssuesCount < 6) {
+
+			$listViewActive = 'active';
+
+		} else {
+
+			$calendarViewActive = 'active';
+
+		}
+
+		$markerArray = array (
+			'###CALENDARVIEWACTIVE###' => $calendarViewActive,
+			'###LISTVIEWACTIVE###' => $listViewActive,
+			'###CALYEAR###' => $yearLink,
+			'###CALALLYEARS###' => $allYearsLink
+		);
+
+		$this->template = $this->cObj->substituteMarkerArray($this->template, $markerArray);
+
+		return $this->cObj->substituteSubpart($this->template, '###CALMONTH###', $subPartContent);
+
+	}
+
+	/**
+	 * The main method of the PlugIn
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	string		The content that is displayed on the website
+	 */
+	public function years($content, $conf) {
+
+		$this->init($conf);
+
+		// Load current document.
+		$this->loadDocument();
+
+		if ($this->doc === NULL) {
+
+			// Quit without doing anything if required variables are not set.
+			return $content;
+
+		}
+
+		// Load template file.
+		if (!empty($this->conf['templateFile'])) {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['templateFile']), '###TEMPLATEYEAR###');
+
+		} else {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource('EXT:dlf/plugins/newspaper/template.tmpl'), '###TEMPLATEYEAR###');
+
+		}
+
+		// Get subpart templates
+		$subparts['template'] = $this->template;
+
+		$subparts['year'] = $this->cObj->getSubpart($subparts['template'], '###LISTYEAR###');
+
+		// get the title of the anchor file
+		$titleAnchor = $this->doc->getTitle($this->doc->uid);
+
+		// get all children of anchor. this should be the year anchor documents
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'tx_dlf_documents.uid AS uid, tx_dlf_documents.title AS title',
+			'tx_dlf_documents',
+			'(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('year', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
+			'',
+			'title ASC',
+			''
+		);
+
+		// Process results.
+		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+			$years[] = array (
+				'title' => $resArray['title'],
+				'uid' => $resArray['uid']
+			);
+
+		}
+
+		$subYearPartContent = '';
+
+		if (count($years) > 0) {
+
+			foreach ($years as $id => $year) {
+
+				$linkConf = array(
+					'useCacheHash' => 1,
+					'parameter' => $this->conf['targetPid'],
+					'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($year['uid']),
+					'title' => $titleAnchor . ': ' . $year['title']
+				);
+
+				$yearArray = array(
+					'###YEARNAME###' => $this->cObj->typoLink($year['title'], $linkConf),
+				);
+
+				$subYearPartContent .= $this->cObj->substituteMarkerArray($subparts['year'], $yearArray);
+
+			}
+		}
+
+		// fill the week markers
+		return $this->cObj->substituteSubpart($subparts['template'], '###LISTYEAR###', $subYearPartContent);
+
+	}
+
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/newspaper-calendar/class.tx_dlf_newspaper-calendar.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/newspaper-calendar/class.tx_dlf_newspaper-calendar.php']);
+}

--- a/dlf/plugins/newspaper/flexform.xml
+++ b/dlf/plugins/newspaper/flexform.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3DataStructure>
+    <meta>
+        <langDisable>1</langDisable>
+    </meta>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>LLL:EXT:dfgviewer/plugins/newspaper-calendar/locallang.xml:tt_content.pi_flexform.sheet_general</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <pages>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>db</internal_type>
+                                <allowed>pages</allowed>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>1</minitems>
+                            </config>
+                        </TCEforms>
+                    </pages>
+                    <templateFile>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dfgviewer/plugins/newspaper/locallang.xml:tt_content.pi_flexform.templateFile</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>file_reference</internal_type>
+                                <allowed>tmpl,tpl,html,htm,txt</allowed>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>0</minitems>
+                                <disable_controls>upload</disable_controls>
+                            </config>
+                        </TCEforms>
+                    </templateFile>
+                </el>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/dlf/plugins/newspaper/locallang.xml
+++ b/dlf/plugins/newspaper/locallang.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3locallang>
+    <meta type="array">
+        <type>module</type>
+        <description>Language labels for plugin tx_dfgviewer_newspaper-calendar</description>
+    </meta>
+    <data type="array">
+        <languageKey index="default" type="array">
+            <label index="tt_content.pi_flexform.sheet_general">Options</label>
+            <label index="tt_content.pi_flexform.templateFile">Template file</label>
+            <label index="allYears">All years overview -  </label>
+        </languageKey>
+        <languageKey index="de" type="array">
+            <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
+            <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
+            <label index="allYears">Jahrgangsübersicht - </label>
+        </languageKey>
+    </data>
+</T3locallang>

--- a/dlf/plugins/newspaper/template.tmpl
+++ b/dlf/plugins/newspaper/template.tmpl
@@ -1,0 +1,63 @@
+<!-- ###TEMPLATECALENDAR### begin -->
+<div class="tx-dfgviewer-newspaper-calendar">
+    <div class="year-anchor">
+        ###CALALLYEARS###
+    </div>
+    <div class="year">
+        ###CALYEAR###
+    </div>
+    <div class="calendar-list-selection">
+        <a class="select-calendar-view ###CALENDARVIEWACTIVE###">Kalender</a>
+        <a class="select-list-view ###LISTVIEWACTIVE###">Listenansicht</a>
+    </div>
+    <div class="calendar-view">
+        <!-- ###CALMONTH### begin -->
+        <table class="month">
+            <caption>###MONTHNAME###</caption>
+            <tr>
+                <th class="">###DAYMON_NAME###</th>
+                <th class="">###DAYTUE_NAME###</th>
+                <th class="">###DAYWED_NAME###</th>
+                <th class="">###DAYTHU_NAME###</th>
+                <th class="">###DAYFRI_NAME###</th>
+                <th class="">###DAYSAT_NAME###</th>
+                <th class="">###DAYSUN_NAME###</th>
+            </tr>
+            <!-- ###CALWEEK### begin -->
+            <tr>
+                <td class="">###DAYMON###</td>
+                <td class="">###DAYTUE###</td>
+                <td class="">###DAYWED###</td>
+                <td class="">###DAYTHU###</td>
+                <td class="">###DAYFRI###</td>
+                <td class="">###DAYSAT###</td>
+                <td class="">###DAYSUN###</td>
+            </tr>
+            <!-- ###CALWEEK### end -->
+        </table>
+        <!-- ###CALMONTH### end -->
+    </div>
+    <!-- ###ISSUELIST### begin -->
+    <div class="list-view">
+        <ul>
+            <!-- ###SINGLEISSUE### begin -->
+            <li>###ITEM###</li>
+            <!-- ###SINGLEISSUE### begin -->
+        </ul>
+    </div>
+    <!-- ###ISSUELIST### end -->
+
+</div>
+<!-- ###TEMPLATECALENDAR### end -->
+
+<!-- ###TEMPLATEYEAR### begin -->
+<div class="tx-dfgviewer-newspaper-years">
+    <ul>
+        <!-- ###LISTYEAR### begin -->
+        <li class="year">
+            ###YEARNAME###
+        </li>
+        <!-- ###LISTYEAR### end -->
+</div>
+<!-- ###TEMPLATEYEAR### end -->
+

--- a/dlf/plugins/newspaper/template.tmpl
+++ b/dlf/plugins/newspaper/template.tmpl
@@ -44,7 +44,7 @@
         <ul>
             <!-- ###SINGLEISSUE### begin -->
             <li>###ITEM###</li>
-            <!-- ###SINGLEISSUE### begin -->
+            <!-- ###SINGLEISSUE### end -->
         </ul>
     </div>
     <!-- ###ISSUELIST### end -->

--- a/dlf/plugins/newspaper/template.tmpl
+++ b/dlf/plugins/newspaper/template.tmpl
@@ -1,14 +1,16 @@
 <!-- ###TEMPLATECALENDAR### begin -->
 <div class="tx-dfgviewer-newspaper-calendar">
-    <div class="year-anchor">
-        ###CALALLYEARS###
-    </div>
-    <div class="year">
-        ###CALYEAR###
-    </div>
-    <div class="calendar-list-selection">
-        <a class="select-calendar-view ###CALENDARVIEWACTIVE###">Kalender</a>
-        <a class="select-list-view ###LISTVIEWACTIVE###">Listenansicht</a>
+    <div class="meta-header">
+        <div class="year-anchor">
+            ###CALALLYEARS###
+        </div>
+        <div class="year">
+            ###CALYEAR###
+        </div>
+        <div class="calendar-list-selection">
+            <a class="select-calendar-view ###CALENDARVIEWACTIVE###">Kalender</a>
+            <a class="select-list-view ###LISTVIEWACTIVE###">Listenansicht</a>
+        </div>
     </div>
     <div class="calendar-view">
         <!-- ###CALMONTH### begin -->

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -89,19 +89,6 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 		$output = array ();
 
-		// Get localization for OpenLayers.
-		if ($GLOBALS['TSFE']->lang) {
-
-			$langFile = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($this->extKey, 'lib/OpenLayers/lib/OpenLayers/Lang/'.strtolower($GLOBALS['TSFE']->lang).'.js');
-
-			if (file_exists($langFile)) {
-
-				$this->lang = strtolower($GLOBALS['TSFE']->lang);
-
-			}
-
-		}
-
 		// Add OpenLayers library.
 		$output[] = '
 		<link type="text/css" rel="stylesheet" href="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'lib/OpenLayers/ol3.css">

--- a/dlf/plugins/pageview/flexform.xml
+++ b/dlf/plugins/pageview/flexform.xml
@@ -68,21 +68,9 @@
 										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.overviewmap</numIndex>
 										<numIndex index="1">OverviewMap</numIndex>
 									</numIndex>
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.panpanel</numIndex>
-										<numIndex index="1">PanPanel</numIndex>
-									</numIndex>
 									<numIndex index="2" type="array">
 										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.zoompanel</numIndex>
 										<numIndex index="1">ZoomPanel</numIndex>
-									</numIndex>
-									<numIndex index="3" type="array">
-										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.panzoom</numIndex>
-										<numIndex index="1">PanZoom</numIndex>
-									</numIndex>
-									<numIndex index="4" type="array">
-										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.panzoombar</numIndex>
-										<numIndex index="1">PanZoomBar</numIndex>
 									</numIndex>
 								</items>
 								<size>5</size>

--- a/dlf/plugins/pageview/flexform.xml
+++ b/dlf/plugins/pageview/flexform.xml
@@ -68,7 +68,7 @@
 										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.overviewmap</numIndex>
 										<numIndex index="1">OverviewMap</numIndex>
 									</numIndex>
-									<numIndex index="2" type="array">
+									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.features.zoompanel</numIndex>
 										<numIndex index="1">ZoomPanel</numIndex>
 									</numIndex>

--- a/dlf/plugins/pageview/locallang.xml
+++ b/dlf/plugins/pageview/locallang.xml
@@ -32,10 +32,7 @@
 			<label index="tt_content.pi_flexform.excludeOther">Show only documents from the selected page</label>
 			<label index="tt_content.pi_flexform.features">Map features</label>
 			<label index="tt_content.pi_flexform.features.overviewmap">Overview Image</label>
-			<label index="tt_content.pi_flexform.features.panpanel">Pan Panel</label>
 			<label index="tt_content.pi_flexform.features.zoompanel">Zoom Panel</label>
-			<label index="tt_content.pi_flexform.features.panzoom">Pan and Zoom Panel</label>
-			<label index="tt_content.pi_flexform.features.panzoombar">Pan Panel and Zoom Bar</label>
 			<label index="tt_content.pi_flexform.elementId">@ID value of the HTML element for the page view</label>
 			<label index="tt_content.pi_flexform.templateFile">Template file</label>
 		</languageKey>
@@ -44,10 +41,7 @@
 			<label index="tt_content.pi_flexform.excludeOther">Nur Dokumente der ausgewählten Seite anzeigen</label>
 			<label index="tt_content.pi_flexform.features">Bedienelemente</label>
 			<label index="tt_content.pi_flexform.features.overviewmap">Übersichtsbild</label>
-			<label index="tt_content.pi_flexform.features.panpanel">Pan-Knöpfe</label>
 			<label index="tt_content.pi_flexform.features.zoompanel">Zoom-Knöpfe</label>
-			<label index="tt_content.pi_flexform.features.panzoom">Pan- und Zoom-Knöpfe</label>
-			<label index="tt_content.pi_flexform.features.panzoombar">Pan-Knöpfe und Zoom-Leiste</label>
 			<label index="tt_content.pi_flexform.elementId">@ID-Wert des HTML-Elements für die Seitenansicht</label>
 			<label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
 		</languageKey>

--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -352,6 +352,13 @@ dlfViewer.prototype.init = function() {
 
         // trigger event after all has been initialize
         $(this).trigger("initialize-end", this);
+
+        // append listener for saving view params in case of flipping pages
+        $(window).unload($.proxy(function() {
+            dlfUtils.setCookie('tx-dlf-pageview-zoomLevel', this.map.getZoom());
+            dlfUtils.setCookie('tx-dlf-pageview-centerLon', this.map.getView().getCenter()[0]);
+            dlfUtils.setCookie('tx-dlf-pageview-centerLat', this.map.getView().getCenter()[1]);
+        }, this));
     }, this);
 
     // init image loading process

--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -176,7 +176,7 @@ dlfViewer.prototype.createControls_ = function(controlNames) {
                     controls.push(new ol.control.OverviewMap());
                     break;
 
-                case "ZoomPanel" || "PanZoomBar" || "PanZoom":
+                case "ZoomPanel":
 
                     controls.push(new ol.control.Zoom());
                     break;

--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -221,7 +221,7 @@ dlfViewer.prototype.displayHighlightWord = function() {
                 [field[0], field[1]],
             ]],
             offset = this.highlightFieldParams.index === 1 ? this.images[0].width : 0;
-            feature = dlfUtils.scaleToImageSize([new ol.Feature(new ol.geom.Polygon(coordinates))],
+            var feature = dlfUtils.scaleToImageSize([new ol.Feature(new ol.geom.Polygon(coordinates))],
             		this.images[this.highlightFieldParams.index],
             		this.highlightFieldParams.width,
                     this.highlightFieldParams.height,

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -103,7 +103,7 @@ dlfUtils.exists = function(val) {
 
 /**
  * @param {string} name Name of the cookie
- * @return {string} Value of the cookie
+ * @return {string|null} Value of the cookie
  * @TODO replace unescape function
  */
 dlfUtils.getCookie = function(name) {


### PR DESCRIPTION
Together with the document type switch, it's possible to replace the
content by this plugin. Other plugins will be removed by typoscript.

Views:
1. tx_dlf_newspaper->years: shows all years of this newspaper (anchor)
2. tx_dlf_newspaper->calendar: shows a calendar of one year

Typoscript:

plugin.tx_dlf_newspaper {
  pages = 4152
  targetPid = #
  template =
}

[userFunc = user_dlf_docTypeCheck(newspaper)]
web.1.marks.DLF {
  20 < plugin.tx_dlf_newspaper
  20.userFunc = tx_dlf_newspaper->years
}
[global]

[userFunc = user_dlf_docTypeCheck(year)]
page.1.marks.DLF {
  20 < plugin.tx_dlf_newspaper
  20.userFunc = tx_dlf_newspaper->calendar
}
[global]
