### PR TITLE
fix #158: replace usage of file_get_contents by GeneralUtility::getUrl

### DIFF
--- a/dlf/common/class.tx_dlf_document.php
+++ b/dlf/common/class.tx_dlf_document.php
@@ -1043,7 +1043,7 @@ final class tx_dlf_document {
 			$previousValueOfEntityLoader = libxml_disable_entity_loader(TRUE);
 
 			// Load XML from file.
-			$xml = simplexml_load_string(file_get_contents($location));
+			$xml = simplexml_load_string(\TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($location));
 
 			// reset entity loader setting
 			libxml_disable_entity_loader($previousValueOfEntityLoader);

--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -728,7 +728,7 @@ class tx_dlf_indexing {
 				$previousValueOfEntityLoader = libxml_disable_entity_loader(TRUE);
 
 				// Load XML from file.
-				$xml = simplexml_load_string(file_get_contents($file));
+				$xml = simplexml_load_string(\TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($file));
 
 				// reset entity loader setting
 				libxml_disable_entity_loader($previousValueOfEntityLoader);

--- a/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php
@@ -53,7 +53,7 @@ class tx_dlf_fulltext_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 		$url = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('url');
 
-		$fulltextData = file_get_contents($url);
+		$fulltextData = file_get_contents(\TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($url);
 
 		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
 		header('Cache-Control: no-cache, must-revalidate');


### PR DESCRIPTION
Using the TYPO3 core function GeneralUtility::getUrl() respects setting e.g. for a HTTP proxy. This patch replace the usage in common document, indexing and inside the fulltext plugin.

In the connection handling with SOLR server there remains some file_get_contents which uses context settings.