### PR TITLE
Add missing 'var' for local JavaScript variable

### DIFF
--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -221,7 +221,7 @@ dlfViewer.prototype.displayHighlightWord = function() {
                 [field[0], field[1]],
             ]],
             offset = this.highlightFieldParams.index === 1 ? this.images[0].width : 0;
-            feature = dlfUtils.scaleToImageSize([new ol.Feature(new ol.geom.Polygon(coordinates))],
+            var feature = dlfUtils.scaleToImageSize([new ol.Feature(new ol.geom.Polygon(coordinates))],
             		this.images[this.highlightFieldParams.index],
             		this.highlightFieldParams.width,
                     this.highlightFieldParams.height,


### PR DESCRIPTION
This fixes a warning from PhpStorm.

Signed-off-by: Stefan Weil sw@weilnetz.de
