### PR TITLE
Add explicit output format for CoreAdmin API

### DIFF
--- a/dlf/hooks/class.tx_dlf_em.php
+++ b/dlf/hooks/class.tx_dlf_em.php
@@ -65,7 +65,7 @@ class tx_dlf_em {
 		$path = (!empty($this->conf['solrPath']) ? trim($this->conf['solrPath'], '/').'/' : '');
 
 		// Build request URI.
-		$url = 'http://'.$host.':'.$port.'/'.$path.'admin/cores';
+		$url = 'http://'.$host.':'.$port.'/'.$path.'admin/cores?wt=xml';
 
 		$context = stream_context_create(array (
 			'http' => array (


### PR DESCRIPTION
Adding the parameter `wt=xml` to the request URL forces XML output from the CoreAdmin API and fixes #217.