### PR TITLE
Explicitly initialise local array

### DIFF
--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -190,6 +190,7 @@ class tx_dlf_em {
 					$usergroup = array_unique(array_merge(array ($groupUid), $resArray['usergroup']));
 
 					// Try to configure user.
+					$data = array();
 					$data['be_users'][$resArray['uid']] = array (
 						'admin' => 0,
 						'usergroup' => implode(',', $usergroup),
@@ -246,6 +247,7 @@ class tx_dlf_em {
 				// Try to create user.
 				$tempUid = uniqid('NEW');
 
+				$data = array();
 				$data['be_users'][$tempUid] = array (
 					'pid' => 0,
 					'username' => '_cli_dlf',
@@ -403,6 +405,7 @@ class tx_dlf_em {
 					$tables_modify = array_unique(array_merge($settings['tables_modify'], $resArray['tables_modify']));
 
 					// Try to configure usergroup.
+					$data = array();
 					$data['be_groups'][$resArray['uid']] = array(
 						'non_exclude_fields' => implode(',', $non_exclude_fields),
 						'tables_select' => implode(',', $tables_select),
@@ -458,6 +461,7 @@ class tx_dlf_em {
 				// Try to create usergroup.
 				$tempUid = uniqid('NEW');
 
+				$data = array();
 				$data['be_groups'][$tempUid] = array(
 					'pid' => 0,
 					'title' => '_cli_dlf',


### PR DESCRIPTION
Report from static code analyzer Scrutinizer:

```
$data was never initialized. Although not strictly required by PHP,
it is generally a good practice to add $data = array(); before
regardless.
```

Signed-off-by: Stefan Weil sw@weilnetz.de
