### PR TITLE
fix #157: add typoscript option config.disableWrapInBaseClass

### DIFF
--- a/dlf/common/class.tx_dlf_plugin.php
+++ b/dlf/common/class.tx_dlf_plugin.php
@@ -263,13 +263,15 @@ abstract class tx_dlf_plugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 	 */
 	public function pi_wrapInBaseClass($content) {
 
-		// Use get_class($this) instead of $this->prefixId for content wrapping because $this->prefixId is the same for all plugins.
-		$content = '<div class="'.str_replace('_', '-', get_class($this)).'">'.$content.'</div>';
+		if (!$GLOBALS['TSFE']->config['config']['disableWrapInBaseClass']) {
+			// Use get_class($this) instead of $this->prefixId for content wrapping because $this->prefixId is the same for all plugins.
+			$content = '<div class="'.str_replace('_', '-', get_class($this)).'">'.$content.'</div>';
 
-		if (!$GLOBALS['TSFE']->config['config']['disablePrefixComment']) {
+			if (!$GLOBALS['TSFE']->config['config']['disablePrefixComment']) {
 
-			$content = "\n\n<!-- BEGIN: Content of extension '".$this->extKey."', plugin '".get_class($this)."' -->\n\n".$content."\n\n<!-- END: Content of extension '".$this->extKey."', plugin '".get_class($this)."' -->\n\n";
+				$content = "\n\n<!-- BEGIN: Content of extension '".$this->extKey."', plugin '".get_class($this)."' -->\n\n".$content."\n\n<!-- END: Content of extension '".$this->extKey."', plugin '".get_class($this)."' -->\n\n";
 
+			}
 		}
 
 		return $content;


### PR DESCRIPTION
With the introduced option `config.disableWrapInBaseClass` it is possible to disable wrapping of plugin output globally.

This is inspired by core patches (e.g. [#19809](https://forge.typo3.org/issues/19809)) were never applied as pi-based plugins are considered as deprecated for long time.