### PR TITLE
Fix for IE: hasOwnProperty() always returns false within that context

### DIFF
--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -240,7 +240,7 @@ dlfViewer.prototype.displayHighlightWord = function() {
     var key = 'tx_dlf[highlight_word]',
         urlParams = dlfUtils.getUrlParams();
 
-    if (urlParams.hasOwnProperty(key) && this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
+    if (urlParams != undefined && urlParams.hasOwnProperty(key) && this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
         var value = urlParams[key],
             values = value.split(';'),
             fulltextData = dlfViewerFullTextControl.fetchFulltextDataFromServer(this.fulltexts[0].url, this.images[0]),

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -392,7 +392,7 @@ dlfUtils.getCookie = function(name) {
  * @returns {Object|undefined}
  */
 dlfUtils.getUrlParams = function() {
-    if (location.hasOwnProperty('search')) {
+    if (Object.prototype.hasOwnProperty.call(location, 'search')) {
         var search = decodeURIComponent(location.search).slice(1).split('&'),
             params = {};
 


### PR DESCRIPTION
That behavior leads to an error within the calling function displayHighlightWord() (tx_dlf_pageview.js) on line 243  ...if (urlParams.hasOwnProperty(key)... Trying to access a property of an "undefined" variable. It seems that the IE messes a little bit with the context of hasOwnProperty(). By fixing that point I decided to avoid that crash if that call returns false and that is true.