### PR TITLE
Fix 192: language overlay of metadata and structures

### DIFF
--- a/dlf/Configuration/TCA/tx_dlf_metadata.php
+++ b/dlf/Configuration/TCA/tx_dlf_metadata.php
@@ -62,7 +62,7 @@ return array (
 					array ('', 0),
 				),
 				'foreign_table' => 'tx_dlf_metadata',
-				'foreign_table_where' => 'AND tx_dlf_metadata.pid=###CURRENT_PID### AND tx_dlf_metadata.sys_language_uid IN (-1,0)',
+				'foreign_table_where' => 'AND tx_dlf_metadata.pid=###CURRENT_PID### AND tx_dlf_metadata.sys_language_uid IN (-1,0) ORDER BY label ASC',
 			),
 		),
 		'l18n_diffsource' => array (

--- a/dlf/Configuration/TCA/tx_dlf_metadata.php
+++ b/dlf/Configuration/TCA/tx_dlf_metadata.php
@@ -90,6 +90,7 @@ return array (
 		),
 		'index_name' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.index_name',
 			'config' => array (
 				'type' => 'input',
@@ -100,6 +101,7 @@ return array (
 		),
 		'format' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.format',
 			'config' => array (
 				'type' => 'inline',
@@ -133,6 +135,7 @@ return array (
 		),
 		'wrap' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'mergeIfNotBlank',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.wrap',
 			'config' => array (
 				'type' => 'text',
@@ -146,6 +149,7 @@ return array (
 		),
 		'tokenized' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.tokenized',
 			'config' => array (
 				'type' => 'check',
@@ -154,6 +158,7 @@ return array (
 		),
 		'stored' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.stored',
 			'config' => array (
 				'type' => 'check',
@@ -162,6 +167,7 @@ return array (
 		),
 		'indexed' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.indexed',
 			'config' => array (
 				'type' => 'check',
@@ -170,6 +176,7 @@ return array (
 		),
 		'boost' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.boost',
 			'config' => array (
 				'type' => 'input',
@@ -181,6 +188,7 @@ return array (
 		),
 		'is_sortable' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.is_sortable',
 			'config' => array (
 				'type' => 'check',
@@ -189,6 +197,7 @@ return array (
 		),
 		'is_facet' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.is_facet',
 			'config' => array (
 				'type' => 'check',
@@ -197,6 +206,7 @@ return array (
 		),
 		'is_listed' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.is_listed',
 			'config' => array (
 				'type' => 'check',
@@ -205,6 +215,7 @@ return array (
 		),
 		'autocomplete' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.autocomplete',
 			'config' => array (
 				'type' => 'check',
@@ -213,6 +224,7 @@ return array (
 		),
 		'status' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_metadata.status',
 			'config' => array (
 				'type' => 'select',

--- a/dlf/Configuration/TCA/tx_dlf_structures.php
+++ b/dlf/Configuration/TCA/tx_dlf_structures.php
@@ -63,7 +63,7 @@ return array (
 					array ('', 0),
 				),
 				'foreign_table' => 'tx_dlf_structures',
-				'foreign_table_where' => 'AND tx_dlf_structures.pid=###CURRENT_PID### AND tx_dlf_structures.sys_language_uid IN (-1,0)',
+				'foreign_table_where' => 'AND tx_dlf_structures.pid=###CURRENT_PID### AND tx_dlf_structures.sys_language_uid IN (-1,0) ORDER BY label ASC',
 			),
 		),
 		'l18n_diffsource' => array (
@@ -81,6 +81,7 @@ return array (
 		),
 		'toplevel' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_structures.toplevel',
 			'config' => array (
 				'type' => 'check',
@@ -99,6 +100,7 @@ return array (
 		),
 		'index_name' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_structures.index_name',
 			'config' => array (
 				'type' => 'input',
@@ -109,6 +111,7 @@ return array (
 		),
 		'oai_name' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_structures.oai_name',
 			'config' => array (
 				'type' => 'input',
@@ -119,6 +122,7 @@ return array (
 		),
 		'thumbnail' => array (
 			'exclude' => 1,
+			'l10n_mode' => 'exclude',
 			'displayCond' => 'FIELD:toplevel:REQ:true',
 			'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_structures.thumbnail',
 			'config' => array (

--- a/dlf/common/class.tx_dlf_helper.php
+++ b/dlf/common/class.tx_dlf_helper.php
@@ -1191,7 +1191,7 @@ class tx_dlf_helper {
 
 		// First fetch the uid of the received index_name
 		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'uid',
+				'uid, l18n_parent',
 				$table,
 				'pid='.$pid.' AND index_name="'.$index_name.'"'.self::whereClause($table, TRUE),
 				'',
@@ -1207,7 +1207,7 @@ class tx_dlf_helper {
 			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
 					'index_name',
 					$table,
-					'pid='.$pid.' AND l18n_parent='.$resArray['uid'].' AND sys_language_uid='.intval($GLOBALS['TSFE']->sys_language_content).self::whereClause($table, TRUE),
+					'pid='.$pid.' AND uid='.$resArray['l18n_parent'].' AND sys_language_uid='.intval($GLOBALS['TSFE']->sys_language_content).self::whereClause($table, TRUE),
 					'',
 					'',
 					''
@@ -1255,7 +1255,7 @@ class tx_dlf_helper {
 						// Overlay localized labels if available.
 						if ($GLOBALS['TSFE']->sys_language_content > 0) {
 
-							$resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay($table, $resArray, $GLOBALS['TSFE']->sys_language_content, ($GLOBALS['TSFE']->sys_language_mode == 'strict' ? 'hideNonTranslated' : ''));
+							$resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay($table, $resArray,$GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
 
 						}
 

--- a/dlf/plugins/metadata/class.tx_dlf_metadata.php
+++ b/dlf/plugins/metadata/class.tx_dlf_metadata.php
@@ -213,7 +213,7 @@ class tx_dlf_metadata extends tx_dlf_plugin {
 		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
 			'tx_dlf_metadata.index_name AS index_name,tx_dlf_metadata.is_listed AS is_listed,tx_dlf_metadata.wrap AS wrap',
 			'tx_dlf_metadata',
-			'tx_dlf_metadata.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_metadata'),
+			'tx_dlf_metadata.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_metadata').' AND (sys_language_uid IN (-1,0) OR (sys_language_uid = ' .$GLOBALS['TSFE']->sys_language_uid. ' AND l18n_parent = 0))',
 			'',
 			'tx_dlf_metadata.sorting',
 			''
@@ -221,14 +221,27 @@ class tx_dlf_metadata extends tx_dlf_plugin {
 
 		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
-			if ($this->conf['showFull'] || $resArray['is_listed']) {
+			if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
 
-				$metaList[$resArray['index_name']] = array (
-					'wrap' => $resArray['wrap'],
-					'label' => tx_dlf_helper::translate($resArray['index_name'], 'tx_dlf_metadata', $this->conf['pages'])
-				);
+					$resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_metadata', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
 
-			}
+				}
+
+				if ($resArray) {
+					// get correct language uid for translated realurl link
+					$link_uid = ($resArray['_LOCALIZED_UID']) ? $resArray['_LOCALIZED_UID'] : $resArray['uid'];
+
+					// do stuff with the row entry data	like built HTML or prepare further usage
+					if ($this->conf['showFull'] || $resArray['is_listed']) {
+
+						$metaList[$resArray['index_name']] = array (
+							'wrap' => $resArray['wrap'],
+							'label' => tx_dlf_helper::translate($resArray['index_name'], 'tx_dlf_metadata', $this->conf['pages'])
+						);
+
+					}
+
+				}
 
 		}
 


### PR DESCRIPTION
This is a patch to be able to use the TYPO3 language overlay feature of database records.

First, it excludes fields in the TCA configuration which are not necessary to change in language overlay.

Second, in the metadata plugin, the query of all metadata is limited to the current language.

Third, the translate() helper method is fixed as it did not do, what is written in the comments ;-)

I tested this patch with the following typoscript configuration:

1. an translated page of the viewer must exist
2. config.sys_language_mode = content_fallback
3. config.sys_language_overlay = 1