### PR TITLE
Add key in array check to tx_dlf_document.getTitledata function

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -953,11 +953,15 @@ final class tx_dlf_document {
 		$titledata = $this->getMetadata($this->_getToplevelId(), $cPid);
 
 		// Set record identifier for METS file if not present.
-		if (is_array($titledata) && !in_array($this->recordId, $titledata['record_id'])) {
+		if (is_array($titledata) && array_key_exists('record_id', $titledata)) {
 
-			array_unshift($titledata['record_id'], $this->recordId);
+			if (!in_array($this->recordId, $titledata['record_id'])) {
 
-		}
+				array_unshift($titledata['record_id'], $this->recordId);
+
+			}
+
+		};
 
 		return $titledata;
 


### PR DESCRIPTION
The using of `array_key_exists` before using `in_array`, prevents an error in case of empty `titledata` arrays.
