### PR TITLE
Build physical structure out of any type of element, not only pages

### DIFF
--- a/dlf/common/class.tx_dlf_indexing.php
+++ b/dlf/common/class.tx_dlf_indexing.php
@@ -147,11 +147,11 @@ class tx_dlf_indexing {
 				// Index fulltext files if available.
 				if ($doc->hasFulltext) {
 
-					foreach ($doc->physicalPages as $pageNumber => $xmlId) {
+					foreach ($doc->physicalStructure as $pageNumber => $xmlId) {
 
 						if (!$errors) {
 
-							$errors = self::processPhysical($doc, $pageNumber, $doc->physicalPagesInfo[$xmlId]);
+							$errors = self::processPhysical($doc, $pageNumber, $doc->physicalStructureInfo[$xmlId]);
 
 						} else {
 

--- a/dlf/plugins/metadata/class.tx_dlf_metadata.php
+++ b/dlf/plugins/metadata/class.tx_dlf_metadata.php
@@ -73,9 +73,9 @@ class tx_dlf_metadata extends tx_dlf_plugin {
 			// Get current structure's @ID.
 			$ids = array ();
 
-			if (!empty($this->doc->physicalPages[$this->piVars['page']]) && !empty($this->doc->smLinks['p2l'][$this->doc->physicalPages[$this->piVars['page']]])) {
+			if (!empty($this->doc->physicalStructure[$this->piVars['page']]) && !empty($this->doc->smLinks['p2l'][$this->doc->physicalStructure[$this->piVars['page']]])) {
 
-				foreach ($this->doc->smLinks['p2l'][$this->doc->physicalPages[$this->piVars['page']]] as $logId) {
+				foreach ($this->doc->smLinks['p2l'][$this->doc->physicalStructure[$this->piVars['page']]] as $logId) {
 
 					$count = count($this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]//mets:div[@ID="'.$logId.'"]/ancestor::*'));
 

--- a/dlf/plugins/navigation/class.tx_dlf_navigation.php
+++ b/dlf/plugins/navigation/class.tx_dlf_navigation.php
@@ -89,7 +89,7 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 
 		for ($i = 1; $i <= $this->doc->numPages; $i++) {
 
-			$output .= '<option value="'.$i.'"'.($this->piVars['page'] == $i ? ' selected="selected"' : '').'>['.$i.']'.($this->doc->physicalPagesInfo[$this->doc->physicalPages[$i]]['label'] ? ' - '.htmlspecialchars($this->doc->physicalPagesInfo[$this->doc->physicalPages[$i]]['label']) : '').'</option>';
+			$output .= '<option value="'.$i.'"'.($this->piVars['page'] == $i ? ' selected="selected"' : '').'>['.$i.']'.($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$i]]['orderlabel'] ? ' - '.htmlspecialchars($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$i]]['orderlabel']) : '').'</option>';
 
 		}
 
@@ -130,14 +130,14 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 			if ($this->doc->numPages > 0) {
 
 				// Set default values if not set.
-				// page may be integer or string (physical page attribute)
+				// $this->piVars['page'] may be integer or string (physical structure @ID)
 				if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
 					$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
 
 				} else {
 
-					$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+					$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
 
 				}
 

--- a/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
+++ b/dlf/plugins/pagegrid/class.tx_dlf_pagegrid.php
@@ -49,12 +49,12 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		$markerArray['###NUMBER###'] = $number;
 
 		// Set pagination.
-		$markerArray['###PAGINATION###'] = $this->doc->physicalPagesInfo[$this->doc->physicalPages[$number]]['label'];
+		$markerArray['###PAGINATION###'] = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$number]]['orderlabel'];
 
 		// Get thumbnail or placeholder.
-		if (!empty($this->doc->physicalPagesInfo[$this->doc->physicalPages[$number]]['files'][$this->conf['fileGrpThumbs']])) {
+		if (!empty($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$number]]['files'][$this->conf['fileGrpThumbs']])) {
 
-			$thumbnailFile = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[$number]]['files'][$this->conf['fileGrpThumbs']]);
+			$thumbnailFile = $this->doc->getFileLocation($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$number]]['files'][$this->conf['fileGrpThumbs']]);
 
 		} elseif (!empty($this->conf['placeholder'])) {
 
@@ -224,14 +224,14 @@ class tx_dlf_pagegrid extends tx_dlf_plugin {
 		}
 
 		// Set some variable defaults.
-		// page may be integer or string (physical page attribute)
+		// $this->piVars['page'] may be integer or string (physical structure @ID)
 		if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
 			$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
 
 		} else {
 
-			$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+			$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
 
 		}
 

--- a/dlf/plugins/pageview/class.tx_dlf_pageview.php
+++ b/dlf/plugins/pageview/class.tx_dlf_pageview.php
@@ -122,9 +122,9 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		while ($fileGrp = @array_pop($fileGrps)) {
 
 			// Get image link.
-			if (!empty($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrp])) {
+			if (!empty($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$fileGrp])) {
 
-				$image['url'] = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrp]);
+				$image['url'] = $this->doc->getFileLocation($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$fileGrp]);
 
 				if ($this->conf['useInternalProxy']) {
 					// Configure @action URL for form.
@@ -136,7 +136,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 					$image['url'] = $this->cObj->typoLink_URL($linkConf);
 				}
 
-				$image['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$fileGrp]);
+				$image['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$fileGrp]);
 
 				break;
 
@@ -170,9 +170,9 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		$fulltext = array ();
 
 		// Get fulltext link.
-		if (!empty($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$this->conf['fileGrpFulltext']])) {
+		if (!empty($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$this->conf['fileGrpFulltext']])) {
 
-			$fulltext['url'] = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$this->conf['fileGrpFulltext']]);
+			$fulltext['url'] = $this->doc->getFileLocation($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$this->conf['fileGrpFulltext']]);
 
 			// Configure @action URL for form.
 			$linkConf = array (
@@ -182,7 +182,7 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 
 			$fulltext['url'] = $this->cObj->typoLink_URL($linkConf);
 
-			$fulltext['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalPagesInfo[$this->doc->physicalPages[$page]]['files'][$this->conf['fileGrpFulltext']]);
+			$fulltext['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$this->conf['fileGrpFulltext']]);
 
 		} else {
 
@@ -223,14 +223,14 @@ class tx_dlf_pageview extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			// page may be integer or string (physical page attribute)
+			// $this->piVars['page'] may be integer or string (physical structure @ID)
 			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
 				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
 
 			} else {
 
-				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
 
 			}
 

--- a/dlf/plugins/toc/class.tx_dlf_toc.php
+++ b/dlf/plugins/toc/class.tx_dlf_toc.php
@@ -203,14 +203,14 @@ class tx_dlf_toc extends tx_dlf_plugin {
 		} else {
 
 			// Set default values for page if not set.
-			// page may be integer or string (physical page attribute)
+			// $this->piVars['page'] may be integer or string (physical structure @ID)
 			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
 				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
 
 			} else {
 
-				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
 
 			}
 
@@ -220,17 +220,17 @@ class tx_dlf_toc extends tx_dlf_plugin {
 
 		$menuArray = array ();
 
-		// Does the document have physical pages or is it an external file?
-		if ($this->doc->physicalPages || !\TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($this->doc->uid)) {
+		// Does the document have physical elements or is it an external file?
+		if ($this->doc->physicalStructure || !\TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($this->doc->uid)) {
 
-			// Get all logical units the current page is a part of.
-			if (!empty($this->piVars['page']) && $this->doc->physicalPages) {
+			// Get all logical units the current page or track is a part of.
+			if (!empty($this->piVars['page']) && $this->doc->physicalStructure) {
 
-				$this->activeEntries = array_merge((array) $this->doc->smLinks['p2l'][$this->doc->physicalPages[0]], (array) $this->doc->smLinks['p2l'][$this->doc->physicalPages[$this->piVars['page']]]);
+				$this->activeEntries = array_merge((array) $this->doc->smLinks['p2l'][$this->doc->physicalStructure[0]], (array) $this->doc->smLinks['p2l'][$this->doc->physicalStructure[$this->piVars['page']]]);
 
 				if (!empty($this->piVars['double']) && $this->piVars['page'] < $this->doc->numPages) {
 
-					$this->activeEntries = array_merge($this->activeEntries, (array) $this->doc->smLinks['p2l'][$this->doc->physicalPages[$this->piVars['page'] + 1]]);
+					$this->activeEntries = array_merge($this->activeEntries, (array) $this->doc->smLinks['p2l'][$this->doc->physicalStructure[$this->piVars['page'] + 1]]);
 
 				}
 

--- a/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
+++ b/dlf/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
@@ -50,14 +50,14 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			// page may be integer or string (physical page attribute)
+			// $this->piVars['page'] may be integer or string (physical structure @ID)
 			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
 				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
 
 			} else {
 
-				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
 
 			}
 
@@ -77,7 +77,7 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
 		}
 
 
-		$fullTextFile = $this->doc->physicalPagesInfo[$this->doc->physicalPages[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
+		$fullTextFile = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
 
 		if (!empty($fullTextFile)) {
 			$markerArray['###FULLTEXT_SELECT###'] = '<a class="select switchoff" id="tx-dlf-tools-fulltext" title="" data-dic="fulltext-on:'

--- a/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -50,14 +50,14 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		} else {
 
 			// Set default values if not set.
-			// page may be integer or string (physical page attribute)
+			// $this->piVars['page'] may be integer or string (physical structure @ID)
 			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
 
 				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
 
 			} else {
 
-				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalPages);
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
 
 			}
 
@@ -102,7 +102,7 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		$pageNumber = $this->piVars['page'];
 
 		// Get image link.
-		$details = $this->doc->physicalPagesInfo[$this->doc->physicalPages[$pageNumber]];
+		$details = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$pageNumber]];
 		$file = $details['files'][$this->conf['fileGrpDownload']];
 		if (!empty($file)) {
 			$page1Link = $this->doc->getFileLocation($file);
@@ -110,7 +110,7 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 
 		// Get second page, too, if double page view is activated.
 		if ($this->piVars['double'] && $pageNumber < $this->doc->numPages) {
-			$details = $this->doc->physicalPagesInfo[$this->doc->physicalPages[$pageNumber + 1]];
+			$details = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$pageNumber + 1]];
 			$file = $details['files'][$this->conf['fileGrpDownload']];
 			if (!empty($file)) {
 				$page2Link = $this->doc->getFileLocation($file);
@@ -155,9 +155,9 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
 		$workLink = '';
 
 		// Get work link.
-		if (!empty($this->doc->physicalPagesInfo[$this->doc->physicalPages[0]]['files'][$this->conf['fileGrpDownload']])) {
+		if (!empty($this->doc->physicalStructureInfo[$this->doc->physicalStructure[0]]['files'][$this->conf['fileGrpDownload']])) {
 
-			$workLink = $this->doc->getFileLocation($this->doc->physicalPagesInfo[$this->doc->physicalPages[0]]['files'][$this->conf['fileGrpDownload']]);
+			$workLink = $this->doc->getFileLocation($this->doc->physicalStructureInfo[$this->doc->physicalStructure[0]]['files'][$this->conf['fileGrpDownload']]);
 
 		} else {
 


### PR DESCRIPTION
This should fix the audioplayer support by refactoring the physical structure handling. Now alle DIVs of the physical structure are considered, not only those of type `page`. This works for `track` and should work for future types as well.

The pull request contains renaming the former `tx_dlf_document->physicalPages` and `tx_dlf_document->physicalPagesInfo` arrays to `tx_dlf_document->physicalStructure` and `tx_dlf_document->physicalStructureInfo` respectively. This affects some other plugins as well.

The pull request also contains the changes proposed in pull request #201, which is obsolete now.