### PR TITLE
tx_dlf_document: Enhance debug message for undefined structure type

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1281,7 +1281,8 @@ final class tx_dlf_document {
 
 			if (TYPO3_DLOG) {
 
-				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Could not identify document/structure type', self::$extKey, SYSLOG_SEVERITY_ERROR);
+				\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->save('.$_pid.', '.$_core.')] Could not identify document/structure type ' . $GLOBALS['TYPO3_DB']->fullQuoteStr($metadata['type'][0], 'tx_dlf_structures'),
+									       self::$extKey, SYSLOG_SEVERITY_ERROR);
 
 			}
 


### PR DESCRIPTION
When indexing documents with an undefined structure type,
this message was reported:

[tx_dlf_document->save(2, 1)] Could not identify document/structure type

Adding the name of the undefined structure type allows
faster fixing of the problem:

[tx_dlf_document->save(2, 1)] Could not identify document/structure type 'newspaper'

Signed-off-by: Stefan Weil sw@weilnetz.de
