### PR TITLE
Add explicit xml output format for solr core creation request

### DIFF
--- a/dlf/hooks/class.tx_dlf_tcemain.php
+++ b/dlf/hooks/class.tx_dlf_tcemain.php
@@ -140,7 +140,7 @@ class tx_dlf_tcemain {
 
 					// Build request for adding new Solr core.
 					// @see http://wiki.apache.org/solr/CoreAdmin
-					$url = 'http://'.$host.':'.$port.'/'.$path.'admin/cores?action=CREATE&name=dlfCore'.$coreNumber.'&instanceDir=.&dataDir=dlfCore'.$coreNumber;
+					$url = 'http://'.$host.':'.$port.'/'.$path.'admin/cores?wt=xml&action=CREATE&name=dlfCore'.$coreNumber.'&instanceDir=.&dataDir=dlfCore'.$coreNumber;
 
 					$response = @simplexml_load_string(file_get_contents($url, FALSE, $context));
 


### PR DESCRIPTION
Issue #217 also affects the creation of a new solr core on a Solr 7 with default settings. Solution is the same.