### PR TITLE
set proper Content-Type if "curlUse" is not set

### DIFF
--- a/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
+++ b/dlf/plugins/pageview/class.tx_dlf_geturl_eid.php
@@ -44,7 +44,7 @@ class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 		$this->extKey = 'dlf';
 
-		$this->scriptRelPath = 'plugins/pageview/class.tx_dlf_fulltext_eid.php';
+		$this->scriptRelPath = 'plugins/pageview/class.tx_dlf_geturl_eid.php';
 
 		$url = GeneralUtility::_GP('url');
     $includeHeader = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange(GeneralUtility::_GP('header'), 0, 2, 0);
@@ -66,14 +66,14 @@ class tx_dlf_geturl_eid extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 		header('Last-Modified: ' . gmdate( "D, d M Y H:i:s" ) . 'GMT');
 		header('Cache-Control: max-age=3600, must-revalidate');
 		header('Content-Length: '.strlen($fetchedData));
+		$fi = finfo_open(FILEINFO_MIME);
+		header('Content-Type: ' . finfo_buffer($fi, $fetchedData));
 
 		// take some tags from request header and overwrite in case already set
 		$fetchedHeader = explode("\n", GeneralUtility::getUrl($url, 2));
+
 		foreach ($fetchedHeader as $headerline) {
 			if (stripos($headerline, 'Last-Modified:') !== FALSE) {
-				header($headerline);
-			}
-			if (stripos($headerline, 'Content-Type:') !== FALSE) {
 				header($headerline);
 			}
 		}

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -455,7 +455,7 @@ dlfUtils.isCorsEnabled = function(imageObjs) {
             url: url,
             async: false
         }).done(function(data, type) {
-            if (type === 'success' && data.includes('Access-Control-Allow-Origin')) {
+            if (type === 'success' && data.indexOf('Access-Control-Allow-Origin') != -1) {
                 response = true && response;
             } else {
                 response = false;


### PR DESCRIPTION
The implementation of GeneralUtility::getUrl() differ in behaviour if
['TYPO3_CONF_VARS']['SYS']['curlUse'] is set or not.

With curlUse enabled, the full header of all redirects is returned.
Without curlUse only the first header is returned.

In case of a redirection, the Content-Type of the first header is e.g.
"text/html" instead of the desired "application/xml". That's why we
cannot use the fetched Content-Type in this case.

To be save with both implementations, the content-type is calculated
manually with finfo_buffer().