### PR TITLE
Update GitHub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kitodo.Presentation is a feature-rich framework for building a METS-based digita
 Kitodo. Digital Library Modules
 ------------------------------
 
-[Kitodo](https://github.com/goobi) is an open source software suite intended to support mass digitization projects for cultural heritage institutions. Kitodo is widely-used and cooperatively maintained by major German libraries and digitization service providers. The software implements international standards such as METS, MODS and other formats maintained by the Library of Congress. Kitodo consists of several independent modules serving different purposes such as controlling the digitization workflow, enriching descriptive and structural metadata, and presenting the results to the public in a modern and convenient way.
+[Kitodo](https://github.com/kitodo) is an open source software suite intended to support mass digitization projects for cultural heritage institutions. Kitodo is widely-used and cooperatively maintained by major German libraries and digitization service providers. The software implements international standards such as METS, MODS and other formats maintained by the Library of Congress. Kitodo consists of several independent modules serving different purposes such as controlling the digitization workflow, enriching descriptive and structural metadata, and presenting the results to the public in a modern and convenient way.
 
 To get more information, visit the [Kitodo homepage](http://kitodo.org). You can also follow Kitodo News on [Twitter](https://twitter.com/kitodo_org).
 

--- a/dlf/NOTICE.txt
+++ b/dlf/NOTICE.txt
@@ -1,1 +1,1 @@
-See https://github.com/goobi/goobi-presentation
+See https://github.com/kitodo/kitodo-presentation

--- a/dlf/ext_emconf.php
+++ b/dlf/ext_emconf.php
@@ -28,7 +28,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'category' => 'fe',
 	'author' => 'Kitodo. Key to digital objects e.V.',
 	'author_email' => 'contact@kitodo.org',
-	'author_company' => '<br /><a href="http://www.kitodo.org/" target="_blank">Kitodo.org</a><br /><a href="https://github.com/goobi" target="_blank">Kitodo on Github</a>',
+	'author_company' => '<br /><a href="http://www.kitodo.org/" target="_blank">Kitodo.org</a><br /><a href="https://github.com/kitodo" target="_blank">Kitodo on GitHub</a>',
 	'shy' => '',
 	'priority' => '',
 	'module' => '',


### PR DESCRIPTION
https://github.com/goobi was moved to https://github.com/kitodo,
and the former goobi-presentation is now kitodo-presentation.

Signed-off-by: Stefan Weil sw@weilnetz.de
