### PR TITLE
Fix for #176

### DIFF
--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -460,9 +460,7 @@ dlfUtils.isCorsEnabled = function(imageObjs) {
             };
         })
         .error(function(data, type) {
-            if (type === 'error') {
-                response = false;
-            }
+            response = false;
         });
     });
 


### PR DESCRIPTION
This request fixes #176 by removing the specific check for the 'error' type when the XHR-Request to determine CORS-Support fails for other reasons.