### PR TITLE
fix #121: change template path for tool plugins inside toolbox

### DIFF
--- a/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
+++ b/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
@@ -79,9 +79,9 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
 		}
 
 		// Load template file.
-		if (!empty($this->conf['templateFile'])) {
+		if (!empty($this->conf['toolTemplateFile'])) {
 
-			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['templateFile']), '###TEMPLATE###');
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['toolTemplateFile']), '###TEMPLATE###');
 
 		} else {
 

--- a/dlf/plugins/toolbox/tools/imagemanipulation/class.tx_dlf_toolsImagemanipulation.php
+++ b/dlf/plugins/toolbox/tools/imagemanipulation/class.tx_dlf_toolsImagemanipulation.php
@@ -55,9 +55,9 @@ class tx_dlf_toolsImagemanipulation extends tx_dlf_plugin {
 		$this->loadDocument();
 
 		// Load template file.
-		if (!empty($this->conf['templateFile'])) {
+		if (!empty($this->conf['toolTemplateFile'])) {
 
-			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['templateFile']), '###TEMPLATE###');
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['toolTemplateFile']), '###TEMPLATE###');
 
 		} else {
 

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -83,9 +83,9 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		}
 
 		// Load template file.
-		if (!empty($this->conf['templateFile'])) {
+		if (!empty($this->conf['toolTemplateFile'])) {
 
-			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['templateFile']), '###TEMPLATE###');
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['toolTemplateFile']), '###TEMPLATE###');
 
 		} else {
 


### PR DESCRIPTION
Now it's possible to deactivate the templateFile Typoscript settings as the proper template will be used. If a custom template is set, the path has to be changed:

Old:
`plugin.tx_dlf_toolsFulltext.templateFile = EXT:dlf/plugins/toolbox/tools/fulltext/template.tmpl`

New:
`plugin.tx_dlf_toolsFulltext.toolTemplateFile = EXT:dlf/plugins/toolbox/tools/fulltext/template.tmpl`
