### PR TITLE
Shorten the label for Goobi.Presentation in TYPO3 backend

### DIFF
--- a/dlf/modules/locallang_mod.xml
+++ b/dlf/modules/locallang_mod.xml
@@ -28,12 +28,12 @@
 	</meta>
 	<data type="array">
 		<languageKey index="default" type="array">
-			<label index="mlang_tabs_tab">Goobi.Presentation</label>
+			<label index="mlang_tabs_tab">Goobi</label>
 			<label index="mlang_labels_tabdescr">These modules allow you to manage your digitized documents and collections.</label>
 			<label index="mlang_labels_tablabel">Goobi Base Modules</label>
 		</languageKey>
 		<languageKey index="de" type="array">
-			<label index="mlang_tabs_tab">Goobi.Presentation</label>
+			<label index="mlang_tabs_tab">Goobi</label>
 			<label index="mlang_labels_tabdescr">Diese Module erlauben Ihnen die Verwaltung Ihrer digitalisierten Dokumente und Sammlungen.</label>
 			<label index="mlang_labels_tablabel">Goobi Basismodule</label>
 		</languageKey>


### PR DESCRIPTION
"Goobi.Presentation" is rather long - too long in the default width,
so it is only partially visible. Use a shorter label which fits
nicely.

Signed-off-by: Stefan Weil sw@weilnetz.de
