### PR TITLE
fix #199 roll back to ECMAScript 5

### DIFF
--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -68,7 +68,17 @@ dlfUtils.createOl3Layers = function (imageSourceObjs, opt_origin) {
             });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF) {
 
-            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0 ? imageSourceObj.tilesize[0] : 256, format = $.inArray('jpg', imageSourceObj.formats) || $.inArray('jpeg', imageSourceObj.formats) ? 'jpg' : imageSourceObj.formats.length > 0 ? imageSourceObj.formats[0] : 'jpg', quality = imageSourceObj.qualities !== undefined && imageSourceObj.qualities.length > 0 ? imageSourceObj.qualities[0] : 'native';
+            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0
+                ? imageSourceObj.tilesize[0]
+                    : 256,
+                format = $.inArray('jpg', imageSourceObj.formats) || $.inArray('jpeg', imageSourceObj.formats)
+                    ? 'jpg'
+                    : imageSourceObj.formats.length > 0
+                        ? imageSourceObj.formats[0]
+                        : 'jpg',
+                quality = imageSourceObj.qualities !== undefined && imageSourceObj.qualities.length > 0
+                    ? imageSourceObj.qualities[0]
+                    : 'native';
 
             layer = new ol.layer.Tile({
                 source: new dlfViewerSource.IIIF({
@@ -88,7 +98,9 @@ dlfUtils.createOl3Layers = function (imageSourceObjs, opt_origin) {
                 })
             });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP) {
-            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0 ? imageSourceObj.tilesize[0] : 256;
+            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0
+                ? imageSourceObj.tilesize[0]
+                : 256;
 
             layer = new ol.layer.Tile({
                 source: new dlfViewerSource.IIP({
@@ -139,7 +151,11 @@ dlfUtils.createOl3View = function (images) {
         maxLatY = images.reduce(function (prev, curr) {
         return Math.max(prev, curr.height);
     }, 0),
-        extent = images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY && images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIIF && images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIP ? [0, 0, maxLonX, maxLatY] : [0, -maxLatY, maxLonX, 0];
+        extent = images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY &&
+        images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIIF &&
+        images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIP
+            ? [0, 0, maxLonX, maxLatY]
+            : [0, -maxLatY, maxLonX, 0];
 
     // globally define max zoom
     window.OL3_MAX_ZOOM = 8;
@@ -192,36 +208,42 @@ dlfUtils.fetchImageData = function (imageSourceObjs) {
         finishLoading = function finishLoading() {
         loadCount += 1;
 
-        if (loadCount === imageSourceObjs.length) deferredResponse.resolve(imageSourceData);
+        if (loadCount === imageSourceObjs.length)
+            deferredResponse.resolve(imageSourceData);
     };
 
     imageSourceObjs.forEach(function (imageSourceObj, index) {
         if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY) {
-            dlfUtils.fetchZoomifyData(imageSourceObj).done(function (imageSourceDataObj) {
-                imageSourceData[index] = imageSourceDataObj;
-                finishLoading();
+            dlfUtils.fetchZoomifyData(imageSourceObj)
+                .done(function (imageSourceDataObj) {
+                    imageSourceData[index] = imageSourceDataObj;
+                    finishLoading();
             });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF) {
-            dlfUtils.getIIIFResource(imageSourceObj).done(function (imageSourceDataObj) {
-                imageSourceData[index] = imageSourceDataObj;
-                finishLoading();
+            dlfUtils.getIIIFResource(imageSourceObj)
+                .done(function (imageSourceDataObj) {
+                    imageSourceData[index] = imageSourceDataObj;
+                      finishLoading();
             });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP) {
-            dlfUtils.fetchIIPData(imageSourceObj).done(function (imageSourceDataObj) {
-                imageSourceData[index] = imageSourceDataObj;
-                finishLoading();
+            dlfUtils.fetchIIPData(imageSourceObj)
+                .done(function (imageSourceDataObj) {
+                    imageSourceData[index] = imageSourceDataObj;
+                    finishLoading();
             });
         } else {
             // In the worse case expect static image file
-            dlfUtils.fetchStaticImageData(imageSourceObj).done(function (imageSourceDataObj) {
-                imageSourceData[index] = imageSourceDataObj;
-                finishLoading();
+            dlfUtils.fetchStaticImageData(imageSourceObj)
+                .done(function (imageSourceDataObj) {
+                    imageSourceData[index] = imageSourceDataObj;
+                    finishLoading();
             });
         }
     });
 
     return deferredResponse;
 };
+
 
 /**
  * Fetches the image data for static images source.
@@ -322,14 +344,18 @@ dlfUtils.supportsIIIF = function supportsIIIF(data) {
     if (data.protocol && data.protocol === 'http://iiif.io/api/image') {
         return true;
         // Version 1.1
-    } else if (data['@context'] && (data['@context'] === "http://library.stanford.edu/iiif/image-api/1.1/context.json" || data['@context'] === "http://iiif.io/api/image/1/context.json")) {
+    } else if (data['@context'] && (
+        data['@context'] === "http://library.stanford.edu/iiif/image-api/1.1/context.json" ||
+        data['@context'] === "http://iiif.io/api/image/1/context.json")) {
         return true;
         // Version 1.0
-    } else if (data.profile && data.profile.indexOf("http://library.stanford.edu/iiif/image-api/compliance.html") === 0) {
+    } else if (data.profile &&
+        data.profile.indexOf("http://library.stanford.edu/iiif/image-api/compliance.html") === 0) {
         return true;
     } else if (data.identifier && data.width && data.height) {
         return true;
-    } else return data.documentElement && "info" === data.documentElement.tagName && "http://library.stanford.edu/iiif/image-api/ns/" === data.documentElement.namespaceURI;
+    } else return data.documentElement && "info" === data.documentElement.tagName &&
+    "http://library.stanford.edu/iiif/image-api/ns/" === data.documentElement.namespaceURI;
 };
 
 /**
@@ -443,7 +469,8 @@ dlfUtils.fetchZoomifyData = function (imageSourceObj) {
         url: imageSourceObj.url
     }).done(cb);
     function cb(response, type) {
-        if (type !== 'success') throw new Error('Problems while fetching ImageProperties.xml');
+        if (type !== 'success')
+            throw new Error('Problems while fetching ImageProperties.xml');
 
         var properties = $(response).find('IMAGE_PROPERTIES');
 
@@ -523,7 +550,8 @@ dlfUtils.isNullEmptyUndefinedOrNoNumber = function (val) {
 dlfUtils.isCorsEnabled = function (imageObjs) {
     // fix for proper working with ie
     if (!window.location.origin) {
-        window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+        window.location.origin = window.location.protocol + '//' + window.location.hostname +
+            (window.location.port ? ':' + window.location.port : '');
     }
 
     // fetch data from server
@@ -531,7 +559,14 @@ dlfUtils.isCorsEnabled = function (imageObjs) {
     var response = true;
 
     imageObjs.forEach(function (imageObj) {
-        var url = imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY ? imageObj.url.replace('ImageProperties.xml', 'TileGroup0/0-0-0.jpg') : imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF ? dlfViewerSource.IIIF.getMetdadataURL(imageObj.url) : imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url) : imageObj.url;
+        var url = imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY
+            ? imageObj.url.replace('ImageProperties.xml', 'TileGroup0/0-0-0.jpg')
+            :
+            imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF
+                ? dlfViewerSource.IIIF.getMetdadataURL(imageObj.url)
+                : imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP
+                ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url)
+                : imageObj.url;
 
         url = window.location.origin + window.location.pathname + '?eID=tx_dlf_geturl_eid&url=' + encodeURIComponent(url) + '&header=2';
 
@@ -640,7 +675,8 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, opt_off
             newCoordinates = [];
 
         for (var j = 0; j < oldCoordinates.length; j++) {
-            newCoordinates.push([offset + scale * oldCoordinates[j][0], displayImageHeight - scale * oldCoordinates[j][1]]);
+            newCoordinates.push(
+              [offset + scale * oldCoordinates[j][0], displayImageHeight - scale * oldCoordinates[j][1]]);
         }
 
         features[i].setGeometry(new ol.geom.Polygon([newCoordinates]));

--- a/dlf/plugins/pageview/tx_dlf_utils.js
+++ b/dlf/plugins/pageview/tx_dlf_utils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
  *
@@ -34,15 +36,15 @@ dlfUtils.RUNNING_INDEX = 99999999;
  * @param {string} opt_origin
  * @return {Array.<ol.layer.Layer>}
  */
-dlfUtils.createOl3Layers = function(imageSourceObjs, opt_origin) {
+dlfUtils.createOl3Layers = function (imageSourceObjs, opt_origin) {
 
-    let origin = opt_origin !== undefined ? opt_origin : null,
+    var origin = opt_origin !== undefined ? opt_origin : null,
         widthSum = 0,
         offsetWidth = 0,
         layers = [];
 
-    imageSourceObjs.forEach(function(imageSourceObj) {
-        let tileSize;
+    imageSourceObjs.forEach(function (imageSourceObj) {
+        var tileSize = void 0;
         if (widthSum > 0) {
             // set offset width in case of multiple images
             offsetWidth = widthSum;
@@ -51,8 +53,8 @@ dlfUtils.createOl3Layers = function(imageSourceObjs, opt_origin) {
         //
         // Create layer
         //
-        let extent = [offsetWidth, 0, imageSourceObj.width + offsetWidth, imageSourceObj.height],
-            layer;
+        var extent = [offsetWidth, 0, imageSourceObj.width + offsetWidth, imageSourceObj.height],
+            layer = void 0;
 
         if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY) {
             // create zoomify layer
@@ -66,17 +68,7 @@ dlfUtils.createOl3Layers = function(imageSourceObjs, opt_origin) {
             });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF) {
 
-            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0
-                ? imageSourceObj.tilesize[0]
-                : 256,
-                format = $.inArray('jpg', imageSourceObj.formats) || $.inArray('jpeg', imageSourceObj.formats)
-                    ? 'jpg'
-                    : imageSourceObj.formats.length > 0
-                        ? imageSourceObj.formats[0]
-                        : 'jpg',
-                quality = imageSourceObj.qualities !== undefined && imageSourceObj.qualities.length > 0
-                    ? imageSourceObj.qualities[0]
-                    : 'native';
+            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0 ? imageSourceObj.tilesize[0] : 256, format = $.inArray('jpg', imageSourceObj.formats) || $.inArray('jpeg', imageSourceObj.formats) ? 'jpg' : imageSourceObj.formats.length > 0 ? imageSourceObj.formats[0] : 'jpg', quality = imageSourceObj.qualities !== undefined && imageSourceObj.qualities.length > 0 ? imageSourceObj.qualities[0] : 'native';
 
             layer = new ol.layer.Tile({
                 source: new dlfViewerSource.IIIF({
@@ -96,9 +88,7 @@ dlfUtils.createOl3Layers = function(imageSourceObjs, opt_origin) {
                 })
             });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP) {
-            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0
-                ? imageSourceObj.tilesize[0]
-                : 256;
+            tileSize = imageSourceObj.tilesize !== undefined && imageSourceObj.tilesize.length > 0 ? imageSourceObj.tilesize[0] : 256;
 
             layer = new ol.layer.Tile({
                 source: new dlfViewerSource.IIP({
@@ -138,35 +128,31 @@ dlfUtils.createOl3Layers = function(imageSourceObjs, opt_origin) {
  * @param {Array.<{src: *, width: *, height: *}>} images
  * @return {ol.View}
  */
-dlfUtils.createOl3View = function(images) {
+dlfUtils.createOl3View = function (images) {
 
     //
     // Calculate map extent
     //
-    let maxLonX = images.reduce(function(prev, curr) {
-            return prev + curr.width;
-        }, 0),
-        maxLatY = images.reduce(function(prev, curr) {
-            return Math.max(prev, curr.height);
-        }, 0),
-        extent = images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY &&
-        images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIIF &&
-        images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIP
-            ? [0, 0, maxLonX, maxLatY]
-            : [0, -maxLatY, maxLonX, 0];
+    var maxLonX = images.reduce(function (prev, curr) {
+        return prev + curr.width;
+    }, 0),
+        maxLatY = images.reduce(function (prev, curr) {
+        return Math.max(prev, curr.height);
+    }, 0),
+        extent = images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY && images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIIF && images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIP ? [0, 0, maxLonX, maxLatY] : [0, -maxLatY, maxLonX, 0];
 
     // globally define max zoom
     window.OL3_MAX_ZOOM = 8;
 
     // define map projection
-    const proj = new ol.proj.Projection({
+    var proj = new ol.proj.Projection({
         code: 'goobi-image',
         units: 'pixels',
         extent: extent
     });
 
     // define view
-    const viewParams = {
+    var viewParams = {
         projection: proj,
         center: ol.extent.getCenter(extent),
         zoom: 1,
@@ -182,7 +168,7 @@ dlfUtils.createOl3View = function(images) {
  * @param {?} val
  * @return {boolean}
  */
-dlfUtils.exists = function(val) {
+dlfUtils.exists = function (val) {
     return val !== undefined;
 };
 
@@ -192,56 +178,50 @@ dlfUtils.exists = function(val) {
  * @param {Array.<{url: *, mimetype: *}>} imageSourceObjs
  * @return {JQueryStatic.Deferred}
  */
-dlfUtils.fetchImageData = function(imageSourceObjs) {
+dlfUtils.fetchImageData = function (imageSourceObjs) {
 
     // use deferred for async behavior
-    const deferredResponse = new $.Deferred();
+    var deferredResponse = new $.Deferred();
 
     /**
      * This holds information about the loading state of the images
      * @type {Array.<number>}
      */
-    let imageSourceData = [],
+    var imageSourceData = [],
         loadCount = 0,
-        finishLoading = function() {
-            loadCount += 1;
+        finishLoading = function finishLoading() {
+        loadCount += 1;
 
-            if (loadCount === imageSourceObjs.length)
-                deferredResponse.resolve(imageSourceData);
-        };
+        if (loadCount === imageSourceObjs.length) deferredResponse.resolve(imageSourceData);
+    };
 
-    imageSourceObjs.forEach(function(imageSourceObj, index) {
+    imageSourceObjs.forEach(function (imageSourceObj, index) {
         if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY) {
-            dlfUtils.fetchZoomifyData(imageSourceObj)
-                .done(function(imageSourceDataObj) {
-                    imageSourceData[index] = imageSourceDataObj;
-                    finishLoading();
-                });
+            dlfUtils.fetchZoomifyData(imageSourceObj).done(function (imageSourceDataObj) {
+                imageSourceData[index] = imageSourceDataObj;
+                finishLoading();
+            });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF) {
-            dlfUtils.getIIIFResource(imageSourceObj)
-                .done(function(imageSourceDataObj) {
-                    imageSourceData[index] = imageSourceDataObj;
-                    finishLoading();
-                });
+            dlfUtils.getIIIFResource(imageSourceObj).done(function (imageSourceDataObj) {
+                imageSourceData[index] = imageSourceDataObj;
+                finishLoading();
+            });
         } else if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP) {
-            dlfUtils.fetchIIPData(imageSourceObj)
-                .done(function(imageSourceDataObj) {
-                    imageSourceData[index] = imageSourceDataObj;
-                    finishLoading();
-                });
+            dlfUtils.fetchIIPData(imageSourceObj).done(function (imageSourceDataObj) {
+                imageSourceData[index] = imageSourceDataObj;
+                finishLoading();
+            });
         } else {
             // In the worse case expect static image file
-            dlfUtils.fetchStaticImageData(imageSourceObj)
-                .done(function(imageSourceDataObj) {
-                    imageSourceData[index] = imageSourceDataObj;
-                    finishLoading();
-                });
+            dlfUtils.fetchStaticImageData(imageSourceObj).done(function (imageSourceDataObj) {
+                imageSourceData[index] = imageSourceDataObj;
+                finishLoading();
+            });
         }
     });
 
     return deferredResponse;
 };
-
 
 /**
  * Fetches the image data for static images source.
@@ -249,18 +229,18 @@ dlfUtils.fetchImageData = function(imageSourceObjs) {
  * @param {{url: *, mimetype: *}} imageSourceObj
  * @return {JQueryStatic.Deferred}
  */
-dlfUtils.fetchStaticImageData = function(imageSourceObj) {
+dlfUtils.fetchStaticImageData = function (imageSourceObj) {
 
     // use deferred for async behavior
-    const deferredResponse = new $.Deferred();
+    var deferredResponse = new $.Deferred();
 
     // Create new Image object.
-    const image = new Image();
+    var image = new Image();
 
     // Register onload handler.
-    image.onload = function() {
+    image.onload = function () {
 
-        const imageDataObj = {
+        var imageDataObj = {
             src: this.src,
             mimetype: imageSourceObj.mimetype,
             width: this.width,
@@ -282,8 +262,8 @@ dlfUtils.fetchStaticImageData = function(imageSourceObj) {
  */
 dlfUtils.getIIIFResource = function getIIIFResource(imageSourceObj) {
 
-    const deferredResponse = new $.Deferred();
-    const type = 'GET';
+    var deferredResponse = new $.Deferred();
+    var type = 'GET';
     $.ajax({
         url: dlfViewerSource.IIIF.getMetdadataURL(imageSourceObj.url),
         type: type,
@@ -291,18 +271,18 @@ dlfUtils.getIIIFResource = function getIIIFResource(imageSourceObj) {
     }).done(cb).fail(error);
 
     function cb(data) {
-        const mimetype = imageSourceObj.mimetype;
+        var mimetype = imageSourceObj.mimetype;
         if (dlfUtils.supportsIIIF(data)) {
             if (data.protocol && data.protocol === 'http://iiif.io/api/image') {
-                let uri = decodeURI(data['@id']);
+                var uri = decodeURI(data['@id']);
                 uri = dlfUtils.removeInfoJson(uri);
-                const imageResource = dlfUtils.buildImageV2(mimetype, uri, data);
+                var imageResource = dlfUtils.buildImageV2(mimetype, uri, data);
                 deferredResponse.resolve(imageResource);
             } else {
-                let uri = imageSourceObj.url;
-                uri = dlfUtils.removeInfoJson(uri);
-                const imageResource = dlfUtils.buildImageV1(mimetype, uri, data);
-                deferredResponse.resolve(imageResource);
+                var _uri = imageSourceObj.url;
+                _uri = dlfUtils.removeInfoJson(_uri);
+                var _imageResource = dlfUtils.buildImageV1(mimetype, _uri, data);
+                deferredResponse.resolve(_imageResource);
             }
         }
     }
@@ -342,18 +322,14 @@ dlfUtils.supportsIIIF = function supportsIIIF(data) {
     if (data.protocol && data.protocol === 'http://iiif.io/api/image') {
         return true;
         // Version 1.1
-    } else if (data['@context'] && (
-        data['@context'] === "http://library.stanford.edu/iiif/image-api/1.1/context.json" ||
-        data['@context'] === "http://iiif.io/api/image/1/context.json")) {
+    } else if (data['@context'] && (data['@context'] === "http://library.stanford.edu/iiif/image-api/1.1/context.json" || data['@context'] === "http://iiif.io/api/image/1/context.json")) {
         return true;
         // Version 1.0
-    } else if (data.profile &&
-        data.profile.indexOf("http://library.stanford.edu/iiif/image-api/compliance.html") === 0) {
+    } else if (data.profile && data.profile.indexOf("http://library.stanford.edu/iiif/image-api/compliance.html") === 0) {
         return true;
     } else if (data.identifier && data.width && data.height) {
         return true;
-    } else return (data.documentElement && "info" === data.documentElement.tagName &&
-    "http://library.stanford.edu/iiif/image-api/ns/" === data.documentElement.namespaceURI);
+    } else return data.documentElement && "info" === data.documentElement.tagName && "http://library.stanford.edu/iiif/image-api/ns/" === data.documentElement.namespaceURI;
 };
 
 /**
@@ -374,22 +350,22 @@ dlfUtils.buildImageV2 = function buildImageV2(mimetype, uri, jsonld) {
         src: uri,
         width: jsonld.width,
         height: jsonld.height,
-        tilesize: [jsonld.tiles.map(function(a) {
+        tilesize: [jsonld.tiles.map(function (a) {
             return a.width;
-        })[0], jsonld.tiles.map(function(a) {
+        })[0], jsonld.tiles.map(function (a) {
             return a.height;
         })[0]],
-        qualities: jsonld.profile.map(function(a) {
-            return a
-        }).map(function(b) {
+        qualities: jsonld.profile.map(function (a) {
+            return a;
+        }).map(function (b) {
             return b.qualities;
         })[1],
-        formats: jsonld.profile.map(function(a) {
-            return a
-        }).map(function(b) {
+        formats: jsonld.profile.map(function (a) {
+            return a;
+        }).map(function (b) {
             return b.formats;
         })[1],
-        resolutions: jsonld.tiles.map(function(a) {
+        resolutions: jsonld.tiles.map(function (a) {
             return a.scaleFactors;
         })[0],
         mimetype: mimetype
@@ -424,26 +400,24 @@ dlfUtils.buildImageV1 = function buildImageV1(mimetype, uri, jsonld) {
     };
 };
 
-
 /**
  * Fetches the image data for iip images source.
  *
  * @param {{url: *, mimetype: *}} imageSourceObj
  * @return {JQueryStatic.Deferred}
  */
-dlfUtils.fetchIIPData = function(imageSourceObj) {
+dlfUtils.fetchIIPData = function (imageSourceObj) {
 
     // use deferred for async behavior
-    const deferredResponse = new $.Deferred();
+    var deferredResponse = new $.Deferred();
 
     $.ajax({
-        url: dlfViewerSource.IIP.getMetdadataURL(imageSourceObj.url)//'http://localhost:8000/fcgi-bin/iipsrv.fcgi?FIF=F4713/HD7.tif&obj=IIP,1.0&obj=Max-size&obj=Tile-size&obj=Resolution-number',
+        url: dlfViewerSource.IIP.getMetdadataURL(imageSourceObj.url) //'http://localhost:8000/fcgi-bin/iipsrv.fcgi?FIF=F4713/HD7.tif&obj=IIP,1.0&obj=Max-size&obj=Tile-size&obj=Resolution-number',
     }).done(cb);
     function cb(response, type) {
-        if (type !== 'success')
-            throw new Error('Problems while fetching ImageProperties.xml');
+        if (type !== 'success') throw new Error('Problems while fetching ImageProperties.xml');
 
-        const imageDataObj = $.extend({
+        var imageDataObj = $.extend({
             src: imageSourceObj.url,
             mimetype: imageSourceObj.mimetype
         }, dlfViewerSource.IIP.parseMetadata(response));
@@ -460,21 +434,20 @@ dlfUtils.fetchIIPData = function(imageSourceObj) {
  * @param {{url: *, mimetype: *}} imageSourceObj
  * @return {JQueryStatic.Deferred}
  */
-dlfUtils.fetchZoomifyData = function(imageSourceObj) {
+dlfUtils.fetchZoomifyData = function (imageSourceObj) {
 
     // use deferred for async behavior
-    const deferredResponse = new $.Deferred();
+    var deferredResponse = new $.Deferred();
 
     $.ajax({
         url: imageSourceObj.url
     }).done(cb);
     function cb(response, type) {
-        if (type !== 'success')
-            throw new Error('Problems while fetching ImageProperties.xml');
+        if (type !== 'success') throw new Error('Problems while fetching ImageProperties.xml');
 
-        const properties = $(response).find('IMAGE_PROPERTIES');
+        var properties = $(response).find('IMAGE_PROPERTIES');
 
-        const imageDataObj = {
+        var imageDataObj = {
             src: response.URL.substring(0, response.URL.lastIndexOf("/") + 1),
             width: parseInt(properties.attr('WIDTH')),
             height: parseInt(properties.attr('HEIGHT')),
@@ -493,40 +466,36 @@ dlfUtils.fetchZoomifyData = function(imageSourceObj) {
  * @return {string|null} Value of the cookie
  * @TODO replace unescape function
  */
-dlfUtils.getCookie = function(name) {
+dlfUtils.getCookie = function (name) {
 
-    const results = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
+    var results = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
 
     if (results) {
 
         return decodeURI(results[2]);
-
     } else {
 
         return null;
-
     }
-
 };
 
 /**
  * Returns url parameters
  * @returns {Object|undefined}
  */
-dlfUtils.getUrlParams = function() {
+dlfUtils.getUrlParams = function () {
     if (Object.prototype.hasOwnProperty.call(location, 'search')) {
-        const search = decodeURIComponent(location.search).slice(1).split('&'),
+        var search = decodeURIComponent(location.search).slice(1).split('&'),
             params = {};
 
-        search.forEach(function(item) {
-            const s = item.split('=');
-            params[s[0]] = s[1]
+        search.forEach(function (item) {
+            var s = item.split('=');
+            params[s[0]] = s[1];
         });
 
         return params;
     }
     return undefined;
-
 };
 
 /**
@@ -534,7 +503,7 @@ dlfUtils.getUrlParams = function() {
  * @param {?} val
  * @return {boolean}
  */
-dlfUtils.isNull = function(val) {
+dlfUtils.isNull = function (val) {
     return val === null;
 };
 
@@ -543,7 +512,7 @@ dlfUtils.isNull = function(val) {
  * @param {?} val
  * @return {boolean}
  */
-dlfUtils.isNullEmptyUndefinedOrNoNumber = function(val) {
+dlfUtils.isNullEmptyUndefinedOrNoNumber = function (val) {
     return val === null || val === undefined || val === '' || isNaN(val);
 };
 
@@ -551,39 +520,29 @@ dlfUtils.isNullEmptyUndefinedOrNoNumber = function(val) {
  * @param {Array.<{url: *, mimetype: *}>} imageObjs
  * @return {boolean}
  */
-dlfUtils.isCorsEnabled = function(imageObjs) {
+dlfUtils.isCorsEnabled = function (imageObjs) {
     // fix for proper working with ie
     if (!window.location.origin) {
-        window.location.origin = window.location.protocol + '//' + window.location.hostname +
-            (window.location.port ? ':' + window.location.port : '');
+        window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
     }
 
     // fetch data from server
     // with access control allowed
-    let response = true;
+    var response = true;
 
-    imageObjs.forEach(function(imageObj) {
-        let url = imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY
-            ? imageObj.url.replace('ImageProperties.xml', 'TileGroup0/0-0-0.jpg')
-            :
-            imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF
-                ? dlfViewerSource.IIIF.getMetdadataURL(imageObj.url)
-                : imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP
-                ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url)
-                : imageObj.url;
+    imageObjs.forEach(function (imageObj) {
+        var url = imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY ? imageObj.url.replace('ImageProperties.xml', 'TileGroup0/0-0-0.jpg') : imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIIF ? dlfViewerSource.IIIF.getMetdadataURL(imageObj.url) : imageObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.IIP ? dlfViewerSource.IIP.getMetdadataURL(imageObj.url) : imageObj.url;
 
-        url =
-            window.location.origin + window.location.pathname + '?eID=tx_dlf_geturl_eid&url=' + encodeURIComponent(
-                url) + '&header=2';
+        url = window.location.origin + window.location.pathname + '?eID=tx_dlf_geturl_eid&url=' + encodeURIComponent(url) + '&header=2';
 
         $.ajax({
             url: url,
             async: false
-        }).done(function(data, type) {
+        }).done(function (data, type) {
             response = type === 'success' && data.indexOf('Access-Control-Allow-Origin') !== -1;
-        }).error(function(data, type) {
-                response = false;
-            });
+        }).error(function (data, type) {
+            response = false;
+        });
     });
     return response;
 };
@@ -592,21 +551,20 @@ dlfUtils.isCorsEnabled = function(imageObjs) {
  * Functions checks if WebGL is enabled in the browser
  * @return {boolean}
  */
-dlfUtils.isWebGLEnabled = function() {
+dlfUtils.isWebGLEnabled = function () {
     if (!!window.WebGLRenderingContext) {
-        let canvas = document.createElement("canvas"),
+        var canvas = document.createElement("canvas"),
             rendererNames = ["webgl", "experimental-webgl", "moz-webgl", "webkit-3d"],
             context = false;
 
-        for (let i = 0; i < rendererNames.length; i++) {
+        for (var i = 0; i < rendererNames.length; i++) {
             try {
                 context = canvas.getContext(rendererNames[i]);
                 if (context && typeof context.getParameter === "function") {
                     // WebGL is enabled;
                     return true;
                 }
-            } catch (e) {
-            }
+            } catch (e) {}
         }
         // WebGL not supported
         return false;
@@ -620,8 +578,8 @@ dlfUtils.isWebGLEnabled = function() {
  * @param {Element} element
  * @return {Object}
  */
-dlfUtils.parseDataDic = function(element) {
-    const dataDicString = $(element).attr('data-dic'),
+dlfUtils.parseDataDic = function (element) {
+    var dataDicString = $(element).attr('data-dic'),
         dataDicRecords = dataDicString.split(';'),
         dataDic = {};
 
@@ -640,10 +598,9 @@ dlfUtils.parseDataDic = function(element) {
  * @param {string} name The key of the value
  * @param {?} value The value to save
  */
-dlfUtils.setCookie = function(name, value) {
+dlfUtils.setCookie = function (name, value) {
 
     document.cookie = name + "=" + decodeURI(value) + "; path=/";
-
 };
 
 /**
@@ -657,36 +614,33 @@ dlfUtils.setCookie = function(name, value) {
  * @deprecated
  * @return {Array.<ol.Feature>}
  */
-dlfUtils.scaleToImageSize = function(features, imageObj, width, height, opt_offset) {
+dlfUtils.scaleToImageSize = function (features, imageObj, width, height, opt_offset) {
 
     // update size / scale settings of imageObj
-    let image;
+    var image = void 0;
     if (width && height) {
 
         image = {
             'width': width,
             'height': height,
             'scale': imageObj.width / width
-        }
-
+        };
     }
 
-    if (image === undefined)
-        return [];
+    if (image === undefined) return [];
 
-    const scale = image.scale,
+    var scale = image.scale,
         displayImageHeight = imageObj.height,
         offset = opt_offset !== undefined ? opt_offset : 0;
 
     // do rescaling and set a id
-    for (const i in features) {
+    for (var i in features) {
 
-        const oldCoordinates = features[i].getGeometry().getCoordinates()[0],
+        var oldCoordinates = features[i].getGeometry().getCoordinates()[0],
             newCoordinates = [];
 
-        for (let j = 0; j < oldCoordinates.length; j++) {
-            newCoordinates.push(
-                [offset + (scale * oldCoordinates[j][0]), displayImageHeight - (scale * oldCoordinates[j][1])]);
+        for (var j = 0; j < oldCoordinates.length; j++) {
+            newCoordinates.push([offset + scale * oldCoordinates[j][0], displayImageHeight - scale * oldCoordinates[j][1]]);
         }
 
         features[i].setGeometry(new ol.geom.Polygon([newCoordinates]));
@@ -697,7 +651,6 @@ dlfUtils.scaleToImageSize = function(features, imageObj, width, height, opt_offs
     }
 
     return features;
-
 };
 
 /**
@@ -706,12 +659,11 @@ dlfUtils.scaleToImageSize = function(features, imageObj, width, height, opt_offs
  * @param {string} text
  * @return {Array.<ol.Feature>|undefined}
  */
-dlfUtils.searchFeatureCollectionForText = function(featureCollection, text) {
-    const features = [];
-    featureCollection.forEach(function(ft) {
+dlfUtils.searchFeatureCollectionForText = function (featureCollection, text) {
+    var features = [];
+    featureCollection.forEach(function (ft) {
         if (ft.get('fulltext') !== undefined) {
-            if (ft.get('fulltext').toLowerCase().indexOf(text.toLowerCase()) > -1)
-                features.push(ft);
+            if (ft.get('fulltext').toLowerCase().indexOf(text.toLowerCase()) > -1) features.push(ft);
         }
     });
     return features.length > 0 ? features : undefined;


### PR DESCRIPTION
This patch was done using babel [1] with the following syntax:

babel tx_dlf_utils.js --presets=es2015

[1] https://github.com/babel/babel