### PR TITLE
fix #164 use new namespaced class of t3jquery

### DIFF
--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -913,14 +913,14 @@ class tx_dlf_helper {
 		// Ensure extension "t3jquery" is available.
 		if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3jquery')) {
 
-			require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('t3jquery').'class.tx_t3jquery.php');
+			require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('t3jquery').'/Classes/Utility/T3jqueryUtility.php');
 
 		}
 
 		// Is "t3jquery" loaded?
 		if (T3JQUERY === TRUE) {
 
-			tx_t3jquery::addJqJS();
+			\T3Ext\T3jquery\Utility\T3jqueryUtility::addJqJS();
 
 			return TRUE;
 

--- a/dlf/ext_emconf.php
+++ b/dlf/ext_emconf.php
@@ -31,7 +31,7 @@ $EM_CONF[$_EXTKEY] = array(
 		'depends' => array(
 			'php' => '5.3.7-',
 			'typo3' => '6.2.0-7.9.99',
-			't3jquery' => '2.6.0-',
+			't3jquery' => '3.0.4-',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
This patch use the new t3jquery class with namespace instead of deprecated `tx_t3jquery`.

The minimum version number of t3jquery is rised to current 3.0.4 to avoid confusion. There is no need to use an older version than 3.0.4.