### PR TITLE
add image download tool

### DIFF
--- a/dlf/ext_autoload.php
+++ b/dlf/ext_autoload.php
@@ -50,5 +50,6 @@ return array (
 	'tx_dlf_toolsPdf' => $extensionPath.'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php',
 	'tx_dlf_toolsFulltext' => $extensionPath.'plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php',
 	'tx_dlf_toolsImagemanipulation' => $extensionPath.'plugins/toolbox/tools/imagemanipulation/class.tx_dlf_toolsImagemanipulation.php',
+	'tx_dlf_toolsImagedownload' => $extensionPath.'plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php',
 	'tx_dlf_validator' => $extensionPath.'plugins/validator/class.tx_dlf_validator.php'
 );

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -52,7 +52,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CM
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', TRUE);
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php', '_toolsImagedownload', '', TRUE);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php', '_toolsImagedownload', '', TRUE);
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsImagedownload'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsImagedownload';
 
 // Register hooks.

--- a/dlf/ext_localconf.php
+++ b/dlf/ext_localconf.php
@@ -52,6 +52,9 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CM
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php', '_toolsPdf', '', TRUE);
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsPdf'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsPdf';
 
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php', '_toolsImagedownload', '', TRUE);
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/plugins/toolbox/tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_toolsImagedownload'] = 'LLL:EXT:dlf/locallang.xml:tx_dlf_toolbox.toolsImagedownload';
+
 // Register hooks.
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = 'EXT:'.$_EXTKEY.'/hooks/class.tx_dlf_tcemain.php:tx_dlf_tcemain';
 

--- a/dlf/locallang.xml
+++ b/dlf/locallang.xml
@@ -123,6 +123,7 @@
 			<label index="tx_dlf_toolbox.toolsPdf">PDF Download</label>
 			<label index="tx_dlf_toolbox.toolsFulltext">Fulltext</label>
 			<label index="tx_dlf_toolbox.toolsImagemanipulation">Image Manipulation</label>
+			<label index="tx_dlf_toolbox.toolsImagedownload">Image Download</label>
 			<label index="tt_content.dlf_audioplayer">DLF: Audio Player</label>
 			<label index="tt_content.dlf_collection">DLF: Collection</label>
 			<label index="tt_content.dlf_feeds">DLF: Feeds</label>
@@ -305,6 +306,7 @@
 			<label index="tx_dlf_toolbox.toolsPdf">PDF-Download</label>
 			<label index="tx_dlf_toolbox.toolsFulltext">Volltext</label>
 			<label index="tx_dlf_toolbox.toolsImagemanipulation">Bildbearbeitung</label>
+			<label index="tx_dlf_toolbox.toolsImagedownload">Bild-Download</label>
 			<label index="tt_content.dlf_audioplayer">DLF: Audioplayer</label>
 			<label index="tt_content.dlf_collection">DLF: Kollektion</label>
 			<label index="tt_content.dlf_feeds">DLF: Feeds</label>

--- a/dlf/plugins/toolbox/flexform.xml
+++ b/dlf/plugins/toolbox/flexform.xml
@@ -49,6 +49,18 @@
 							</config>
 						</TCEforms>
 					</tools>
+					<fileGrpsImageDownload>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>LLL:EXT:dlf/plugins/toolbox/locallang.xml:tt_content.pi_flexform.fileGrps</label>
+							<config>
+								<type>input</type>
+								<size>30</size>
+								<max>30</max>
+								<default>MIN,DEFAULT,MAX</default>
+							</config>
+						</TCEforms>
+					</fileGrpsImageDownload>
 					<templateFile>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/dlf/plugins/toolbox/locallang.xml
+++ b/dlf/plugins/toolbox/locallang.xml
@@ -18,11 +18,13 @@
 			<label index="tt_content.pi_flexform.sheet_general">Options</label>
 			<label index="tt_content.pi_flexform.tools">Tools</label>
 			<label index="tt_content.pi_flexform.templateFile">Template file</label>
+			<label index="tt_content.pi_flexform.fileGrps">Page fileGrps used by image download tool: comma-separated list of @USE attribute values ordered by increasing size (default is "MIN,DEFAULT,MAX")</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
 			<label index="tt_content.pi_flexform.tools">Werkzeuge</label>
 			<label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
+			<label index="tt_content.pi_flexform.fileGrp">Seiten fileGrps für das Werkzeug Bild-Download: Komma-getrennte Liste der @USE Attributwerte der Seitenansichten nach aufsteigender Größe sortiert (Standard ist "MIN,DEFAULT,MAX")</label>
 		</languageKey>
 	</data>
 </T3locallang>

--- a/dlf/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php
+++ b/dlf/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Tool 'Image Download' for the plugin 'DLF: Toolbox' of the 'dlf' extension.
+ *
+ * @author	Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @package	TYPO3
+ * @subpackage	tx_dlf
+ * @access	public
+ */
+class tx_dlf_toolsImagedownload extends tx_dlf_plugin {
+
+	public $scriptRelPath = 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php';
+
+	/**
+	 * The main method of the PlugIn
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	string		The content that is displayed on the website
+	 */
+	public function main($content, $conf) {
+
+		$this->init($conf);
+
+		// Merge configuration with conf array of toolbox.
+		$this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+
+		// Load current document.
+		$this->loadDocument();
+
+		if ($this->doc === NULL || $this->doc->numPages < 1 || empty($this->conf['fileGrpsImageDownload'])) {
+
+			// Quit without doing anything if required variables are not set.
+			return $content;
+
+		} else {
+
+			// Set default values if not set.
+			// $this->piVars['page'] may be integer or string (physical structure @ID)
+			if ( (int)$this->piVars['page'] > 0 || empty($this->piVars['page'])) {
+
+				$this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int)$this->piVars['page'], 1, $this->doc->numPages, 1);
+
+			} else {
+
+				$this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
+
+			}
+
+			$this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
+
+		}
+
+		// Load template file.
+		if (!empty($this->conf['toolTemplateFile'])) {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource($this->conf['toolTemplateFile']), '###TEMPLATE###');
+
+		} else {
+
+			$this->template = $this->cObj->getSubpart($this->cObj->fileResource('EXT:dlf/plugins/toolbox/tools/imagedownload/template.tmpl'), '###TEMPLATE###');
+
+		}
+
+		// Get single page downloads.
+		$markerArray['###IMAGE_LEFT###'] =  $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'], $this->pi_getLL('leftPage', '')) : $this->getImage($this->piVars['page'], $this->pi_getLL('singlePage', ''));
+
+		// Get work download.
+		$markerArray['###IMAGE_RIGHT###'] = $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'] + 1, $this->pi_getLL('rightPage', '')) : '';
+
+		$content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+
+		return $this->pi_wrapInBaseClass($content);
+
+	}
+
+
+	/**
+	 * Get image's URL and MIME type
+	 *
+	 * @access	protected
+	 *
+	 * @param	integer		$page: Page number
+	 * @param	string		$label: Link title and label
+	 *
+	 * @return	string	linkt to image file with given label
+	 */
+	protected function getImage($page, $label) {
+
+		$image = array ();
+
+		// Get @USE value of METS fileGrp.
+		$fileGrps = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['fileGrpsImageDownload']);
+
+		while ($fileGrp = @array_pop($fileGrps)) {
+
+			// Get image link.
+			if (!empty($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$fileGrp])) {
+
+				$image['url'] = $this->doc->getFileLocation($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$fileGrp]);
+
+				$image['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$fileGrp]);
+
+				switch ($image['mimetype']) {
+					case 'image/jpeg': 	$mimetypeLabel = '(JPG)';
+						break;
+					case 'image/tiff': 	$mimetypeLabel = '(TIFF)';
+							break;
+					default:	$mimetypeLabel = '';
+				}
+				$linkConf = array (
+					'parameter' => $image['url'],
+					'title' => $label . ' ' . $mimetypeLabel,
+					'additionalParams' => '',
+				);
+
+				$imageLink = $this->cObj->typoLink($label . ' ' . $mimetypeLabel, $linkConf);
+
+				break;
+
+			} else {
+
+				if (TYPO3_DLOG) {
+
+					\TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_toolsImagedownload->getImage('.$page.')] File not found in fileGrp "'.$fileGrp.'"', $this->extKey, SYSLOG_SEVERITY_WARNING);
+
+				}
+
+			}
+
+		}
+
+		return $imageLink;
+
+	}
+
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php']);
+}

--- a/dlf/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php
+++ b/dlf/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php
@@ -19,7 +19,7 @@
  */
 class tx_dlf_toolsImagedownload extends tx_dlf_plugin {
 
-	public $scriptRelPath = 'plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php';
+	public $scriptRelPath = 'plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php';
 
 	/**
 	 * The main method of the PlugIn
@@ -75,10 +75,10 @@ class tx_dlf_toolsImagedownload extends tx_dlf_plugin {
 
 		}
 
-		// Get single page downloads.
+		// Get left or single page download.
 		$markerArray['###IMAGE_LEFT###'] =  $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'], $this->pi_getLL('leftPage', '')) : $this->getImage($this->piVars['page'], $this->pi_getLL('singlePage', ''));
 
-		// Get work download.
+		// Get right page download.
 		$markerArray['###IMAGE_RIGHT###'] = $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'] + 1, $this->pi_getLL('rightPage', '')) : '';
 
 		$content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
@@ -149,6 +149,6 @@ class tx_dlf_toolsImagedownload extends tx_dlf_plugin {
 
 }
 
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php'])	{
-	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/pdf/class.tx_dlf_toolsImagedownload.php']);
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php']);
 }

--- a/dlf/plugins/toolbox/tools/imagedownload/locallang.xml
+++ b/dlf/plugins/toolbox/tools/imagedownload/locallang.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+<T3locallang>
+	<meta type="array">
+		<type>module</type>
+		<description>Language labels for tool tx_dlf_toolsImagedownload</description>
+	</meta>
+	<data type="array">
+		<languageKey index="default" type="array">
+			<label index="singlePage">Download single page</label>
+			<label index="leftPage">Download left page</label>
+			<label index="rightPage">Download right page</label>
+			<label index="work">Download whole work</label>
+		</languageKey>
+		<languageKey index="de" type="array">
+			<label index="singlePage">Einzelseite herunterladen</label>
+			<label index="leftPage">Linke Seite herunterladen</label>
+			<label index="rightPage">Rechte Seite herunterladen</label>
+			<label index="work">Ganzes Werk herunterladen</label>
+		</languageKey>
+	</data>
+</T3locallang>

--- a/dlf/plugins/toolbox/tools/imagedownload/locallang.xml
+++ b/dlf/plugins/toolbox/tools/imagedownload/locallang.xml
@@ -18,13 +18,11 @@
 			<label index="singlePage">Download single page</label>
 			<label index="leftPage">Download left page</label>
 			<label index="rightPage">Download right page</label>
-			<label index="work">Download whole work</label>
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="singlePage">Einzelseite herunterladen</label>
 			<label index="leftPage">Linke Seite herunterladen</label>
 			<label index="rightPage">Rechte Seite herunterladen</label>
-			<label index="work">Ganzes Werk herunterladen</label>
 		</languageKey>
 	</data>
 </T3locallang>

--- a/dlf/plugins/toolbox/tools/imagedownload/template.tmpl
+++ b/dlf/plugins/toolbox/tools/imagedownload/template.tmpl
@@ -1,0 +1,13 @@
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+<!-- ###TEMPLATE### -->
+<span class="tx-dlf-tools-imagedownload">###IMAGE_LEFT###</span>
+<span class="tx-dlf-tools-imagedownload">###IMAGE_RIGHT###</span>
+<!-- ###TEMPLATE### -->


### PR DESCRIPTION
This patch adds a new download tool for the toolbox plugin.

As sub-tools have no flexform configuration, the configuration of the
allowed fileGrps for download is put to toolbox flexform. As done in the
pageview plugin, the best found fileGrp will be used.

Two links will be generated in double mode with the translated labels
"Download left page (JPG)" and "Download right page (JPG)". In single
view mode the label is "Download single page (JPG)". The mime-type is
detected and appended to the label in case of JPG and TIFF.