### PR TITLE
fix #226 add suggest wizard with thumbnail preview to all plugin flexforms

### DIFF
--- a/dlf/plugins/audioplayer/flexform.xml
+++ b/dlf/plugins/audioplayer/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>

--- a/dlf/plugins/collection/flexform.xml
+++ b/dlf/plugins/collection/flexform.xml
@@ -32,6 +32,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -108,6 +114,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/feeds/flexform.xml
+++ b/dlf/plugins/feeds/flexform.xml
@@ -32,6 +32,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -108,6 +114,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/listview/flexform.xml
+++ b/dlf/plugins/listview/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -56,6 +62,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/metadata/flexform.xml
+++ b/dlf/plugins/metadata/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -67,6 +73,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/navigation/flexform.xml
+++ b/dlf/plugins/navigation/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -56,6 +62,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/newspaper/flexform.xml
+++ b/dlf/plugins/newspaper/flexform.xml
@@ -31,6 +31,12 @@
                                 <size>1</size>
                                 <maxitems>1</maxitems>
                                 <minitems>1</minitems>
+                                <show_thumbs>1</show_thumbs>
+                                <wizards>
+                                    <suggest>
+                                        <type>suggest</type>
+                                    </suggest>
+                                </wizards>
                             </config>
                         </TCEforms>
                     </pages>

--- a/dlf/plugins/oai/flexform.xml
+++ b/dlf/plugins/oai/flexform.xml
@@ -33,6 +33,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>

--- a/dlf/plugins/pagegrid/flexform.xml
+++ b/dlf/plugins/pagegrid/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -70,6 +76,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/pageview/flexform.xml
+++ b/dlf/plugins/pageview/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>

--- a/dlf/plugins/search/flexform.xml
+++ b/dlf/plugins/search/flexform.xml
@@ -33,6 +33,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+									<suggest>
+										<type>suggest</type>
+									</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -154,7 +160,7 @@
 							<config>
 								<type>select</type>
 								<items type="array"/>
-								<itemsProcFunc>tx_dlf_tceforms-&gt;itemsProcFunc_collectionList</itemsProcFunc>
+								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_collectionList</itemsProcFunc>
 								<size>5</size>
 								<autoSizeMax>15</autoSizeMax>
 								<maxitems>1024</maxitems>
@@ -225,6 +231,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+									<suggest>
+										<type>suggest</type>
+									</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/statistics/flexform.xml
+++ b/dlf/plugins/statistics/flexform.xml
@@ -32,6 +32,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>

--- a/dlf/plugins/toc/flexform.xml
+++ b/dlf/plugins/toc/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>
@@ -55,6 +61,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetPid>

--- a/dlf/plugins/toolbox/flexform.xml
+++ b/dlf/plugins/toolbox/flexform.xml
@@ -31,6 +31,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>1</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</pages>


### PR DESCRIPTION
This adds to all flexforms the suggest feature. This is used especially with targetPid and pages configuration.

The "show_thunbs" let you see a "thumbnail" and uid of the selected page. This is helpful, if you have several pages with the same name. Without the uid you have to open every time the page browser which might by slow.