### PR TITLE
fix #224 remove unused t3jquery.txt file

### DIFF
--- a/dlf/t3jquery.txt
+++ b/dlf/t3jquery.txt
@@ -1,1 +1,0 @@
-components=jQuery,Core,Position,Autocomplete,Resizable,Slider


### PR DESCRIPTION
Most work is already done in #234. Only the t3jquery configuration file still exists in the main root. This patch removes this file.