### PR TITLE
CORS detection routed via server eID script

### DIFF
--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -65,7 +65,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys'][$_EXTKEY] = array
 // Register AJAX eID handlers.
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_suggest'] = 'EXT:'.$_EXTKEY.'/plugins/search/class.tx_dlf_search_suggest.php';
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_fulltext_eid'] = 'EXT:'.$_EXTKEY.'/plugins/pageview/class.tx_dlf_fulltext_eid.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_geturl_eid'] = 'EXT:'.$_EXTKEY.'/plugins/pageview/class.tx_dlf_geturl_eid.php';
 
 if (TYPO3_MODE === 'FE') {
 

--- a/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
@@ -62,7 +62,12 @@ class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 		}
 
-		// take some tags from request header.
+		// add some self calculated header tags
+		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
+		header('Cache-Control: max-age=3600, must-revalidate');
+		header('Content-Length: '.strlen($fetchedData));
+
+		// take some tags from request header and overwrite in case already set
 		$fetchedHeader = explode("\n", GeneralUtility::getUrl($url, 2));
 		foreach ($fetchedHeader as $headerline) {
 			if (stripos($headerline, 'Last-Modified:') !== FALSE) {
@@ -72,8 +77,6 @@ class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 				header($headerline);
 			}
 		}
-		// add some self calculated header tags
-		header('Content-Length: '.strlen($fetchedData));
 
 		echo $fetchedData;
 

--- a/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
@@ -9,8 +9,10 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use \TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
- * Plugin 'DFG-Viewer: SRU Client eID script' for the 'dfgviewer' extension.
+ * eID-script helper to fetch data from Javascript via server
  *
  * @author	Alexander Bigga <alexander.bigga@slub-dresden.de>
  * @copyright	Copyright (c) 2015, Alexander Bigga, SLUB Dresden
@@ -18,7 +20,7 @@
  * @subpackage	tx_dlf
  * @access	public
  */
-class tx_dlf_fulltext_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
+class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 	/**
 	 *
@@ -38,32 +40,34 @@ class tx_dlf_fulltext_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 	 */
 	public function main($content = '', $conf = array ()) {
 
-		$this->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
+		$this->cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
 
 		$this->extKey = 'dlf';
 
 		$this->scriptRelPath = 'plugins/pageview/class.tx_dlf_fulltext_eid.php';
 
-		$url = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('url');
+		$url = GeneralUtility::_GP('url');
+    $includeHeader = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange(GeneralUtility::_GP('header'), 0, 2, 0);
 
-		$fulltextData = \TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($url);
+    $report = array();
+		$fetchedData = GeneralUtility::getUrl($url, $includeHeader, false, $report);
 
 		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
 		header('Cache-Control: no-cache, must-revalidate');
 		header('Pragma: no-cache');
-		header('Content-Length: '.strlen($fulltextData));
-		header('Content-Type: text/xml');
+		header('Content-Length: '.strlen($fetchedData));
+		header('Content-Type: ' . $report['content_type']);
 
-		echo $fulltextData;
+		echo $fetchedData;
 
 	}
 
 }
 
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php'])	{
-	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_fulltext_eid.php']);
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php']);
 }
 
-$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_fulltext_eid');
+$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_geturl_eid');
 
 $cObj->main();

--- a/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
@@ -53,8 +53,8 @@ class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 		$fetchedData = GeneralUtility::getUrl($url, $includeHeader, false, $report);
 
 		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
-		header('Cache-Control: no-cache, must-revalidate');
-		header('Pragma: no-cache');
+	//	header('Cache-Control: no-cache, must-revalidate');
+	//	header('Pragma: no-cache');
 		header('Content-Length: '.strlen($fetchedData));
 		header('Content-Type: ' . $report['content_type']);
 

--- a/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
@@ -49,14 +49,31 @@ class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 		$url = GeneralUtility::_GP('url');
     $includeHeader = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange(GeneralUtility::_GP('header'), 0, 2, 0);
 
-    $report = array();
-		$fetchedData = GeneralUtility::getUrl($url, $includeHeader, false, $report);
+		// first we fetch header separately
+		$fetchedHeader = GeneralUtility::getUrl($url, 2);
 
-		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
-	//	header('Cache-Control: no-cache, must-revalidate');
-	//	header('Pragma: no-cache');
+		if ($includeHeader == 0) {
+
+			$fetchedData = GeneralUtility::getUrl($url, $includeHeader);
+
+		} else {
+
+			$fetchedData = $fetchedHeader;
+
+		}
+
+		// take some tags from request header.
+		$fetchedHeader = explode("\n", GeneralUtility::getUrl($url, 2));
+		foreach ($fetchedHeader as $headerline) {
+			if (stripos($headerline, 'Last-Modified:') !== FALSE) {
+				header($headerline);
+			}
+			if (stripos($headerline, 'Content-Type:') !== FALSE) {
+				header($headerline);
+			}
+		}
+		// add some self calculated header tags
 		header('Content-Length: '.strlen($fetchedData));
-		header('Content-Type: ' . $report['content_type']);
 
 		echo $fetchedData;
 

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -166,7 +166,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 			// Configure @action URL for form.
 			$linkConf = array (
 				'parameter' => $GLOBALS['TSFE']->id,
-				'additionalParams' => '&eID=tx_dlf_fulltext_eid&url='.urlencode($fulltext['url']),
+				'additionalParams' => '&eID=tx_dlf_geturl_eid&url='.urlencode($fulltext['url']),
 			);
 
 			$fulltext['url'] = $this->cObj->typoLink_URL($linkConf);

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -125,6 +125,16 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 				$image['url'] = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrp]);
 
+				if ($this->conf['useInternalProxy']) {
+					// Configure @action URL for form.
+					$linkConf = array (
+						'parameter' => $GLOBALS['TSFE']->id,
+						'additionalParams' => '&eID=tx_dlf_geturl_eid&url='.urlencode($image['url']),
+					);
+
+					$image['url'] = $this->cObj->typoLink_URL($linkConf);
+				}
+
 				$image['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrp]);
 
 				break;

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -92,7 +92,8 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 						controls: ["' . implode('", "', $this->controls) . '"],
 						div: "' . $this->conf['elementId'] . '",
 						images: ' . json_encode($this->images) . ',
-						fulltexts: '. json_encode($this->fulltexts) . '
+						fulltexts: '. json_encode($this->fulltexts) . ',
+						useInternalProxy: ' . $this->conf['useInternalProxy'] .'
 					})
 				}
 			}

--- a/dlf/plugins/pageview/flexform.xml
+++ b/dlf/plugins/pageview/flexform.xml
@@ -78,6 +78,16 @@
 							</config>
 						</TCEforms>
 					</elementId>
+					<useInternalProxy>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>LLL:EXT:dlf/plugins/pageview/locallang.xml:tt_content.pi_flexform.useInternalProxy</label>
+							<config>
+								<type>check</type>
+								<default>0</default>
+							</config>
+						</TCEforms>
+					</useInternalProxy>
 					<templateFile>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/dlf/plugins/pageview/locallang.xml
+++ b/dlf/plugins/pageview/locallang.xml
@@ -22,6 +22,7 @@
 			<label index="tt_content.pi_flexform.features.zoompanel">Zoom Panel</label>
 			<label index="tt_content.pi_flexform.elementId">@ID value of the HTML element for the page view</label>
 			<label index="tt_content.pi_flexform.templateFile">Template file</label>
+			<label index="tt_content.pi_flexform.useInternalProxy">Use Internal Proxy</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
@@ -31,6 +32,7 @@
 			<label index="tt_content.pi_flexform.features.zoompanel">Zoom-Knöpfe</label>
 			<label index="tt_content.pi_flexform.elementId">@ID-Wert des HTML-Elements für die Seitenansicht</label>
 			<label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
+			<label index="tt_content.pi_flexform.useInternalProxy">Internen Proxy verwenden</label>
 		</languageKey>
 	</data>
 </T3locallang>

--- a/dlf/plugins/pageview/tx_dlf_pageview.js
+++ b/dlf/plugins/pageview/tx_dlf_pageview.js
@@ -72,6 +72,13 @@ var dlfViewer = function(settings){
      */
     this.imageManipulationControl = undefined;
 
+    /**
+     * use internal proxy setting
+     * @type {boolean}
+     * @private
+     */
+    this.useInternalProxy = dlfUtils.exists(settings.useInternalProxy) ? settings.useInternalProxy : false;
+
     this.init(dlfUtils.exists(settings.controls) ? settings.controls : []);
 };
 
@@ -281,7 +288,11 @@ dlfViewer.prototype.init = function(controlNames) {
      * Is cors enabled. Important information for correct renderer and layer initialization
      * @type {boolean}
      */
-    this.isCorsEnabled = dlfUtils.isCorsEnabled(this.imageUrls);
+     if (this.useInternalProxy) {
+       this.isCorsEnabled = true;
+     } else {
+       this.isCorsEnabled = dlfUtils.isCorsEnabled(this.imageUrls);
+     }
 
     this.initLayer(this.imageUrls, this.isCorsEnabled)
         .done($.proxy(function(layers){

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -449,21 +449,14 @@ dlfUtils.isCorsEnabled = function(imageObjs) {
                 ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url)
                 : imageObj.url;
 
-        $.ajax({
-            url: url,
-            async: false
-        }).done(function(data, type) {
-            if (type === 'success') {
-                response = true && response;
-            } else {
-                response = false;
-            };
-        })
-        .error(function(data, type) {
-            if (type === 'error') {
-                response = false;
+        $.get( url, function( data, textStatus, request) {
+            var header = request.getResponseHeader('access-control-allow-origin');
+
+            if(typeof header !== 'undefined') {
+                 response = false;
             }
         });
+
     });
 
 
@@ -595,32 +588,4 @@ dlfUtils.searchFeatureCollectionForText = function(featureCollection, text) {
         }
     });
     return features.length > 0 ? features : undefined;
-};
-
-/**
- * @param {string} url
- * @param {Function=} opt_callback_ifEnabled Should be called if CORS is enabled
- * @param {Function=} opt_callback_ifNotEnabled Should be called if CORS is not enabled
- * @return {boolean}
- */
-dlfUtils.testIfCORSEnabled = function(url, opt_callback_ifEnabled, opt_callback_ifNotEnabled) {
-	// fix for proper working with ie
-	if (!window.location.origin) {
-		window.location.origin = window.location.protocol + '//' + window.location.hostname +
-			(window.location.port ? ':' + window.location.port: '');
-	}
-
-	// fetch data from server
-	// with access control allowed
-    var request = $.ajax({
-        url: url
-    })
-    .done(function() {
-    	if (opt_callback_ifEnabled !== undefined)
-    		opt_callback_ifEnabled();
-    })
-    .fail(function() {
-    	if (opt_callback_ifNotEnabled !== undefined)
-    		opt_callback_ifNotEnabled();
-    });
 };

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -449,11 +449,13 @@ dlfUtils.isCorsEnabled = function(imageObjs) {
                 ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url)
                 : imageObj.url;
 
+        url = window.location.origin + '?eID=tx_dlf_geturl_eid&url=' + encodeURIComponent(url) + '&header=2';
+
         $.ajax({
             url: url,
             async: false
         }).done(function(data, type) {
-            if (type === 'success') {
+            if (type === 'success' && data.includes('Access-Control-Allow-Origin')) {
                 response = true && response;
             } else {
                 response = false;

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -449,7 +449,7 @@ dlfUtils.isCorsEnabled = function(imageObjs) {
                 ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url)
                 : imageObj.url;
 
-        url = window.location.origin + '?eID=tx_dlf_geturl_eid&url=' + encodeURIComponent(url) + '&header=2';
+        url = window.location.origin + window.location.pathname + '?eID=tx_dlf_geturl_eid&url=' + encodeURIComponent(url) + '&header=2';
 
         $.ajax({
             url: url,


### PR DESCRIPTION
The imagemanipulation tool requires loading the images via WebGL. This is only allowed if CORS is enabled. [CORS = Cross-Origin Resource Sharing](https://www.w3.org/wiki/CORS_Enabled) requires a header tag "Access-Control-Allow-Origin" by the image provider server.

If CORS is not enabled, the WebGL layer is simply black. To avoid this behaviour, Kitodo.Presentation tries to check if CORS is enabled.

The current implementation does something similar. It tries to load the image in javascript context. If this fails, it should fail in WebGL context too. This is not true in all conditions! In case of mixed content (Kitodo.Presentation running HTTPS, images provided via HTTP) this test always fails. But WebGL is fine with mixed content if the CORS header are sent.

This patch use another approach which was already used to fetch the fulltext files. It fetches the image header via an eID script on the Kitodo.Presentation server. This is done via HTTPS or HTTP as the whole frontend. If the header contains the "Access-Control-Allow-Origin" tag, the CORS-test is true.

As fetching the fulltext files and the image header is in fact the same task, the eID script has been renamed and unified for both. It would be easily possible to fetch even the images via eID. This is not implemented here.

ToDo: Check the value of the "Access-Control-Allow-Origin"-tag to be really perfect.