### PR TITLE
add language labels for rotation in navigation plugin

### DIFF
--- a/dlf/plugins/navigation/class.tx_dlf_navigation.php
+++ b/dlf/plugins/navigation/class.tx_dlf_navigation.php
@@ -275,6 +275,10 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 		$markerArray['###ZOOM_OUT###'] = $this->pi_getLL('zoom-out', '', TRUE);
 		$markerArray['###ZOOM_FULLSCREEN###'] = $this->pi_getLL('zoom-fullscreen', '', TRUE);
 
+		$markerArray['###ROTATE_LEFT###'] =  $this->pi_getLL('rotate-left', '', TRUE);
+		$markerArray['###ROTATE_RIGHT###'] = $this->pi_getLL('rotate-right', '', TRUE);
+		$markerArray['###ROTATE_RESET###'] = $this->pi_getLL('rotate-reset', '', TRUE);
+
  		$content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
 
 		return $this->pi_wrapInBaseClass($content);

--- a/dlf/plugins/navigation/locallang.xml
+++ b/dlf/plugins/navigation/locallang.xml
@@ -33,6 +33,9 @@
 			<label index="zoom-in">Zoom In</label>
 			<label index="zoom-out">Zoom Out</label>
 			<label index="zoom-fullscreen">Fullscreen Mode</label>
+			<label index="rotate-left">Rotate Left</label>
+			<label index="rotate-right">Rotate Right</label>
+			<label index="rotate-reset">Reset Rotation</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
@@ -53,6 +56,9 @@
 			<label index="zoom-in">Ansicht vergrößern</label>
 			<label index="zoom-out">Ansicht verkleinern</label>
 			<label index="zoom-fullscreen">Vollansicht</label>
+			<label index="rotate-left">Ansicht nach links drehen</label>
+			<label index="rotate-right">Ansicht nach rechts drehen</label>
+			<label index="rotate-reset">Drehung zurücksetzen</label>
 		</languageKey>
 	</data>
 </T3locallang>

--- a/dlf/plugins/navigation/template.tmpl
+++ b/dlf/plugins/navigation/template.tmpl
@@ -18,4 +18,10 @@
 <div class="tx-dlf-navigation-fwd">###FORWARD###</div>
 <div class="tx-dlf-navigation-last">###LAST###</div>
 <div class="tx-dlf-navigation-listview">###LINKLISTVIEW###</div>
+<div class="tx-dlf-navigation-zoom-in">###ZOOM_IN###</div>
+<div class="tx-dlf-navigation-zoom-out">###ZOOM_OUT###</div>
+<div class="tx-dlf-navigation-fullscreen">###ZOOM_FULLSCREEN###</div>
+<div class="tx-dlf-navigation-rotate-left">###ROTATE_LEFT###</div>
+<div class="tx-dlf-navigation-rotate-right">###ROTATE_RIGHT###</div>
+<div class="tx-dlf-navigation-rotate-reset">###ROTATE_RESET###</div>
 <!-- ###TEMPLATE### -->


### PR DESCRIPTION
rotate-left, rotate-right and rotate-reset is already used in DFG-Viewer
and is part of Kitodo.Presentation. The labels are missing in
Kitodo.Presentation so far. This patch adds these labels and
translations.