### PR TITLE
add page wizard to targetBasket settings

### DIFF
--- a/dlf/plugins/basket/flexform.xml
+++ b/dlf/plugins/basket/flexform.xml
@@ -119,6 +119,12 @@
 									<size>1</size>
 									<maxitems>1</maxitems>
 									<minitems>1</minitems>
+									<show_thumbs>1</show_thumbs>
+									<wizards>
+											<suggest>
+													<type>suggest</type>
+											</suggest>
+									</wizards>
 								</config>
 						</TCEforms>
 					</targetBasket>

--- a/dlf/plugins/pageview/flexform.xml
+++ b/dlf/plugins/pageview/flexform.xml
@@ -135,6 +135,12 @@
 									<size>1</size>
 									<maxitems>1</maxitems>
 									<minitems>0</minitems>
+									<show_thumbs>1</show_thumbs>
+									<wizards>
+											<suggest>
+													<type>suggest</type>
+											</suggest>
+									</wizards>
 								</config>
 						</TCEforms>
 					</targetBasket>

--- a/dlf/plugins/toc/flexform.xml
+++ b/dlf/plugins/toc/flexform.xml
@@ -71,6 +71,12 @@
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+										<suggest>
+												<type>suggest</type>
+										</suggest>
+								</wizards>
 							</config>
 						</TCEforms>
 					</targetBasket>


### PR DESCRIPTION
We added recently the page wizard to all flexforms where you select a local page as target. The new targetBasket-setting doesn't have this wizard yet. This patch adds it to all three plugins.