### PR TITLE
Refactor and extend OAI Plugin

### DIFF
--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -120,6 +120,16 @@ return array (
                 'eval' => 'required,uniqueInPid',
             ),
         ),
+        'index_search' => array (
+            'exclude' => 1,
+            'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.index_search',
+            'config' => array (
+            'type' => 'text',
+                'cols' => 30,
+                'rows' => 5,
+                'eval' => '',
+            ),
+        ),
         'oai_name' => array (
             'exclude' => 1,
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.oai_name',
@@ -251,7 +261,7 @@ return array (
         '0' => array ('showitem' => '--div--;LLL:EXT:dlf/locallang.xml:tx_dlf_collections.tab1, label,--palette--;;1;;1-1-1, description,--palette--;;2;;2-2-2, --div--;LLL:EXT:dlf/locallang.xml:tx_dlf_collections.tab2, sys_language_uid;;;;1-1-1, l18n_parent, l18n_diffsource, --div--;LLL:EXT:dlf/locallang.xml:tx_dlf_collections.tab3, hidden;;;;1-1-1, fe_group;;;;2-2-2, status;;;;3-3-3, owner;;;;4-4-4, fe_cruser_id,--palette--;;3'),
     ),
     'palettes' => array (
-        '1' => array ('showitem' => 'index_name, --linebreak--, oai_name', 'canNotCollapse' => 1),
+        '1' => array ('showitem' => 'index_name, --linebreak--, index_search, --linebreak--, oai_name', 'canNotCollapse' => 1),
         '2' => array ('showitem' => 'thumbnail, priority', 'canNotCollapse' => 1),
         '3' => array ('showitem' => 'fe_admin_lock', 'canNotCollapse' => 1),
     ),

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -42,7 +42,7 @@ return array (
         'index_name' => array (
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_solrcores.index_name',
             'config' => array (
-                'type' => 'input',
+                'type' => 'none',
                 'size' => 30,
                 'max' => 255,
                 'eval' => 'alphanum,unique',

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -42,7 +42,7 @@ return array (
         'index_name' => array (
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_solrcores.index_name',
             'config' => array (
-                'type' => 'none',
+                'type' => 'input',
                 'size' => 30,
                 'max' => 255,
                 'eval' => 'alphanum,unique',

--- a/cli/class.tx_dlf_cli.php
+++ b/cli/class.tx_dlf_cli.php
@@ -89,7 +89,7 @@ class tx_dlf_cli extends \TYPO3\CMS\Core\Controller\CommandLineController {
                 }
 
                 // Get the document...
-                $doc =& tx_dlf_document::getInstance($this->cli_args['-doc'][0], $this->cli_args['-pid'][0], TRUE);
+                $doc = & tx_dlf_document::getInstance($this->cli_args['-doc'][0], $this->cli_args['-pid'][0], TRUE);
 
                 if ($doc->ready) {
 
@@ -170,7 +170,7 @@ class tx_dlf_cli extends \TYPO3\CMS\Core\Controller\CommandLineController {
                 while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
                     // Get the document...
-                    $doc =& tx_dlf_document::getInstance($resArray['uid'], $this->cli_args['-pid'][0], TRUE);
+                    $doc = & tx_dlf_document::getInstance($resArray['uid'], $this->cli_args['-pid'][0], TRUE);
 
                     if ($doc->ready) {
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -1526,7 +1526,7 @@ final class tx_dlf_document {
 
             if ($parentLocation != $this->location) {
 
-                $parentDoc =& tx_dlf_document::getInstance($parentLocation, $pid);
+                $parentDoc = & tx_dlf_document::getInstance($parentLocation, $pid);
 
                 if ($parentDoc->ready) {
 

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -101,7 +101,7 @@ class tx_dlf_indexing {
             // Handle multi-volume documents.
             if ($doc->parentId) {
 
-                $parent =& tx_dlf_document::getInstance($doc->parentId, 0, TRUE);
+                $parent = & tx_dlf_document::getInstance($doc->parentId, 0, TRUE);
 
                 if ($parent->ready) {
 
@@ -595,7 +595,7 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('purl', $metadata['purl'][0]);
 
-            $solrDoc->setField('location',$doc->location);
+            $solrDoc->setField('location', $doc->location);
 
             $solrDoc->setField('urn', $metadata['urn']);
 

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -591,6 +591,16 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('volume', $metadata['volume'][0], self::$fields['fieldboost']['volume']);
 
+            $solrDoc->setField('record_id', $metadata['record_id'][0]);
+
+            $solrDoc->setField('purl', $metadata['purl'][0]);
+
+            $solrDoc->setField('location',$doc->location);
+
+            $solrDoc->setField('urn', $metadata['urn']);
+
+            $solrDoc->setField('collection', $metadata['collection']);
+
             $autocomplete = array ();
 
             foreach ($metadata as $index_name => $data) {

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -530,6 +530,41 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
     }
 
     /**
+     * This removes elements at the given range from the list
+     *
+     * @access	public
+     *
+     * @param	integer		$position: Numeric position for start of range
+     *
+     * @param	integer		$length: Numeric position for length of range
+     *
+     * @return	array		The indizes of the removed elements
+     */
+    public function removeRange($position, $length) {
+
+        // Save parameter for logging purposes.
+        $_position = $position;
+
+        $position = intval($position);
+
+        if ($position < 0 || $position >= $this->count) {
+
+            if (TYPO3_DLOG) {
+
+                \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_list->remove('.$_position.')] Invalid position "'.$position.'" for element removing', $this->extKey, SYSLOG_SEVERITY_WARNING);
+            }
+
+            return;
+        }
+
+        $removed = array_splice($this->elements, $position, $length);
+
+        $this->count = count($this->elements);
+
+        return $removed;
+    }
+
+    /**
      * This clears the current list
      *
      * @access	public

--- a/common/class.tx_dlf_plugin.php
+++ b/common/class.tx_dlf_plugin.php
@@ -132,7 +132,7 @@ abstract class tx_dlf_plugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
             $pid = (!empty($this->conf['excludeOther']) ? intval($this->conf['pages']) : 0);
 
             // Get instance of tx_dlf_document.
-            $this->doc =& tx_dlf_document::getInstance($this->piVars['id'], $pid);
+            $this->doc = & tx_dlf_document::getInstance($this->piVars['id'], $pid);
 
             if (!$this->doc->ready) {
 

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -539,8 +539,7 @@ class tx_dlf_solr {
      *
      * @return	array       The Apache Solr Documents that were fetched
      */
-    public function search_raw($query = '', $parameters = array ())
-    {
+    public function search_raw($query = '', $parameters = array ()) {
         $solr_response = $this->service->search((string) $query, 0, $this->limit, array_merge($this->params, $parameters));
 
         $searchresult = array ();

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -539,11 +539,11 @@ class tx_dlf_solr {
      *
      * @return	array       The Apache Solr Documents that were fetched
      */
-    public function search_raw($query = '', $parameters = array())
+    public function search_raw($query = '', $parameters = array ())
     {
-        $solr_response = $this->service->search((string)$query, 0, $this->limit, array_merge($this->params, $parameters));
+        $solr_response = $this->service->search((string) $query, 0, $this->limit, array_merge($this->params, $parameters));
 
-        $searchresult = array();
+        $searchresult = array ();
 
         foreach ($solr_response->response->docs as $doc) {
             $searchresult[] = $doc;

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -136,7 +136,7 @@ class tx_dlf_solr {
     public static function escapeQueryKeepField($query, $pid) {
 
         // Is there a field query?
-        if (preg_match('/^[[:alnum:]]+_[tu][su]i:\(.*\)$/', $query)) {
+        if (preg_match('/^[[:alnum:]]+_[tu][su]i:\(?.*\)?$/', $query)) {
 
             // Get all indexed fields.
             $fields = array ();

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -531,6 +531,28 @@ class tx_dlf_solr {
     }
 
     /**
+     * Processes a search request and returns the raw Apache Solr Documents.
+     *
+     * @access	public
+     *
+     * @param	string		$query: The search query
+     *
+     * @return	array       The Apache Solr Documents that were fetched
+     */
+    public function search_raw($query = '', $parameters = array())
+    {
+        $solr_response = $this->service->search((string)$query, 0, $this->limit, array_merge($this->params, $parameters));
+
+        $searchresult = array();
+
+        foreach ($solr_response->response->docs as $doc) {
+            $searchresult[] = $doc;
+        }
+
+        return $searchresult;
+    }
+
+    /**
      * This returns $this->limit via __get()
      *
      * @access	protected

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -179,6 +179,7 @@ CREATE TABLE tx_dlf_collections (
     fe_group varchar(100) DEFAULT '' NOT NULL,
     label text NOT NULL,
     index_name tinytext NOT NULL,
+    index_search text NOT NULL,
     oai_name tinytext NOT NULL,
     description text NOT NULL,
     thumbnail text NOT NULL,

--- a/hooks/class.tx_dlf_doctype.php
+++ b/hooks/class.tx_dlf_doctype.php
@@ -161,7 +161,7 @@ class tx_dlf_doctype {
         if (!empty($this->piVars['id'])) {
 
             // Get instance of tx_dlf_document.
-            $this->doc =& tx_dlf_document::getInstance($this->piVars['id']);
+            $this->doc = & tx_dlf_document::getInstance($this->piVars['id']);
 
             if (!$this->doc->ready) {
 

--- a/hooks/class.tx_dlf_tcemain.php
+++ b/hooks/class.tx_dlf_tcemain.php
@@ -337,7 +337,7 @@ class tx_dlf_tcemain {
                             } else {
 
                                 // Reindex document.
-                                $doc =& tx_dlf_document::getInstance($id);
+                                $doc = & tx_dlf_document::getInstance($id);
 
                                 if ($doc->ready) {
 
@@ -422,7 +422,7 @@ class tx_dlf_tcemain {
                     case 'undelete':
 
                         // Reindex document.
-                        $doc =& tx_dlf_document::getInstance($id);
+                        $doc = & tx_dlf_document::getInstance($id);
 
                         if ($doc->ready) {
 

--- a/lib/ApacheSolr/conf/schema.xml
+++ b/lib/ApacheSolr/conf/schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
+contributor license agreements. See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.
 The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
@@ -126,6 +126,16 @@ limitations under the License.
 		<field name="autocomplete" type="autocomplete" indexed="true" stored="false" multiValued="true" />
 		<!-- Fulltext field for OCR results. -->
 		<field name="fulltext" type="fulltext" indexed="true" stored="true" multiValued="false" default="" />
+		<!-- Record ID of the document (required for OAI_DC output). -->
+		<field name="record_id" type="string" indexed="true" stored="true" required="true" multiValued="false" default="" />
+		<!-- Permanent URL of the document (required for EPICUR output). -->
+		<field name="purl" type="string" indexed="true" stored="true" required="true" multiValued="false" default="" />
+		<!-- URN of the Document (required for EPICUR output). -->
+		<field name="urn" type="string" indexed="true" stored="true" required="true" multiValued="false" default="" />
+		<!-- Location of METS XML (required for METS output). -->
+		<field name="location" type="string" indexed="true" stored="true" required="true" multiValued="false" default="" />
+		<!-- Associated collection(s) of the document. -->
+		<field name="collection" type="string" indexed="true" stored="true" required="true" multiValued="true" default="" />
 
 		<!--
 			The following dynamic fields define all possible field variants.

--- a/locallang.xml
+++ b/locallang.xml
@@ -102,6 +102,7 @@
 			<label index="tx_dlf_collections">Collections</label>
 			<label index="tx_dlf_collections.label">Display Label</label>
 			<label index="tx_dlf_collections.index_name">Index Name</label>
+			<label index="tx_dlf_collections.index_search">Define (virtual) collection via Solr Query</label>
 			<label index="tx_dlf_collections.oai_name">OAI Mapping</label>
 			<label index="tx_dlf_collections.description">Description</label>
 			<label index="tx_dlf_collections.thumbnail">Thumbnail</label>
@@ -220,6 +221,7 @@
 			<label index="update.copyIndexRelatedColumns">Copy index related columns...</label>
 			<label index="update.copyIndexRelatedColumnsOkay">...successfully completed!</label>
 			<label index="update.copyIndexRelatedColumnsNotOkay">...incomplete! The index related columns (tokenized, stored, indexed, boost, autocomplete) of table tx_dlf_metadata have to be copied manually.</label>
+
 		</languageKey>
 		<languageKey index="de" type="array">
 			<label index="tx_dlf_actionlog">Aktionsprotokoll</label>
@@ -310,6 +312,7 @@
 			<label index="tx_dlf_collections.label">Anzeigeform</label>
 			<label index="tx_dlf_collections.index_name">Index-Bezeichnung</label>
 			<label index="tx_dlf_collections.oai_name">OAI-Mapping</label>
+			<label index="tx_dlf_collections.index_search">(Virtuelle) Kollektion über Solr Anfrage definieren</label>
 			<label index="tx_dlf_collections.description">Beschreibung</label>
 			<label index="tx_dlf_collections.thumbnail">Vorschaubild</label>
 			<label index="tx_dlf_collections.priority">Priorität</label>

--- a/modules/indexing/index.php
+++ b/modules/indexing/index.php
@@ -162,7 +162,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
         $this->list->save();
 
         // Save document to database and index.
-        $doc =& tx_dlf_document::getInstance($uid, 0, TRUE);
+        $doc = & tx_dlf_document::getInstance($uid, 0, TRUE);
 
         if ($doc->ready) {
 
@@ -219,7 +219,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
                         && \TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl($this->data['id'])) {
 
                         // Save document to database and index.
-                        $doc =& tx_dlf_document::getInstance($this->data['id'], $this->id, TRUE);
+                        $doc = & tx_dlf_document::getInstance($this->data['id'], $this->id, TRUE);
 
                         if ($doc->ready) {
 

--- a/plugins/oai/class.tx_dlf_oai.php
+++ b/plugins/oai/class.tx_dlf_oai.php
@@ -19,1118 +19,1118 @@
  */
 class tx_dlf_oai extends tx_dlf_plugin {
 
-	public $scriptRelPath = 'plugins/oai/class.tx_dlf_oai.php';
-
-	/**
-	 * Did an error occur?
-	 *
-	 * @var	boolean
-	 * @access protected
-	 */
-	protected $error = FALSE;
-
-	/**
-	 * This holds the OAI DOM object
-	 *
-	 * @var	DOMDocument
-	 * @access protected
-	 */
-	protected $oai;
-
-	/**
-	 * This holds the configuration for all supported metadata prefixes
-	 *
-	 * @var	array
-	 * @access protected
-	 */
-	protected $formats = array (
-		'oai_dc' => array (
-			'schema' => 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
-			'namespace' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-			'requiredFields' => array ('record_id'),
-		),
-		'epicur' => array (
-			'schema' => 'http://www.persistent-identifier.de/xepicur/version1.0/xepicur.xsd',
-			'namespace' => 'urn:nbn:de:1111-2004033116',
-			'requiredFields' => array ('purl', 'urn'),
-		),
-		'mets' => array (
-			'schema' => 'http://www.loc.gov/standards/mets/version17/mets.v1-7.xsd',
-			'namespace' => 'http://www.loc.gov/METS/',
-			'requiredFields' => array ('location'),
-		)
-	);
-
-	/**
-	 * Delete expired resumption tokens
-	 *
-	 * @access	protected
-	 *
-	 * @return	void
-	 */
-	protected function deleteExpiredTokens() {
-
-		// Delete expired resumption tokens.
-		$result = $GLOBALS['TYPO3_DB']->exec_DELETEquery(
-			'tx_dlf_tokens',
-			'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.tstamp<'.intval($GLOBALS['EXEC_TIME'] - $this->conf['expired'])
-		);
-
-		if ($GLOBALS['TYPO3_DB']->sql_affected_rows() === -1) {
-			// Deletion failed.
-			$this->devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens',SYSLOG_SEVERITY_WARNING);
-		}
-	}
-
-	/**
-	 * Process error
-	 *
-	 * @access	protected
-	 *
-	 * @param	string		$type: Error type
-	 *
-	 * @return	DOMElement		XML node to add to the OAI response
-	 */
-	protected function error($type) {
-		$this->error = TRUE;
-
-		$error = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'error', htmlspecialchars($this->pi_getLL($type, $type, FALSE), ENT_NOQUOTES, 'UTF-8'));
-		$error->setAttribute('code', $type);
-
-		return $error;
-	}
-
-	/**
-	 * Load URL parameters
-	 *
-	 * @access	protected
-	 *
-	 * @return	void
-	 */
-	protected function getUrlParams() {
-
-		$allowedParams = array (
-			'verb',
-			'identifier',
-			'metadataPrefix',
-			'from',
-			'until',
-			'set',
-			'resumptionToken'
-		);
-
-		// Clear plugin variables.
-		$this->piVars = array ();
-
-		// Set only allowed parameters.
-		foreach ($allowedParams as $param) {
-			if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param)) {
-				$this->piVars[$param] = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param);
-			}
-		}
-	}
-
-	/**
-	 * Get unqualified Dublin Core data.
-	 * @see http://www.openarchives.org/OAI/openarchivesprotocol.html#dublincore
-	 *
-	 * @access	protected
-	 *
-	 * @param	array		$metadata: The metadata array
-	 *
-	 * @return	DOMElement		XML node to add to the OAI response
-	 */
-	protected function getDcData(array $metadata) {
+    public $scriptRelPath = 'plugins/oai/class.tx_dlf_oai.php';
+
+    /**
+     * Did an error occur?
+     *
+     * @var	boolean
+     * @access protected
+     */
+    protected $error = FALSE;
+
+    /**
+     * This holds the OAI DOM object
+     *
+     * @var	DOMDocument
+     * @access protected
+     */
+    protected $oai;
+
+    /**
+     * This holds the configuration for all supported metadata prefixes
+     *
+     * @var	array
+     * @access protected
+     */
+    protected $formats = array (
+        'oai_dc' => array (
+            'schema' => 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+            'namespace' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+            'requiredFields' => array ('record_id'),
+        ),
+        'epicur' => array (
+            'schema' => 'http://www.persistent-identifier.de/xepicur/version1.0/xepicur.xsd',
+            'namespace' => 'urn:nbn:de:1111-2004033116',
+            'requiredFields' => array ('purl', 'urn'),
+        ),
+        'mets' => array (
+            'schema' => 'http://www.loc.gov/standards/mets/version17/mets.v1-7.xsd',
+            'namespace' => 'http://www.loc.gov/METS/',
+            'requiredFields' => array ('location'),
+        )
+    );
+
+    /**
+     * Delete expired resumption tokens
+     *
+     * @access	protected
+     *
+     * @return	void
+     */
+    protected function deleteExpiredTokens() {
+
+        // Delete expired resumption tokens.
+        $result = $GLOBALS['TYPO3_DB']->exec_DELETEquery(
+            'tx_dlf_tokens',
+            'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.tstamp<'.intval($GLOBALS['EXEC_TIME'] - $this->conf['expired'])
+        );
+
+        if ($GLOBALS['TYPO3_DB']->sql_affected_rows() === -1) {
+            // Deletion failed.
+            $this->devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens',SYSLOG_SEVERITY_WARNING);
+        }
+    }
+
+    /**
+     * Process error
+     *
+     * @access	protected
+     *
+     * @param	string		$type: Error type
+     *
+     * @return	DOMElement		XML node to add to the OAI response
+     */
+    protected function error($type) {
+        $this->error = TRUE;
+
+        $error = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'error', htmlspecialchars($this->pi_getLL($type, $type, FALSE), ENT_NOQUOTES, 'UTF-8'));
+        $error->setAttribute('code', $type);
+
+        return $error;
+    }
+
+    /**
+     * Load URL parameters
+     *
+     * @access	protected
+     *
+     * @return	void
+     */
+    protected function getUrlParams() {
+
+        $allowedParams = array (
+            'verb',
+            'identifier',
+            'metadataPrefix',
+            'from',
+            'until',
+            'set',
+            'resumptionToken'
+        );
+
+        // Clear plugin variables.
+        $this->piVars = array ();
+
+        // Set only allowed parameters.
+        foreach ($allowedParams as $param) {
+            if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param)) {
+                $this->piVars[$param] = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param);
+            }
+        }
+    }
+
+    /**
+     * Get unqualified Dublin Core data.
+     * @see http://www.openarchives.org/OAI/openarchivesprotocol.html#dublincore
+     *
+     * @access	protected
+     *
+     * @param	array		$metadata: The metadata array
+     *
+     * @return	DOMElement		XML node to add to the OAI response
+     */
+    protected function getDcData(array $metadata) {
 
-		$oai_dc = $this->oai->createElementNS($this->formats['oai_dc']['namespace'], 'oai_dc:dc');
+        $oai_dc = $this->oai->createElementNS($this->formats['oai_dc']['namespace'], 'oai_dc:dc');
 
-		$oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:dc', 'http://purl.org/dc/elements/1.1/');
-		$oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-		$oai_dc->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['oai_dc']['namespace'].' '.$this->formats['oai_dc']['schema']);
+        $oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:dc', 'http://purl.org/dc/elements/1.1/');
+        $oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $oai_dc->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['oai_dc']['namespace'].' '.$this->formats['oai_dc']['schema']);
 
-		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['record_id'], ENT_NOQUOTES, 'UTF-8')));
+        $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['record_id'], ENT_NOQUOTES, 'UTF-8')));
 
-		if (!empty($metadata['purl'])) {
-			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8')));
-		}
+        if (!empty($metadata['purl'])) {
+            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8')));
+        }
 
-		if (!empty($metadata['urn'])) {
-			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8')));
-		}
+        if (!empty($metadata['urn'])) {
+            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8')));
+        }
 
-		if (!empty($metadata['title'])) {
-			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:title', htmlspecialchars($metadata['title'], ENT_NOQUOTES, 'UTF-8')));
-		}
+        if (!empty($metadata['title'])) {
+            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:title', htmlspecialchars($metadata['title'], ENT_NOQUOTES, 'UTF-8')));
+        }
 
-		if (!empty($metadata['author'])) {
-			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:creator', htmlspecialchars($metadata['author'], ENT_NOQUOTES, 'UTF-8')));
-		}
+        if (!empty($metadata['author'])) {
+            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:creator', htmlspecialchars($metadata['author'], ENT_NOQUOTES, 'UTF-8')));
+        }
 
-		if (!empty($metadata['year'])) {
-			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:date', htmlspecialchars($metadata['year'], ENT_NOQUOTES, 'UTF-8')));
-		}
+        if (!empty($metadata['year'])) {
+            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:date', htmlspecialchars($metadata['year'], ENT_NOQUOTES, 'UTF-8')));
+        }
 
-		if (!empty($metadata['place'])) {
-			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:coverage', htmlspecialchars($metadata['place'], ENT_NOQUOTES, 'UTF-8')));
-		}
+        if (!empty($metadata['place'])) {
+            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:coverage', htmlspecialchars($metadata['place'], ENT_NOQUOTES, 'UTF-8')));
+        }
 
-		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:format', 'application/mets+xml'));
-		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:type', 'Text'));
+        $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:format', 'application/mets+xml'));
+        $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:type', 'Text'));
 
-		if (!empty($metadata['partof'])) {
-			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'tx_dlf_documents.record_id',
-				'tx_dlf_documents',
-				'tx_dlf_documents.uid='.intval($metadata['partof']).tx_dlf_helper::whereClause('tx_dlf_documents'),
-				'',
-				'',
-				'1'
-			);
+        if (!empty($metadata['partof'])) {
+            $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                'tx_dlf_documents.record_id',
+                'tx_dlf_documents',
+                'tx_dlf_documents.uid='.intval($metadata['partof']).tx_dlf_helper::whereClause('tx_dlf_documents'),
+                '',
+                '',
+                '1'
+            );
 
-			if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-				$partof = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+            if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+                $partof = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-				$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:relation', htmlspecialchars($partof['record_id'], ENT_NOQUOTES, 'UTF-8')));
-			}
-		}
+                $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:relation', htmlspecialchars($partof['record_id'], ENT_NOQUOTES, 'UTF-8')));
+            }
+        }
 
-		return $oai_dc;
-	}
+        return $oai_dc;
+    }
 
-	/**
-	 * Get epicur data.
-	 * @see http://www.persistent-identifier.de/?link=210
-	 *
-	 * @access	protected
-	 *
-	 * @param	array		$metadata: The metadata array
-	 *
-	 * @return	DOMElement		XML node to add to the OAI response
-	 */
-	protected function getEpicurData(array $metadata) {
+    /**
+     * Get epicur data.
+     * @see http://www.persistent-identifier.de/?link=210
+     *
+     * @access	protected
+     *
+     * @param	array		$metadata: The metadata array
+     *
+     * @return	DOMElement		XML node to add to the OAI response
+     */
+    protected function getEpicurData(array $metadata) {
 
-		// Define all XML elements with or without qualified namespace.
-		if (empty($this->conf['unqualified_epicur'])) {
-			$epicur = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:epicur');
+        // Define all XML elements with or without qualified namespace.
+        if (empty($this->conf['unqualified_epicur'])) {
+            $epicur = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:epicur');
 
-			$admin = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:administrative_data');
+            $admin = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:administrative_data');
 
-			$delivery = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:delivery');
+            $delivery = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:delivery');
 
-			$update = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:update_status');
+            $update = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:update_status');
 
-			$transfer = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:transfer');
+            $transfer = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:transfer');
 
-			$format = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:format', 'text/html');
+            $format = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:format', 'text/html');
 
-			$record = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:record');
+            $record = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:record');
 
-			$identifier = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
+            $identifier = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
 
-			$resource = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:resource');
+            $resource = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:resource');
 
-			$ident = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
+            $ident = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
 
-		} else {
-			$epicur = $this->oai->createElement('epicur');
-			$epicur->setAttribute('xmlns', $this->formats['epicur']['namespace']);
+        } else {
+            $epicur = $this->oai->createElement('epicur');
+            $epicur->setAttribute('xmlns', $this->formats['epicur']['namespace']);
 
-			$admin = $this->oai->createElement('administrative_data');
+            $admin = $this->oai->createElement('administrative_data');
 
-			$delivery = $this->oai->createElement('delivery');
+            $delivery = $this->oai->createElement('delivery');
 
-			$update = $this->oai->createElement('update_status');
+            $update = $this->oai->createElement('update_status');
 
-			$transfer = $this->oai->createElement('transfer');
+            $transfer = $this->oai->createElement('transfer');
 
-			$format = $this->oai->createElement('format', 'text/html');
+            $format = $this->oai->createElement('format', 'text/html');
 
-			$record = $this->oai->createElement('record');
+            $record = $this->oai->createElement('record');
 
-			$identifier = $this->oai->createElement('identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
+            $identifier = $this->oai->createElement('identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
 
-			$resource = $this->oai->createElement('resource');
+            $resource = $this->oai->createElement('resource');
 
-			$ident = $this->oai->createElement('identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
-		}
+            $ident = $this->oai->createElement('identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
+        }
 
-		// Add attributes and build XML tree.
-		$epicur->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-		$epicur->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['epicur']['namespace'].' '.$this->formats['epicur']['schema']);
+        // Add attributes and build XML tree.
+        $epicur->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $epicur->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['epicur']['namespace'].' '.$this->formats['epicur']['schema']);
 
-		// Do we update an URN or register a new one?
-		if ($metadata['tstamp'] == $metadata['crdate']) {
-			$update->setAttribute('type', 'urn_new');
-		} else {
-			$update->setAttribute('type', 'url_update_general');
-		}
+        // Do we update an URN or register a new one?
+        if ($metadata['tstamp'] == $metadata['crdate']) {
+            $update->setAttribute('type', 'urn_new');
+        } else {
+            $update->setAttribute('type', 'url_update_general');
+        }
 
-		$delivery->appendChild($update);
+        $delivery->appendChild($update);
 
-		$transfer->setAttribute('type', 'http');
+        $transfer->setAttribute('type', 'http');
 
-		$delivery->appendChild($transfer);
+        $delivery->appendChild($transfer);
 
-		$admin->appendChild($delivery);
+        $admin->appendChild($delivery);
 
-		$epicur->appendChild($admin);
+        $epicur->appendChild($admin);
 
-		$identifier->setAttribute('scheme', 'urn:nbn:de');
+        $identifier->setAttribute('scheme', 'urn:nbn:de');
 
-		$record->appendChild($identifier);
+        $record->appendChild($identifier);
 
-		$ident->setAttribute('scheme', 'url');
-		$ident->setAttribute('type', 'frontpage');
-		$ident->setAttribute('role', 'primary');
+        $ident->setAttribute('scheme', 'url');
+        $ident->setAttribute('type', 'frontpage');
+        $ident->setAttribute('role', 'primary');
 
-		$resource->appendChild($ident);
+        $resource->appendChild($ident);
 
-		$format->setAttribute('scheme', 'imt');
+        $format->setAttribute('scheme', 'imt');
 
-		$resource->appendChild($format);
+        $resource->appendChild($format);
 
-		$record->appendChild($resource);
+        $record->appendChild($resource);
 
-		$epicur->appendChild($record);
+        $epicur->appendChild($record);
 
-		return $epicur;
-	}
+        return $epicur;
+    }
 
-	/**
-	 * Get METS data.
-	 * @see http://www.loc.gov/standards/mets/docs/mets.v1-7.html
-	 *
-	 * @access	protected
-	 *
-	 * @param	array		$metadata: The metadata array
-	 *
-	 * @return	DOMElement		XML node to add to the OAI response
-	 */
-	protected function getMetsData(array $metadata) {
+    /**
+     * Get METS data.
+     * @see http://www.loc.gov/standards/mets/docs/mets.v1-7.html
+     *
+     * @access	protected
+     *
+     * @param	array		$metadata: The metadata array
+     *
+     * @return	DOMElement		XML node to add to the OAI response
+     */
+    protected function getMetsData(array $metadata) {
 
-		$mets = NULL;
+        $mets = NULL;
 
-		// Load METS file.
-		$xml = new DOMDocument();
+        // Load METS file.
+        $xml = new DOMDocument();
 
-		if ($xml->load($metadata['location'])) {
-			// Get root element.
-			$root = $xml->getElementsByTagNameNS($this->formats['mets']['namespace'], 'mets');
+        if ($xml->load($metadata['location'])) {
+            // Get root element.
+            $root = $xml->getElementsByTagNameNS($this->formats['mets']['namespace'], 'mets');
 
-			if ($root->item(0) instanceof DOMNode) {
-				// Import node into DOMDocument.
-				$mets = $this->oai->importNode($root->item(0), TRUE);
-			} else {
-				   $this->devLog('[tx_dlf_oai->getMetsData([data])] No METS part found in document with location "'.$metadata['location'].'"', SYSLOG_SEVERITY_ERROR, $metadata);
-			}
-		} else {
-			$this->devLog('[tx_dlf_oai->getMetsData([data])] Could not load XML file from "'.$metadata['location'].'"', SYSLOG_SEVERITY_ERROR, $metadata);
-		}
+            if ($root->item(0) instanceof DOMNode) {
+                // Import node into DOMDocument.
+                $mets = $this->oai->importNode($root->item(0), TRUE);
+            } else {
+                    $this->devLog('[tx_dlf_oai->getMetsData([data])] No METS part found in document with location "'.$metadata['location'].'"', SYSLOG_SEVERITY_ERROR, $metadata);
+            }
+        } else {
+            $this->devLog('[tx_dlf_oai->getMetsData([data])] Could not load XML file from "'.$metadata['location'].'"', SYSLOG_SEVERITY_ERROR, $metadata);
+        }
 
-		if ($mets === NULL) {
-			$mets = $this->oai->createElementNS('http://kitodo.org/', 'kitodo:error', htmlspecialchars($this->pi_getLL('error', 'Error!', FALSE), ENT_NOQUOTES, 'UTF-8'));
-		}
+        if ($mets === NULL) {
+            $mets = $this->oai->createElementNS('http://kitodo.org/', 'kitodo:error', htmlspecialchars($this->pi_getLL('error', 'Error!', FALSE), ENT_NOQUOTES, 'UTF-8'));
+        }
 
-		return $mets;
-	}
+        return $mets;
+    }
 
-	/**
-	 * The main method of the PlugIn
-	 *
-	 * @access	public
-	 *
-	 * @param	string		$content: The PlugIn content
-	 * @param	array		$conf: The PlugIn configuration
-	 *
-	 * @return	void
-	 */
-	public function main($content, $conf) {
+    /**
+     * The main method of the PlugIn
+     *
+     * @access	public
+     *
+     * @param	string		$content: The PlugIn content
+     * @param	array		$conf: The PlugIn configuration
+     *
+     * @return	void
+     */
+    public function main($content, $conf) {
 
-		// Initialize plugin.
-		$this->init($conf);
+        // Initialize plugin.
+        $this->init($conf);
 
-		// Turn cache off.
-		$this->setCache(FALSE);
+        // Turn cache off.
+        $this->setCache(FALSE);
 
-		// Get GET and POST variables.
-		$this->getUrlParams();
+        // Get GET and POST variables.
+        $this->getUrlParams();
 
-		// Delete expired resumption tokens.
-		$this->deleteExpiredTokens();
+        // Delete expired resumption tokens.
+        $this->deleteExpiredTokens();
 
-		// Create XML document.
-		$this->oai = new DOMDocument('1.0', 'UTF-8');
+        // Create XML document.
+        $this->oai = new DOMDocument('1.0', 'UTF-8');
 
-		// Add processing instruction (aka XSL stylesheet).
-		if (!empty($this->conf['stylesheet'])) {
-			// Resolve "EXT:" prefix in file path.
-			if (substr($this->conf['stylesheet'], 0, 4) == 'EXT:') {
+        // Add processing instruction (aka XSL stylesheet).
+        if (!empty($this->conf['stylesheet'])) {
+            // Resolve "EXT:" prefix in file path.
+            if (substr($this->conf['stylesheet'], 0, 4) == 'EXT:') {
 
-				list ($extKey, $filePath) = explode('/', substr($this->conf['stylesheet'], 4), 2);
+                list ($extKey, $filePath) = explode('/', substr($this->conf['stylesheet'], 4), 2);
 
-				if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
-					$this->conf['stylesheet'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($extKey).$filePath;
-				}
-			}
+                if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
+                    $this->conf['stylesheet'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($extKey).$filePath;
+                }
+            }
 
-			$stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->conf['stylesheet']);
+            $stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->conf['stylesheet']);
 
-		} else {
-			// Use default stylesheet if no custom stylesheet is given.
-			$stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
-		}
+        } else {
+            // Use default stylesheet if no custom stylesheet is given.
+            $stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
+        }
 
-		$this->oai->appendChild($this->oai->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="'.htmlspecialchars($stylesheet, ENT_NOQUOTES, 'UTF-8').'"'));
+        $this->oai->appendChild($this->oai->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="'.htmlspecialchars($stylesheet, ENT_NOQUOTES, 'UTF-8').'"'));
 
-		// Create root element.
-		$root = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'OAI-PMH');
+        // Create root element.
+        $root = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'OAI-PMH');
 
-		$root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-		$root->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', 'http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd');
+        $root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $root->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', 'http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd');
 
-		// Add response date.
-		$root->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'responseDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'])));
+        // Add response date.
+        $root->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'responseDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'])));
 
-		// Get response data.
-		switch ($this->piVars['verb']) {
-			case 'GetRecord':
-				$response = $this->verbGetRecord();
-				break;
+        // Get response data.
+        switch ($this->piVars['verb']) {
+            case 'GetRecord':
+                $response = $this->verbGetRecord();
+                break;
 
-			case 'Identify':
-				$response = $this->verbIdentify();
-				break;
+            case 'Identify':
+                $response = $this->verbIdentify();
+                break;
 
-			case 'ListIdentifiers':
-				$response = $this->verbListIdentifiers();
-				break;
+            case 'ListIdentifiers':
+                $response = $this->verbListIdentifiers();
+                break;
 
-			case 'ListMetadataFormats':
-				$response = $this->verbListMetadataFormats();
-				break;
+            case 'ListMetadataFormats':
+                $response = $this->verbListMetadataFormats();
+                break;
 
-			case 'ListRecords':
-				$response = $this->verbListRecords();
-				break;
+            case 'ListRecords':
+                $response = $this->verbListRecords();
+                break;
 
-			case 'ListSets':
-				$response = $this->verbListSets();
-				break;
+            case 'ListSets':
+                $response = $this->verbListSets();
+                break;
 
-			default:
-				$response = $this->error('badVerb');
-		}
+            default:
+                $response = $this->error('badVerb');
+        }
 
-		// Add request.
-		$linkConf = array (
-			'parameter' => $GLOBALS['TSFE']->id,
-			'forceAbsoluteUrl' => 1
-		);
+        // Add request.
+        $linkConf = array (
+            'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => 1
+        );
 
-		$request = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'request', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8'));
+        $request = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'request', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8'));
 
-		if (!$this->error) {
-			foreach ($this->piVars as $key => $value) {
-				$request->setAttribute($key, htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8'));
-			}
-		}
+        if (!$this->error) {
+            foreach ($this->piVars as $key => $value) {
+                $request->setAttribute($key, htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8'));
+            }
+        }
 
-		$root->appendChild($request);
-		$root->appendChild($response);
+        $root->appendChild($request);
+        $root->appendChild($response);
 
-		$this->oai->appendChild($root);
+        $this->oai->appendChild($root);
 
-		$content = $this->oai->saveXML();
+        $content = $this->oai->saveXML();
 
-		// Clean output buffer.
-		\TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
+        // Clean output buffer.
+        \TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
 
-		// Send headers.
-		header('HTTP/1.1 200 OK');
-		header('Cache-Control: no-cache');
-		header('Content-Length: '.strlen($content));
-		header('Content-Type: text/xml; charset=utf-8');
-		header('Date: '.date('r', $GLOBALS['EXEC_TIME']));
-		header('Expires: '.date('r', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
+        // Send headers.
+        header('HTTP/1.1 200 OK');
+        header('Cache-Control: no-cache');
+        header('Content-Length: '.strlen($content));
+        header('Content-Type: text/xml; charset=utf-8');
+        header('Date: '.date('r', $GLOBALS['EXEC_TIME']));
+        header('Expires: '.date('r', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
 
-		echo $content;
+        echo $content;
 
-		// Flush output buffer and end script processing.
-		ob_end_flush();
+        // Flush output buffer and end script processing.
+        ob_end_flush();
 
-		exit;
-	}
+        exit;
+    }
 
-	/**
-	 * Continue with resumption token
-	 *
-	 * @access	protected
-	 *
-	 * @return	string		Substitution for subpart "###RESPONSE###"
-	 */
-	protected function resume() {
-		// Get resumption token.
-		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'tx_dlf_tokens.options AS options',
-			'tx_dlf_tokens',
-			'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.token='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['resumptionToken'], 'tx_dlf_tokens'),
-			'',
-			'',
-			'1'
-		);
+    /**
+     * Continue with resumption token
+     *
+     * @access	protected
+     *
+     * @return	string		Substitution for subpart "###RESPONSE###"
+     */
+    protected function resume() {
+        // Get resumption token.
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_tokens.options AS options',
+            'tx_dlf_tokens',
+            'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.token='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['resumptionToken'], 'tx_dlf_tokens'),
+            '',
+            '',
+            '1'
+        );
 
-		if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-			// No resumption token found or resumption token expired.
-			return $this->error('badResumptionToken');
-		}
+        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+            // No resumption token found or resumption token expired.
+            return $this->error('badResumptionToken');
+        }
 
-		$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+        $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-		$resultSet = unserialize($resArray['options']);
+        $resultSet = unserialize($resArray['options']);
 
-		return $this->generateOutputForDocumentList($resultSet);
+        return $this->generateOutputForDocumentList($resultSet);
 
-	}
+    }
 
-	/**
-	 * Process verb "GetRecord"
-	 *
-	 * @access	protected
-	 *
-	 * @return	string		Substitution for subpart "###RESPONSE###"
-	 */
-	protected function verbGetRecord() {
+    /**
+     * Process verb "GetRecord"
+     *
+     * @access	protected
+     *
+     * @return	string		Substitution for subpart "###RESPONSE###"
+     */
+    protected function verbGetRecord() {
 
-		if (count($this->piVars) != 3 || empty($this->piVars['metadataPrefix']) || empty($this->piVars['identifier'])) {
-			return $this->error('badArgument');
-		}
+        if (count($this->piVars) != 3 || empty($this->piVars['metadataPrefix']) || empty($this->piVars['identifier'])) {
+            return $this->error('badArgument');
+        }
 
-		if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
-			return $this->error('cannotDisseminateFormat');
-		}
+        if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
+            return $this->error('cannotDisseminateFormat');
+        }
 
-		$where = '';
+        $where = '';
 
-		if (!$this->conf['show_userdefined']) {
-			$where .= ' AND tx_dlf_collections.fe_cruser_id=0';
-		}
+        if (!$this->conf['show_userdefined']) {
+            $where .= ' AND tx_dlf_collections.fe_cruser_id=0';
+        }
 
-		$record = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-			'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
-			'tx_dlf_documents',
-			'tx_dlf_relations',
-			'tx_dlf_collections',
-			'AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents').' AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-			'tx_dlf_documents.uid',
-			'tx_dlf_documents.tstamp',
-			'1'
-		);
+        $record = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
+            'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
+            'tx_dlf_documents',
+            'tx_dlf_relations',
+            'tx_dlf_collections',
+            'AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents').' AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_documents.uid',
+            'tx_dlf_documents.tstamp',
+            '1'
+        );
 
-		if (!$GLOBALS['TYPO3_DB']->sql_num_rows($record)) {
-			return $this->error('idDoesNotExist');
-		}
+        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($record)) {
+            return $this->error('idDoesNotExist');
+        }
 
-		$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($record);
+        $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($record);
 
-		// Check for required fields.
-		foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
-			if (empty($resArray[$required])) {
-				return $this->error('cannotDisseminateFormat');
-			}
-		}
+        // Check for required fields.
+        foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
+            if (empty($resArray[$required])) {
+                return $this->error('cannotDisseminateFormat');
+            }
+        }
 
-		$GetRecord = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'GetRecord');
+        $GetRecord = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'GetRecord');
 
-		$recordNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
+        $recordNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
 
-		$headerNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
-		$headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
-		$headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
+        $headerNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
+        $headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
+        $headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
 
-		// Handle deleted documents.
-		// TODO: Use TYPO3 API functions here!
-		if ($resArray['deleted'] || $resArray['hidden']) {
-			$headerNode->setAttribute('status', 'deleted');
+        // Handle deleted documents.
+        // TODO: Use TYPO3 API functions here!
+        if ($resArray['deleted'] || $resArray['hidden']) {
+            $headerNode->setAttribute('status', 'deleted');
 
-			$recordNode->appendChild($headerNode);
+            $recordNode->appendChild($headerNode);
 
-		} else {
-			foreach (explode(' ', $resArray['collections']) as $spec) {
-				$headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
-			}
+        } else {
+            foreach (explode(' ', $resArray['collections']) as $spec) {
+                $headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
+            }
 
-			$recordNode->appendChild($headerNode);
+            $recordNode->appendChild($headerNode);
 
-			$metadataNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
+            $metadataNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
 
-			switch ($this->piVars['metadataPrefix']) {
-				case 'oai_dc':
-					$metadataNode->appendChild($this->getDcData($resArray));
-					break;
+            switch ($this->piVars['metadataPrefix']) {
+                case 'oai_dc':
+                    $metadataNode->appendChild($this->getDcData($resArray));
+                    break;
 
-				case 'epicur':
-					$metadataNode->appendChild($this->getEpicurData($resArray));
-					break;
+                case 'epicur':
+                    $metadataNode->appendChild($this->getEpicurData($resArray));
+                    break;
 
-				case 'mets':
-					$metadataNode->appendChild($this->getMetsData($resArray));
-					break;
-			}
-
-			$recordNode->appendChild($metadataNode);
-		}
-
-		$GetRecord->appendChild($recordNode);
-
-		return $GetRecord;
-	}
-
-	/**
-	 * Process verb "Identify"
-	 *
-	 * @access	protected
-	 *
-	 * @return	DOMElement		XML node to add to the OAI response
-	 */
-	protected function verbIdentify() {
-
-		// Check for invalid arguments.
-		if (count($this->piVars) > 1) {
-			return $this->error('badArgument');
-		}
-
-		// Get repository name and administrative contact.
-		// Use default values for an installation with incomplete plugin configuration.
-
-		$adminEmail = 'unknown@example.org';
-		$repositoryName = 'Kitodo.Presentation OAI-PMH interface (incomplete configuration)';
-
-		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'tx_dlf_libraries.oai_label AS oai_label,tx_dlf_libraries.contact AS contact',
-			'tx_dlf_libraries',
-			'tx_dlf_libraries.pid='.intval($this->conf['pages']).' AND tx_dlf_libraries.uid='.intval($this->conf['library']).tx_dlf_helper::whereClause('tx_dlf_libraries'),
-			'',
-			'',
-			''
-		);
-
-		if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-			$adminEmail = htmlspecialchars(trim(str_replace('mailto:', '', $resArray['contact'])), ENT_NOQUOTES);
-			$repositoryName = htmlspecialchars($resArray['oai_label'], ENT_NOQUOTES);
-
-		} else {
-			$this->devLog('[tx_dlf_oai->verbIdentify()] Incomplete plugin configuration', SYSLOG_SEVERITY_NOTICE);
-		}
-
-		// Get earliest datestamp. Use a default value if that fails.
-
-		$earliestDatestamp = '0000-00-00T00:00:00Z';
-
-		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'tx_dlf_documents.tstamp AS tstamp',
-			'tx_dlf_documents',
-			'tx_dlf_documents.pid=' . intval($this->conf['pages']),
-			'',
-			'tx_dlf_documents.tstamp ASC',
-			'1'
-		);
-
-		if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-			list ($timestamp) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
-			$earliestDatestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
-		} else {
-			$this->devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "' . $this->conf['pages'] . '"',SYSLOG_SEVERITY_NOTICE);
-		}
-
-		$linkConf = array (
-			'parameter' => $GLOBALS['TSFE']->id,
-			'forceAbsoluteUrl' => 1
-		);
-		$baseURL = htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES);
-
-		// Add identification node.
-		$Identify = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'Identify');
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'repositoryName', $repositoryName));
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','baseURL', $baseURL));
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','protocolVersion', '2.0'));
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','adminEmail', $adminEmail));
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','earliestDatestamp', $earliestDatestamp));
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','deletedRecord', 'transient'));
-		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','granularity', 'YYYY-MM-DDThh:mm:ssZ'));
-
-		return $Identify;
-	}
-
-	/**
-	 * Process verb "ListIdentifiers"
-	 *
-	 * @access	protected
-	 *
-	 * @return	string		Substitution for subpart "###RESPONSE###"
-	 */
-	protected function verbListIdentifiers() {
-
-		// If we have a resumption token we can continue our work
-		if (!empty($this->piVars['resumptionToken'])) {
-			// "resumptionToken" is an exclusive argument.
-			if (count($this->piVars) > 2) {
-				return $this->error('badArgument');
-			} else {
-				return $this->resume();
-			}
-		}
-
-		// "metadataPrefix" is required and "identifier" is not allowed.
-		if (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
-			return $this->error('badArgument');
-		}
-
-		if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
-			return $this->error('cannotDisseminateFormat');
-		}
-
-		try {
-			$documentSet = $this->fetchDocumentUIDs();
-		} catch (Exception $exception) {
-			return $this->error($exception->getMessage());
-		}
-
-		$resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
-
-		$resultSet->reset();
-		$resultSet->add($documentSet);
-		$resultSet->metadata = array (
-			'completeListSize' => count($documentSet),
-			'metadataPrefix' => $this->piVars['metadataPrefix'],
-		);
-
-		return $this->generateOutputForDocumentList($resultSet);
-
-	}
-
-	/**
-	 * Process verb "ListMetadataFormats"
-	 *
-	 * @access	protected
-	 *
-	 * @return	DOMElement		XML node to add to the OAI response
-	 */
-	protected function verbListMetadataFormats() {
-
-		$resArray = array ();
-
-		// Check for invalid arguments.
-		if (count($this->piVars) > 1) {
-			if (empty($this->piVars['identifier']) || count($this->piVars) > 2) {
-				return $this->error('badArgument');
-			}
-
-			// Check given identifier.
-			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'tx_dlf_documents.*',
-				'tx_dlf_documents',
-				'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents'),
-				'',
-				'',
-				'1'
-			);
-
-			if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-				return $this->error('idDoesNotExist');
-			}
-
-			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-		}
-
-		// Add metadata formats node.
-		$ListMetadaFormats = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListMetadataFormats');
-
-		foreach ($this->formats as $prefix => $details) {
-			if (!empty($resArray)) {
-				foreach ($details['requiredFields'] as $required) {
-					if (empty($resArray[$required])) {
-						// Skip metadata formats whose requirements are not met.
-						continue 2;
-					}
-				}
-			}
-
-			// Add format node.
-			$format = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataFormat');
-
-			$format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataPrefix', htmlspecialchars($prefix, ENT_NOQUOTES, 'UTF-8')));
-			$format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'schema', htmlspecialchars($details['schema'], ENT_NOQUOTES, 'UTF-8')));
-			$format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataNamespace', htmlspecialchars($details['namespace'], ENT_NOQUOTES, 'UTF-8')));
-
-			$ListMetadaFormats->appendChild($format);
-		}
-
-		return $ListMetadaFormats;
-	}
-
-	/**
-	 * Process verb "ListRecords"
-	 *
-	 * @access	protected
-	 *
-	 * @return	string		Substitution for subpart "###RESPONSE###"
-	 */
-	protected function verbListRecords() {
-
-		// Check for invalid arguments.
-		if (!empty($this->piVars['resumptionToken'])) {
-			// "resumptionToken" is an exclusive argument.
-			if (count($this->piVars) > 2) {
-				return $this->error('badArgument');
-			} else {
-				return $this->resume();
-			}
-
-		}
-
-		if (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
-			// "metadataPrefix" is required and "identifier" is not allowed.
-			return $this->error('badArgument');
-		}
-
-		// Check "metadataPrefix" for valid value.
-		if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
-			return $this->error('cannotDisseminateFormat');
-		}
-
-		try {
-			$documentSet = $this->fetchDocumentUIDs();
-		} catch (Exception $exception) {
-			return $this->error($exception->getMessage());
-		}
-
-		$resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
-
-		$resultSet->reset();
-		$resultSet->add($documentSet);
-		$resultSet->metadata = array (
-			'completeListSize' => count($documentSet),
-			'metadataPrefix' => $this->piVars['metadataPrefix'],
-		);
-
-		return $this->generateOutputForDocumentList($resultSet);
-	}
-
-	/**
-	 * Process verb "ListSets"
-	 *
-	 * @access	protected
-	 *
-	 * @return	string		Substitution for subpart "###RESPONSE###"
-	 */
-	protected function verbListSets() {
-
-		// Check for invalid arguments.
-		if (count($this->piVars) > 1) {
-			if (!empty($this->piVars['resumptionToken'])) {
-				return $this->error('badResumptionToken');
-			} else {
-				return $this->error('badArgument');
-			}
-		}
-
-		$where = '';
-
-		if (!$this->conf['show_userdefined']) {
-			$where = ' AND tx_dlf_collections.fe_cruser_id=0';
-		}
-
-		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-			'tx_dlf_collections.oai_name AS oai_name,tx_dlf_collections.label AS label',
-			'tx_dlf_collections',
-			'tx_dlf_collections.sys_language_uid IN (-1,0) AND NOT tx_dlf_collections.oai_name=\'\' AND tx_dlf_collections.pid='.intval($this->conf['pages']).$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-			'tx_dlf_collections.oai_name',
-			'tx_dlf_collections.oai_name',
-			''
-		);
-
-		if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-			return $this->error('noSetHierarchy');
-		}
-
-		$ListSets = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListSets');
-
-		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-			$set = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'set');
-
-			$set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($resArray['oai_name'], ENT_NOQUOTES, 'UTF-8')));
-			$set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setName', htmlspecialchars($resArray['label'], ENT_NOQUOTES, 'UTF-8')));
-
-			$ListSets->appendChild($set);
-		}
-
-		return $ListSets;
-	}
-
-
-
-	/**
-	 * @return array
-	 * @throws Exception
-	 */
-	private function fetchDocumentUIDs()
-	{
-		$solr_query = '';
-
-		if (!$this->conf['show_userdefined']) {
-			$where = ' AND tx_dlf_collections.fe_cruser_id=0';
-		}
-
-		// Check "set" for valid value.
-		if (!empty($this->piVars['set'])) {
-
-			// For SOLR we need the index_name of the collection,
-			// For DB Query we need the UID of the collection
-			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-				'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.uid AS uid, tx_dlf_collections.index_search as index_query ',
-				'tx_dlf_collections',
-				'tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.oai_name=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'],
-					'tx_dlf_collections') . $where . tx_dlf_helper::whereClause('tx_dlf_collections'),
-				'',
-				'',
-				'1'
-			);
-
-			if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-				throw new Exception('noSetHierarchy');
-			}
-
-			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-			if($resArray['index_query'] != "") {
-				$solr_query .= '(' . $resArray['index_query'] . ')';
-			} else {
-				$solr_query .= 'collection:' . '"' . $resArray['index_name'] . '"';
-			}
-
-		} else {
-			// If no set is specified we have to query for all collections
-			$solr_query .= 'collection:* NOT collection:""';
-
-		}
-
-		// Check for required fields.
-		foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
-			$solr_query .= ' NOT ' . $required . ':""';
-		}
-
-		$from = "*";
-		// Check "from" for valid value.
-		if (!empty($this->piVars['from'])) {
-
-			// Is valid format?
-			if (is_array($date_array = strptime($this->piVars['from'],
-					'%Y-%m-%dT%H:%M:%SZ')) || is_array($date_array = strptime($this->piVars['from'], '%Y-%m-%d'))) {
-
-				$timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
-					$date_array['tm_mday'], $date_array['tm_year'] + 1900);
-
-			   $from = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) .'.000Z';
-
-			} else {
-				throw new Exception('badArgument');
-			}
-		}
-
-		$until = "*";
-		// Check "until" for valid value.
-		if (!empty($this->piVars['until'])) {
-
-			// Is valid format?
-			if (is_array($date_array = strptime($this->piVars['until'],
-					'%Y-%m-%dT%H:%M:%SZ')) || is_array($date_array = strptime($this->piVars['until'], '%Y-%m-%d'))) {
-
-				$timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
-					$date_array['tm_mday'], $date_array['tm_year'] + 1900);
-
-				$until = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) . '.999Z';
-
-				if ($from != "*" && $from > $until) {
-					throw new Exception('badArgument');
-				}
-
-			} else {
-				throw new Exception('badArgument');
-			}
-		}
-
-		// Check "from" and "until" for same granularity.
-		if (!empty($this->piVars['from']) && !empty($this->piVars['until'])) {
-			if (strlen($this->piVars['from']) != strlen($this->piVars['until'])) {
-				throw new Exception('badArgument');
-			}
-		}
-
-		$solr_query .= ' AND timestamp:[' . $from . ' TO ' . $until .']';
-
-		$documentSet = array();
-
-		$solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
-
-		// We only care about the UID in the results and want them sorted
-		$parameters = array("fl" => "uid", "sort" => "uid asc");
-
-		$result = $solr->search_raw($solr_query, $parameters);
-
-		if (empty($result)) {
-			throw new Exception('noRecordsMatch');
-		}
-
-		foreach ($result as $doc) {
-			$documentSet[] = $doc->uid;
-		}
-
-		return $documentSet;
-	}
-
-	/**
-	 * @param tx_dlf_list $documentListSet
-	 * @return DOMElement
-	 */
-	private function generateOutputForDocumentList($documentListSet) {
-
-		 $documentsToProcess = $documentListSet->removeRange(0, intval($this->conf['limit']));
-		 $verb = $this->piVars['verb'];
-
-		$documents = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-			'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
-			'tx_dlf_documents',
-			'tx_dlf_relations',
-			'tx_dlf_collections',
-			'AND tx_dlf_documents.uid IN (' . implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($documentsToProcess)) . ') AND tx_dlf_documents.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_relations.ident=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations') . tx_dlf_helper::whereClause('tx_dlf_collections'),
-			'tx_dlf_documents.uid',
-			'tx_dlf_documents.tstamp',
-			$this->conf['limit']
-		);
-
-		$output = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $verb);
-
-		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
-			// Add header node.
-			$header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
-
-			$header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
-			$header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
-
-			// Check if document is deleted or hidden.
-			// TODO: Use TYPO3 API functions here!
-			if ($resArray['deleted'] || $resArray['hidden']) {
-				// Add "deleted" status.
-				$header->setAttribute('status', 'deleted');
-
-				if ($verb == 'ListRecords') {
-					// Add record node.
-					$record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
-
-					$record->appendChild($header);
-					$output->appendChild($record);
-
-				} elseif ($verb == 'ListIdentifiers') {
-					$output->appendChild($header);
-				}
-
-			} else {
-				// Add sets.
-				foreach (explode(' ', $resArray['collections']) as $spec) {
-					$header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
-				}
-
-				if ($verb == 'ListRecords') {
-					// Add record node.
-					$record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
-
-					$record->appendChild($header);
-
-					// Add metadata node.
-					$metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
-
-					$metadataPrefix = $this->piVars['metadataPrefix'];
-					if(!$metadataPrefix) {
-						// If we resume an action the metadataPrefix is stored with the documentSet
-						$metadataPrefix = $documentListSet->metadata['metadataPrefix'];
-					}
-
-					switch ($metadataPrefix) {
-						case 'oai_dc':
-							$metadata->appendChild($this->getDcData($resArray));
-							break;
-
-						case 'epicur':
-							$metadata->appendChild($this->getEpicurData($resArray));
-							break;
-
-						case 'mets':
-							$metadata->appendChild($this->getMetsData($resArray));
-							break;
-					}
-
-					$record->appendChild($metadata);
-					$output->appendChild($record);
-
-				} elseif ($verb == 'ListIdentifiers') {
-					$output->appendChild($header);
-				}
-			}
-		}
-
-		$output->appendChild($this->generateResumptionTokenForDocumentListSet($documentListSet));
-
-		return $output;
-	}
-
-	/**
-	 * @param tx_dlf_list $documentListSet
-	 * @return DOMElement
-	 */
-	private function generateResumptionTokenForDocumentListSet($documentListSet)
-	{
-		$resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
-
-		if ($documentListSet->count() != 0) {
-
-			$token = uniqid();
-
-			$GLOBALS['TYPO3_DB']->exec_INSERTquery(
-				'tx_dlf_tokens',
-				array(
-					'tstamp' => $GLOBALS['EXEC_TIME'],
-					'token' => $token,
-					'options' => serialize($documentListSet),
-					'ident' => 'oai',
-				)
-			);
-
-			if($GLOBALS['TYPO3_DB']->sql_affected_rows() == 1) {
-				$resumptionToken->setAttribute('resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
-			} else {
-				$this->devLog('[tx_dlf_oai->verb'. $this->piVars['verb'] .'()] Could not create resumption token', SYSLOG_SEVERITY_ERROR);
-			}
-		}
-
-		$resumptionToken->setAttribute('cursor', intval($documentListSet->metadata['completeListSize']) - count($documentListSet));
-		$resumptionToken->setAttribute('completeListSize',	$documentListSet->metadata['completeListSize']);
-		$resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
-
-		return $resumptionToken;
-	}
-
-	private function devLog($message, $severity, $data = null) {
-		if (TYPO3_DLOG) {
-			\TYPO3\CMS\Core\Utility\GeneralUtility::devLog($message, $this->extKey, $severity, $data);
-		}
-	}
+                case 'mets':
+                    $metadataNode->appendChild($this->getMetsData($resArray));
+                    break;
+            }
+
+            $recordNode->appendChild($metadataNode);
+        }
+
+        $GetRecord->appendChild($recordNode);
+
+        return $GetRecord;
+    }
+
+    /**
+     * Process verb "Identify"
+     *
+     * @access	protected
+     *
+     * @return	DOMElement		XML node to add to the OAI response
+     */
+    protected function verbIdentify() {
+
+        // Check for invalid arguments.
+        if (count($this->piVars) > 1) {
+            return $this->error('badArgument');
+        }
+
+        // Get repository name and administrative contact.
+        // Use default values for an installation with incomplete plugin configuration.
+
+        $adminEmail = 'unknown@example.org';
+        $repositoryName = 'Kitodo.Presentation OAI-PMH interface (incomplete configuration)';
+
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_libraries.oai_label AS oai_label,tx_dlf_libraries.contact AS contact',
+            'tx_dlf_libraries',
+            'tx_dlf_libraries.pid='.intval($this->conf['pages']).' AND tx_dlf_libraries.uid='.intval($this->conf['library']).tx_dlf_helper::whereClause('tx_dlf_libraries'),
+            '',
+            '',
+            ''
+        );
+
+        if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+            $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+
+            $adminEmail = htmlspecialchars(trim(str_replace('mailto:', '', $resArray['contact'])), ENT_NOQUOTES);
+            $repositoryName = htmlspecialchars($resArray['oai_label'], ENT_NOQUOTES);
+
+        } else {
+            $this->devLog('[tx_dlf_oai->verbIdentify()] Incomplete plugin configuration', SYSLOG_SEVERITY_NOTICE);
+        }
+
+        // Get earliest datestamp. Use a default value if that fails.
+
+        $earliestDatestamp = '0000-00-00T00:00:00Z';
+
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_documents.tstamp AS tstamp',
+            'tx_dlf_documents',
+            'tx_dlf_documents.pid=' . intval($this->conf['pages']),
+            '',
+            'tx_dlf_documents.tstamp ASC',
+            '1'
+        );
+
+        if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+            list ($timestamp) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
+            $earliestDatestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
+        } else {
+            $this->devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "' . $this->conf['pages'] . '"',SYSLOG_SEVERITY_NOTICE);
+        }
+
+        $linkConf = array (
+            'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => 1
+        );
+        $baseURL = htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES);
+
+        // Add identification node.
+        $Identify = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'Identify');
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'repositoryName', $repositoryName));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','baseURL', $baseURL));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','protocolVersion', '2.0'));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','adminEmail', $adminEmail));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','earliestDatestamp', $earliestDatestamp));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','deletedRecord', 'transient'));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','granularity', 'YYYY-MM-DDThh:mm:ssZ'));
+
+        return $Identify;
+    }
+
+    /**
+     * Process verb "ListIdentifiers"
+     *
+     * @access	protected
+     *
+     * @return	string		Substitution for subpart "###RESPONSE###"
+     */
+    protected function verbListIdentifiers() {
+
+        // If we have a resumption token we can continue our work
+        if (!empty($this->piVars['resumptionToken'])) {
+            // "resumptionToken" is an exclusive argument.
+            if (count($this->piVars) > 2) {
+                return $this->error('badArgument');
+            } else {
+                return $this->resume();
+            }
+        }
+
+        // "metadataPrefix" is required and "identifier" is not allowed.
+        if (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
+            return $this->error('badArgument');
+        }
+
+        if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
+            return $this->error('cannotDisseminateFormat');
+        }
+
+        try {
+            $documentSet = $this->fetchDocumentUIDs();
+        } catch (Exception $exception) {
+            return $this->error($exception->getMessage());
+        }
+
+        $resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
+
+        $resultSet->reset();
+        $resultSet->add($documentSet);
+        $resultSet->metadata = array (
+            'completeListSize' => count($documentSet),
+            'metadataPrefix' => $this->piVars['metadataPrefix'],
+        );
+
+        return $this->generateOutputForDocumentList($resultSet);
+
+    }
+
+    /**
+     * Process verb "ListMetadataFormats"
+     *
+     * @access	protected
+     *
+     * @return	DOMElement		XML node to add to the OAI response
+     */
+    protected function verbListMetadataFormats() {
+
+        $resArray = array ();
+
+        // Check for invalid arguments.
+        if (count($this->piVars) > 1) {
+            if (empty($this->piVars['identifier']) || count($this->piVars) > 2) {
+                return $this->error('badArgument');
+            }
+
+            // Check given identifier.
+            $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                'tx_dlf_documents.*',
+                'tx_dlf_documents',
+                'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents'),
+                '',
+                '',
+                '1'
+            );
+
+            if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+                return $this->error('idDoesNotExist');
+            }
+
+            $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+        }
+
+        // Add metadata formats node.
+        $ListMetadaFormats = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListMetadataFormats');
+
+        foreach ($this->formats as $prefix => $details) {
+            if (!empty($resArray)) {
+                foreach ($details['requiredFields'] as $required) {
+                    if (empty($resArray[$required])) {
+                        // Skip metadata formats whose requirements are not met.
+                        continue 2;
+                    }
+                }
+            }
+
+            // Add format node.
+            $format = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataFormat');
+
+            $format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataPrefix', htmlspecialchars($prefix, ENT_NOQUOTES, 'UTF-8')));
+            $format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'schema', htmlspecialchars($details['schema'], ENT_NOQUOTES, 'UTF-8')));
+            $format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataNamespace', htmlspecialchars($details['namespace'], ENT_NOQUOTES, 'UTF-8')));
+
+            $ListMetadaFormats->appendChild($format);
+        }
+
+        return $ListMetadaFormats;
+    }
+
+    /**
+     * Process verb "ListRecords"
+     *
+     * @access	protected
+     *
+     * @return	string		Substitution for subpart "###RESPONSE###"
+     */
+    protected function verbListRecords() {
+
+        // Check for invalid arguments.
+        if (!empty($this->piVars['resumptionToken'])) {
+            // "resumptionToken" is an exclusive argument.
+            if (count($this->piVars) > 2) {
+                return $this->error('badArgument');
+            } else {
+                return $this->resume();
+            }
+
+        }
+
+        if (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
+            // "metadataPrefix" is required and "identifier" is not allowed.
+            return $this->error('badArgument');
+        }
+
+        // Check "metadataPrefix" for valid value.
+        if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
+            return $this->error('cannotDisseminateFormat');
+        }
+
+        try {
+            $documentSet = $this->fetchDocumentUIDs();
+        } catch (Exception $exception) {
+            return $this->error($exception->getMessage());
+        }
+
+        $resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
+
+        $resultSet->reset();
+        $resultSet->add($documentSet);
+        $resultSet->metadata = array (
+            'completeListSize' => count($documentSet),
+            'metadataPrefix' => $this->piVars['metadataPrefix'],
+        );
+
+        return $this->generateOutputForDocumentList($resultSet);
+    }
+
+    /**
+     * Process verb "ListSets"
+     *
+     * @access	protected
+     *
+     * @return	string		Substitution for subpart "###RESPONSE###"
+     */
+    protected function verbListSets() {
+
+        // Check for invalid arguments.
+        if (count($this->piVars) > 1) {
+            if (!empty($this->piVars['resumptionToken'])) {
+                return $this->error('badResumptionToken');
+            } else {
+                return $this->error('badArgument');
+            }
+        }
+
+        $where = '';
+
+        if (!$this->conf['show_userdefined']) {
+            $where = ' AND tx_dlf_collections.fe_cruser_id=0';
+        }
+
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.oai_name AS oai_name,tx_dlf_collections.label AS label',
+            'tx_dlf_collections',
+            'tx_dlf_collections.sys_language_uid IN (-1,0) AND NOT tx_dlf_collections.oai_name=\'\' AND tx_dlf_collections.pid='.intval($this->conf['pages']).$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.oai_name',
+            'tx_dlf_collections.oai_name',
+            ''
+        );
+
+        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+            return $this->error('noSetHierarchy');
+        }
+
+        $ListSets = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListSets');
+
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+            $set = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'set');
+
+            $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($resArray['oai_name'], ENT_NOQUOTES, 'UTF-8')));
+            $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setName', htmlspecialchars($resArray['label'], ENT_NOQUOTES, 'UTF-8')));
+
+            $ListSets->appendChild($set);
+        }
+
+        return $ListSets;
+    }
+
+
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    private function fetchDocumentUIDs()
+    {
+        $solr_query = '';
+
+        if (!$this->conf['show_userdefined']) {
+            $where = ' AND tx_dlf_collections.fe_cruser_id=0';
+        }
+
+        // Check "set" for valid value.
+        if (!empty($this->piVars['set'])) {
+
+            // For SOLR we need the index_name of the collection,
+            // For DB Query we need the UID of the collection
+            $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+                'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.uid AS uid, tx_dlf_collections.index_search as index_query ',
+                'tx_dlf_collections',
+                'tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.oai_name=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'],
+                    'tx_dlf_collections') . $where . tx_dlf_helper::whereClause('tx_dlf_collections'),
+                '',
+                '',
+                '1'
+            );
+
+            if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+                throw new Exception('noSetHierarchy');
+            }
+
+            $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+
+            if($resArray['index_query'] != "") {
+                $solr_query .= '(' . $resArray['index_query'] . ')';
+            } else {
+                $solr_query .= 'collection:' . '"' . $resArray['index_name'] . '"';
+            }
+
+        } else {
+            // If no set is specified we have to query for all collections
+            $solr_query .= 'collection:* NOT collection:""';
+
+        }
+
+        // Check for required fields.
+        foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
+            $solr_query .= ' NOT ' . $required . ':""';
+        }
+
+        $from = "*";
+        // Check "from" for valid value.
+        if (!empty($this->piVars['from'])) {
+
+            // Is valid format?
+            if (is_array($date_array = strptime($this->piVars['from'],
+                    '%Y-%m-%dT%H:%M:%SZ')) || is_array($date_array = strptime($this->piVars['from'], '%Y-%m-%d'))) {
+
+                $timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
+                    $date_array['tm_mday'], $date_array['tm_year'] + 1900);
+
+                $from = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) .'.000Z';
+
+            } else {
+                throw new Exception('badArgument');
+            }
+        }
+
+        $until = "*";
+        // Check "until" for valid value.
+        if (!empty($this->piVars['until'])) {
+
+            // Is valid format?
+            if (is_array($date_array = strptime($this->piVars['until'],
+                    '%Y-%m-%dT%H:%M:%SZ')) || is_array($date_array = strptime($this->piVars['until'], '%Y-%m-%d'))) {
+
+                $timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
+                    $date_array['tm_mday'], $date_array['tm_year'] + 1900);
+
+                $until = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) . '.999Z';
+
+                if ($from != "*" && $from > $until) {
+                    throw new Exception('badArgument');
+                }
+
+            } else {
+                throw new Exception('badArgument');
+            }
+        }
+
+        // Check "from" and "until" for same granularity.
+        if (!empty($this->piVars['from']) && !empty($this->piVars['until'])) {
+            if (strlen($this->piVars['from']) != strlen($this->piVars['until'])) {
+                throw new Exception('badArgument');
+            }
+        }
+
+        $solr_query .= ' AND timestamp:[' . $from . ' TO ' . $until .']';
+
+        $documentSet = array();
+
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+
+        // We only care about the UID in the results and want them sorted
+        $parameters = array("fl" => "uid", "sort" => "uid asc");
+
+        $result = $solr->search_raw($solr_query, $parameters);
+
+        if (empty($result)) {
+            throw new Exception('noRecordsMatch');
+        }
+
+        foreach ($result as $doc) {
+            $documentSet[] = $doc->uid;
+        }
+
+        return $documentSet;
+    }
+
+    /**
+     * @param tx_dlf_list $documentListSet
+     * @return DOMElement
+     */
+    private function generateOutputForDocumentList($documentListSet) {
+
+            $documentsToProcess = $documentListSet->removeRange(0, intval($this->conf['limit']));
+            $verb = $this->piVars['verb'];
+
+        $documents = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
+            'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
+            'tx_dlf_documents',
+            'tx_dlf_relations',
+            'tx_dlf_collections',
+            'AND tx_dlf_documents.uid IN (' . implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($documentsToProcess)) . ') AND tx_dlf_documents.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_relations.ident=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations') . tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_documents.uid',
+            'tx_dlf_documents.tstamp',
+            $this->conf['limit']
+        );
+
+        $output = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $verb);
+
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
+            // Add header node.
+            $header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
+
+            $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
+            $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
+
+            // Check if document is deleted or hidden.
+            // TODO: Use TYPO3 API functions here!
+            if ($resArray['deleted'] || $resArray['hidden']) {
+                // Add "deleted" status.
+                $header->setAttribute('status', 'deleted');
+
+                if ($verb == 'ListRecords') {
+                    // Add record node.
+                    $record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
+
+                    $record->appendChild($header);
+                    $output->appendChild($record);
+
+                } elseif ($verb == 'ListIdentifiers') {
+                    $output->appendChild($header);
+                }
+
+            } else {
+                // Add sets.
+                foreach (explode(' ', $resArray['collections']) as $spec) {
+                    $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
+                }
+
+                if ($verb == 'ListRecords') {
+                    // Add record node.
+                    $record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
+
+                    $record->appendChild($header);
+
+                    // Add metadata node.
+                    $metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
+
+                    $metadataPrefix = $this->piVars['metadataPrefix'];
+                    if(!$metadataPrefix) {
+                        // If we resume an action the metadataPrefix is stored with the documentSet
+                        $metadataPrefix = $documentListSet->metadata['metadataPrefix'];
+                    }
+
+                    switch ($metadataPrefix) {
+                        case 'oai_dc':
+                            $metadata->appendChild($this->getDcData($resArray));
+                            break;
+
+                        case 'epicur':
+                            $metadata->appendChild($this->getEpicurData($resArray));
+                            break;
+
+                        case 'mets':
+                            $metadata->appendChild($this->getMetsData($resArray));
+                            break;
+                    }
+
+                    $record->appendChild($metadata);
+                    $output->appendChild($record);
+
+                } elseif ($verb == 'ListIdentifiers') {
+                    $output->appendChild($header);
+                }
+            }
+        }
+
+        $output->appendChild($this->generateResumptionTokenForDocumentListSet($documentListSet));
+
+        return $output;
+    }
+
+    /**
+     * @param tx_dlf_list $documentListSet
+     * @return DOMElement
+     */
+    private function generateResumptionTokenForDocumentListSet($documentListSet)
+    {
+        $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
+
+        if ($documentListSet->count() != 0) {
+
+            $token = uniqid();
+
+            $GLOBALS['TYPO3_DB']->exec_INSERTquery(
+                'tx_dlf_tokens',
+                array(
+                    'tstamp' => $GLOBALS['EXEC_TIME'],
+                    'token' => $token,
+                    'options' => serialize($documentListSet),
+                    'ident' => 'oai',
+                )
+            );
+
+            if($GLOBALS['TYPO3_DB']->sql_affected_rows() == 1) {
+                $resumptionToken->setAttribute('resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
+            } else {
+                $this->devLog('[tx_dlf_oai->verb'. $this->piVars['verb'] .'()] Could not create resumption token', SYSLOG_SEVERITY_ERROR);
+            }
+        }
+
+        $resumptionToken->setAttribute('cursor', intval($documentListSet->metadata['completeListSize']) - count($documentListSet));
+        $resumptionToken->setAttribute('completeListSize',	$documentListSet->metadata['completeListSize']);
+        $resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
+
+        return $resumptionToken;
+    }
+
+    private function devLog($message, $severity, $data = null) {
+        if (TYPO3_DLOG) {
+            \TYPO3\CMS\Core\Utility\GeneralUtility::devLog($message, $this->extKey, $severity, $data);
+        }
+    }
 
 }
 
 if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php'])	{
-	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php']);
+    include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php']);
 
 }

--- a/plugins/oai/class.tx_dlf_oai.php
+++ b/plugins/oai/class.tx_dlf_oai.php
@@ -78,7 +78,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
         if ($GLOBALS['TYPO3_DB']->sql_affected_rows() === -1) {
             // Deletion failed.
-            $this->devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens',SYSLOG_SEVERITY_WARNING);
+            $this->devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens', SYSLOG_SEVERITY_WARNING);
         }
     }
 
@@ -631,7 +631,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_documents.tstamp AS tstamp',
             'tx_dlf_documents',
-            'tx_dlf_documents.pid=' . intval($this->conf['pages']),
+            'tx_dlf_documents.pid='.intval($this->conf['pages']),
             '',
             'tx_dlf_documents.tstamp ASC',
             '1'
@@ -641,7 +641,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
             list ($timestamp) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
             $earliestDatestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
         } else {
-            $this->devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "' . $this->conf['pages'] . '"',SYSLOG_SEVERITY_NOTICE);
+            $this->devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "'.$this->conf['pages'].'"', SYSLOG_SEVERITY_NOTICE);
         }
 
         $linkConf = array (
@@ -653,12 +653,12 @@ class tx_dlf_oai extends tx_dlf_plugin {
         // Add identification node.
         $Identify = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'Identify');
         $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'repositoryName', $repositoryName));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','baseURL', $baseURL));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','protocolVersion', '2.0'));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','adminEmail', $adminEmail));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','earliestDatestamp', $earliestDatestamp));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','deletedRecord', 'transient'));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','granularity', 'YYYY-MM-DDThh:mm:ssZ'));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'baseURL', $baseURL));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'protocolVersion', '2.0'));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'adminEmail', $adminEmail));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'earliestDatestamp', $earliestDatestamp));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'deletedRecord', 'transient'));
+        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'granularity', 'YYYY-MM-DDThh:mm:ssZ'));
 
         return $Identify;
     }
@@ -876,8 +876,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
      * @return array
      * @throws Exception
      */
-    private function fetchDocumentUIDs()
-    {
+    private function fetchDocumentUIDs() {
         $solr_query = '';
 
         if (!$this->conf['show_userdefined']) {
@@ -892,8 +891,8 @@ class tx_dlf_oai extends tx_dlf_plugin {
             $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
                 'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.uid AS uid, tx_dlf_collections.index_search as index_query ',
                 'tx_dlf_collections',
-                'tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.oai_name=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'],
-                    'tx_dlf_collections') . $where . tx_dlf_helper::whereClause('tx_dlf_collections'),
+                'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.oai_name='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'],
+                    'tx_dlf_collections').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
                 '',
                 '',
                 '1'
@@ -905,10 +904,10 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
             $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-            if($resArray['index_query'] != "") {
-                $solr_query .= '(' . $resArray['index_query'] . ')';
+            if ($resArray['index_query'] != "") {
+                $solr_query .= '('.$resArray['index_query'].')';
             } else {
-                $solr_query .= 'collection:' . '"' . $resArray['index_name'] . '"';
+                $solr_query .= 'collection:'.'"'.$resArray['index_name'].'"';
             }
 
         } else {
@@ -919,7 +918,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
         // Check for required fields.
         foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
-            $solr_query .= ' NOT ' . $required . ':""';
+            $solr_query .= ' NOT '.$required.':""';
         }
 
         $from = "*";
@@ -933,7 +932,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
                 $timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
                     $date_array['tm_mday'], $date_array['tm_year'] + 1900);
 
-                $from = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) .'.000Z';
+                $from = date("Y-m-d", $timestamp).'T'.date("H:i:s", $timestamp).'.000Z';
 
             } else {
                 throw new Exception('badArgument');
@@ -951,7 +950,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
                 $timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
                     $date_array['tm_mday'], $date_array['tm_year'] + 1900);
 
-                $until = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) . '.999Z';
+                $until = date("Y-m-d", $timestamp).'T'.date("H:i:s", $timestamp).'.999Z';
 
                 if ($from != "*" && $from > $until) {
                     throw new Exception('badArgument');
@@ -969,14 +968,14 @@ class tx_dlf_oai extends tx_dlf_plugin {
             }
         }
 
-        $solr_query .= ' AND timestamp:[' . $from . ' TO ' . $until .']';
+        $solr_query .= ' AND timestamp:['.$from.' TO '.$until.']';
 
-        $documentSet = array();
+        $documentSet = array ();
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
 
         // We only care about the UID in the results and want them sorted
-        $parameters = array("fl" => "uid", "sort" => "uid asc");
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
 
         $result = $solr->search_raw($solr_query, $parameters);
 
@@ -1005,7 +1004,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
             'tx_dlf_documents',
             'tx_dlf_relations',
             'tx_dlf_collections',
-            'AND tx_dlf_documents.uid IN (' . implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($documentsToProcess)) . ') AND tx_dlf_documents.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_relations.ident=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations') . tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'AND tx_dlf_documents.uid IN ('.implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($documentsToProcess)).') AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').tx_dlf_helper::whereClause('tx_dlf_collections'),
             'tx_dlf_documents.uid',
             'tx_dlf_documents.tstamp',
             $this->conf['limit']
@@ -1053,7 +1052,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
                     $metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
 
                     $metadataPrefix = $this->piVars['metadataPrefix'];
-                    if(!$metadataPrefix) {
+                    if (!$metadataPrefix) {
                         // If we resume an action the metadataPrefix is stored with the documentSet
                         $metadataPrefix = $documentListSet->metadata['metadataPrefix'];
                     }
@@ -1090,8 +1089,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
      * @param tx_dlf_list $documentListSet
      * @return DOMElement
      */
-    private function generateResumptionTokenForDocumentListSet($documentListSet)
-    {
+    private function generateResumptionTokenForDocumentListSet($documentListSet) {
         $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
 
         if ($documentListSet->count() != 0) {
@@ -1100,7 +1098,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
             $GLOBALS['TYPO3_DB']->exec_INSERTquery(
                 'tx_dlf_tokens',
-                array(
+                array (
                     'tstamp' => $GLOBALS['EXEC_TIME'],
                     'token' => $token,
                     'options' => serialize($documentListSet),
@@ -1108,21 +1106,21 @@ class tx_dlf_oai extends tx_dlf_plugin {
                 )
             );
 
-            if($GLOBALS['TYPO3_DB']->sql_affected_rows() == 1) {
+            if ($GLOBALS['TYPO3_DB']->sql_affected_rows() == 1) {
                 $resumptionToken->setAttribute('resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
             } else {
-                $this->devLog('[tx_dlf_oai->verb'. $this->piVars['verb'] .'()] Could not create resumption token', SYSLOG_SEVERITY_ERROR);
+                $this->devLog('[tx_dlf_oai->verb'.$this->piVars['verb'].'()] Could not create resumption token', SYSLOG_SEVERITY_ERROR);
             }
         }
 
         $resumptionToken->setAttribute('cursor', intval($documentListSet->metadata['completeListSize']) - count($documentListSet));
-        $resumptionToken->setAttribute('completeListSize',	$documentListSet->metadata['completeListSize']);
+        $resumptionToken->setAttribute('completeListSize', $documentListSet->metadata['completeListSize']);
         $resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
 
         return $resumptionToken;
     }
 
-    private function devLog($message, $severity, $data = null) {
+    private function devLog($message, $severity, $data = NULL) {
         if (TYPO3_DLOG) {
             \TYPO3\CMS\Core\Utility\GeneralUtility::devLog($message, $this->extKey, $severity, $data);
         }
@@ -1130,7 +1128,7 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
 }
 
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php'])	{
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php']) {
     include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php']);
 
 }

--- a/plugins/oai/class.tx_dlf_oai.php
+++ b/plugins/oai/class.tx_dlf_oai.php
@@ -19,1755 +19,1118 @@
  */
 class tx_dlf_oai extends tx_dlf_plugin {
 
-    public $scriptRelPath = 'plugins/oai/class.tx_dlf_oai.php';
-
-    /**
-     * Did an error occur?
-     *
-     * @var	boolean
-     * @access protected
-     */
-    protected $error = FALSE;
-
-    /**
-     * This holds the OAI DOM object
-     *
-     * @var	DOMDocument
-     * @access protected
-     */
-    protected $oai;
-
-    /**
-     * This holds the configuration for all supported metadata prefixes
-     *
-     * @var	array
-     * @access protected
-     */
-    protected $formats = array (
-        'oai_dc' => array (
-            'schema' => 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
-            'namespace' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-            'requiredFields' => array ('record_id'),
-        ),
-        'epicur' => array (
-            'schema' => 'http://www.persistent-identifier.de/xepicur/version1.0/xepicur.xsd',
-            'namespace' => 'urn:nbn:de:1111-2004033116',
-            'requiredFields' => array ('purl', 'urn'),
-        ),
-        'mets' => array (
-            'schema' => 'http://www.loc.gov/standards/mets/version17/mets.v1-7.xsd',
-            'namespace' => 'http://www.loc.gov/METS/',
-            'requiredFields' => array ('location'),
-        )
-    );
-
-    /**
-     * Delete expired resumption tokens
-     *
-     * @access	protected
-     *
-     * @return	void
-     */
-    protected function deleteExpiredTokens() {
-
-        // Delete expired resumption tokens.
-        $result = $GLOBALS['TYPO3_DB']->exec_DELETEquery(
-            'tx_dlf_tokens',
-            'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.tstamp<'.intval($GLOBALS['EXEC_TIME'] - $this->conf['expired'])
-        );
-
-        if ($GLOBALS['TYPO3_DB']->sql_affected_rows($result) === -1) {
-
-            // Deletion failed.
-            if (TYPO3_DLOG) {
-
-                \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens', $this->extKey, SYSLOG_SEVERITY_WARNING);
-
-            }
-
-        }
+	public $scriptRelPath = 'plugins/oai/class.tx_dlf_oai.php';
+
+	/**
+	 * Did an error occur?
+	 *
+	 * @var	boolean
+	 * @access protected
+	 */
+	protected $error = FALSE;
+
+	/**
+	 * This holds the OAI DOM object
+	 *
+	 * @var	DOMDocument
+	 * @access protected
+	 */
+	protected $oai;
+
+	/**
+	 * This holds the configuration for all supported metadata prefixes
+	 *
+	 * @var	array
+	 * @access protected
+	 */
+	protected $formats = array (
+		'oai_dc' => array (
+			'schema' => 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+			'namespace' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+			'requiredFields' => array ('record_id'),
+		),
+		'epicur' => array (
+			'schema' => 'http://www.persistent-identifier.de/xepicur/version1.0/xepicur.xsd',
+			'namespace' => 'urn:nbn:de:1111-2004033116',
+			'requiredFields' => array ('purl', 'urn'),
+		),
+		'mets' => array (
+			'schema' => 'http://www.loc.gov/standards/mets/version17/mets.v1-7.xsd',
+			'namespace' => 'http://www.loc.gov/METS/',
+			'requiredFields' => array ('location'),
+		)
+	);
+
+	/**
+	 * Delete expired resumption tokens
+	 *
+	 * @access	protected
+	 *
+	 * @return	void
+	 */
+	protected function deleteExpiredTokens() {
+
+		// Delete expired resumption tokens.
+		$result = $GLOBALS['TYPO3_DB']->exec_DELETEquery(
+			'tx_dlf_tokens',
+			'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.tstamp<'.intval($GLOBALS['EXEC_TIME'] - $this->conf['expired'])
+		);
+
+		if ($GLOBALS['TYPO3_DB']->sql_affected_rows() === -1) {
+			// Deletion failed.
+			$this->devLog('[tx_dlf_oai->deleteExpiredTokens()] Could not delete expired resumption tokens',SYSLOG_SEVERITY_WARNING);
+		}
+	}
+
+	/**
+	 * Process error
+	 *
+	 * @access	protected
+	 *
+	 * @param	string		$type: Error type
+	 *
+	 * @return	DOMElement		XML node to add to the OAI response
+	 */
+	protected function error($type) {
+		$this->error = TRUE;
+
+		$error = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'error', htmlspecialchars($this->pi_getLL($type, $type, FALSE), ENT_NOQUOTES, 'UTF-8'));
+		$error->setAttribute('code', $type);
+
+		return $error;
+	}
+
+	/**
+	 * Load URL parameters
+	 *
+	 * @access	protected
+	 *
+	 * @return	void
+	 */
+	protected function getUrlParams() {
+
+		$allowedParams = array (
+			'verb',
+			'identifier',
+			'metadataPrefix',
+			'from',
+			'until',
+			'set',
+			'resumptionToken'
+		);
+
+		// Clear plugin variables.
+		$this->piVars = array ();
+
+		// Set only allowed parameters.
+		foreach ($allowedParams as $param) {
+			if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param)) {
+				$this->piVars[$param] = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param);
+			}
+		}
+	}
+
+	/**
+	 * Get unqualified Dublin Core data.
+	 * @see http://www.openarchives.org/OAI/openarchivesprotocol.html#dublincore
+	 *
+	 * @access	protected
+	 *
+	 * @param	array		$metadata: The metadata array
+	 *
+	 * @return	DOMElement		XML node to add to the OAI response
+	 */
+	protected function getDcData(array $metadata) {
 
-    }
+		$oai_dc = $this->oai->createElementNS($this->formats['oai_dc']['namespace'], 'oai_dc:dc');
 
-    /**
-     * Process error
-     *
-     * @access	protected
-     *
-     * @param	string		$type: Error type
-     *
-     * @return	DOMElement		XML node to add to the OAI response
-     */
-    protected function error($type) {
+		$oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:dc', 'http://purl.org/dc/elements/1.1/');
+		$oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+		$oai_dc->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['oai_dc']['namespace'].' '.$this->formats['oai_dc']['schema']);
 
-        $this->error = TRUE;
+		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['record_id'], ENT_NOQUOTES, 'UTF-8')));
 
-        $error = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'error', htmlspecialchars($this->pi_getLL($type, $type, FALSE), ENT_NOQUOTES, 'UTF-8'));
+		if (!empty($metadata['purl'])) {
+			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8')));
+		}
 
-        $error->setAttribute('code', $type);
+		if (!empty($metadata['urn'])) {
+			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8')));
+		}
 
-        return $error;
+		if (!empty($metadata['title'])) {
+			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:title', htmlspecialchars($metadata['title'], ENT_NOQUOTES, 'UTF-8')));
+		}
 
-    }
+		if (!empty($metadata['author'])) {
+			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:creator', htmlspecialchars($metadata['author'], ENT_NOQUOTES, 'UTF-8')));
+		}
 
-    /**
-     * Load URL parameters
-     *
-     * @access	protected
-     *
-     * @return	void
-     */
-    protected function getUrlParams() {
+		if (!empty($metadata['year'])) {
+			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:date', htmlspecialchars($metadata['year'], ENT_NOQUOTES, 'UTF-8')));
+		}
 
-        $allowedParams = array (
-            'verb',
-            'identifier',
-            'metadataPrefix',
-            'from',
-            'until',
-            'set',
-            'resumptionToken'
-        );
+		if (!empty($metadata['place'])) {
+			$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:coverage', htmlspecialchars($metadata['place'], ENT_NOQUOTES, 'UTF-8')));
+		}
 
-        // Clear plugin variables.
-        $this->piVars = array ();
+		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:format', 'application/mets+xml'));
+		$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:type', 'Text'));
 
-        // Set only allowed parameters.
-        foreach ($allowedParams as $param) {
+		if (!empty($metadata['partof'])) {
+			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+				'tx_dlf_documents.record_id',
+				'tx_dlf_documents',
+				'tx_dlf_documents.uid='.intval($metadata['partof']).tx_dlf_helper::whereClause('tx_dlf_documents'),
+				'',
+				'',
+				'1'
+			);
 
-            if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param)) {
+			if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+				$partof = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-                $this->piVars[$param] = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP($param);
+				$oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:relation', htmlspecialchars($partof['record_id'], ENT_NOQUOTES, 'UTF-8')));
+			}
+		}
 
-            }
+		return $oai_dc;
+	}
 
-        }
+	/**
+	 * Get epicur data.
+	 * @see http://www.persistent-identifier.de/?link=210
+	 *
+	 * @access	protected
+	 *
+	 * @param	array		$metadata: The metadata array
+	 *
+	 * @return	DOMElement		XML node to add to the OAI response
+	 */
+	protected function getEpicurData(array $metadata) {
 
-    }
+		// Define all XML elements with or without qualified namespace.
+		if (empty($this->conf['unqualified_epicur'])) {
+			$epicur = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:epicur');
 
-    /**
-     * Get unqualified Dublin Core data.
-     * @see http://www.openarchives.org/OAI/openarchivesprotocol.html#dublincore
-     *
-     * @access	protected
-     *
-     * @param	array		$metadata: The metadata array
-     *
-     * @return	DOMElement		XML node to add to the OAI response
-     */
-    protected function getDcData(array $metadata) {
+			$admin = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:administrative_data');
 
-        $oai_dc = $this->oai->createElementNS($this->formats['oai_dc']['namespace'], 'oai_dc:dc');
+			$delivery = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:delivery');
 
-        $oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:dc', 'http://purl.org/dc/elements/1.1/');
+			$update = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:update_status');
 
-        $oai_dc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+			$transfer = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:transfer');
 
-        $oai_dc->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['oai_dc']['namespace'].' '.$this->formats['oai_dc']['schema']);
+			$format = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:format', 'text/html');
 
-        $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['record_id'], ENT_NOQUOTES, 'UTF-8')));
+			$record = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:record');
 
-        if (!empty($metadata['purl'])) {
+			$identifier = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
 
-            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8')));
+			$resource = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:resource');
 
-        }
+			$ident = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
 
-        if (!empty($metadata['urn'])) {
+		} else {
+			$epicur = $this->oai->createElement('epicur');
+			$epicur->setAttribute('xmlns', $this->formats['epicur']['namespace']);
 
-            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8')));
+			$admin = $this->oai->createElement('administrative_data');
 
-        }
+			$delivery = $this->oai->createElement('delivery');
 
-        if (!empty($metadata['title'])) {
+			$update = $this->oai->createElement('update_status');
 
-            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:title', htmlspecialchars($metadata['title'], ENT_NOQUOTES, 'UTF-8')));
+			$transfer = $this->oai->createElement('transfer');
 
-        }
+			$format = $this->oai->createElement('format', 'text/html');
 
-        if (!empty($metadata['author'])) {
+			$record = $this->oai->createElement('record');
 
-            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:creator', htmlspecialchars($metadata['author'], ENT_NOQUOTES, 'UTF-8')));
+			$identifier = $this->oai->createElement('identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
 
-        }
+			$resource = $this->oai->createElement('resource');
 
-        if (!empty($metadata['year'])) {
+			$ident = $this->oai->createElement('identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
+		}
 
-            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:date', htmlspecialchars($metadata['year'], ENT_NOQUOTES, 'UTF-8')));
+		// Add attributes and build XML tree.
+		$epicur->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+		$epicur->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['epicur']['namespace'].' '.$this->formats['epicur']['schema']);
 
-        }
+		// Do we update an URN or register a new one?
+		if ($metadata['tstamp'] == $metadata['crdate']) {
+			$update->setAttribute('type', 'urn_new');
+		} else {
+			$update->setAttribute('type', 'url_update_general');
+		}
 
-        if (!empty($metadata['place'])) {
+		$delivery->appendChild($update);
 
-            $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:coverage', htmlspecialchars($metadata['place'], ENT_NOQUOTES, 'UTF-8')));
+		$transfer->setAttribute('type', 'http');
 
-        }
+		$delivery->appendChild($transfer);
 
-        $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:format', 'application/mets+xml'));
+		$admin->appendChild($delivery);
 
-        $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:type', 'Text'));
+		$epicur->appendChild($admin);
 
-        if (!empty($metadata['partof'])) {
+		$identifier->setAttribute('scheme', 'urn:nbn:de');
 
-            $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                'tx_dlf_documents.record_id',
-                'tx_dlf_documents',
-                'tx_dlf_documents.uid='.intval($metadata['partof']).tx_dlf_helper::whereClause('tx_dlf_documents'),
-                '',
-                '',
-                '1'
-            );
+		$record->appendChild($identifier);
 
-            if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+		$ident->setAttribute('scheme', 'url');
+		$ident->setAttribute('type', 'frontpage');
+		$ident->setAttribute('role', 'primary');
 
-                $partof = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+		$resource->appendChild($ident);
 
-                $oai_dc->appendChild($this->oai->createElementNS('http://purl.org/dc/elements/1.1/', 'dc:relation', htmlspecialchars($partof['record_id'], ENT_NOQUOTES, 'UTF-8')));
+		$format->setAttribute('scheme', 'imt');
 
-            }
+		$resource->appendChild($format);
 
-        }
+		$record->appendChild($resource);
 
-        return $oai_dc;
+		$epicur->appendChild($record);
 
-    }
+		return $epicur;
+	}
 
-    /**
-     * Get epicur data.
-     * @see http://www.persistent-identifier.de/?link=210
-     *
-     * @access	protected
-     *
-     * @param	array		$metadata: The metadata array
-     *
-     * @return	DOMElement		XML node to add to the OAI response
-     */
-    protected function getEpicurData(array $metadata) {
+	/**
+	 * Get METS data.
+	 * @see http://www.loc.gov/standards/mets/docs/mets.v1-7.html
+	 *
+	 * @access	protected
+	 *
+	 * @param	array		$metadata: The metadata array
+	 *
+	 * @return	DOMElement		XML node to add to the OAI response
+	 */
+	protected function getMetsData(array $metadata) {
 
-        // Define all XML elements with or without qualified namespace.
-        if (empty($this->conf['unqualified_epicur'])) {
+		$mets = NULL;
 
-            // Create epicur element.
-            $epicur = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:epicur');
+		// Load METS file.
+		$xml = new DOMDocument();
 
-            // Add administrative data.
-            $admin = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:administrative_data');
+		if ($xml->load($metadata['location'])) {
+			// Get root element.
+			$root = $xml->getElementsByTagNameNS($this->formats['mets']['namespace'], 'mets');
 
-            $delivery = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:delivery');
+			if ($root->item(0) instanceof DOMNode) {
+				// Import node into DOMDocument.
+				$mets = $this->oai->importNode($root->item(0), TRUE);
+			} else {
+				   $this->devLog('[tx_dlf_oai->getMetsData([data])] No METS part found in document with location "'.$metadata['location'].'"', SYSLOG_SEVERITY_ERROR, $metadata);
+			}
+		} else {
+			$this->devLog('[tx_dlf_oai->getMetsData([data])] Could not load XML file from "'.$metadata['location'].'"', SYSLOG_SEVERITY_ERROR, $metadata);
+		}
 
-            $update = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:update_status');
+		if ($mets === NULL) {
+			$mets = $this->oai->createElementNS('http://kitodo.org/', 'kitodo:error', htmlspecialchars($this->pi_getLL('error', 'Error!', FALSE), ENT_NOQUOTES, 'UTF-8'));
+		}
 
-            $transfer = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:transfer');
+		return $mets;
+	}
 
-            $format = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:format', 'text/html');
+	/**
+	 * The main method of the PlugIn
+	 *
+	 * @access	public
+	 *
+	 * @param	string		$content: The PlugIn content
+	 * @param	array		$conf: The PlugIn configuration
+	 *
+	 * @return	void
+	 */
+	public function main($content, $conf) {
 
-            // Add record data.
-            $record = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:record');
+		// Initialize plugin.
+		$this->init($conf);
 
-            $identifier = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
+		// Turn cache off.
+		$this->setCache(FALSE);
 
-            $resource = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:resource');
+		// Get GET and POST variables.
+		$this->getUrlParams();
 
-            $ident = $this->oai->createElementNS($this->formats['epicur']['namespace'], 'epicur:identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
+		// Delete expired resumption tokens.
+		$this->deleteExpiredTokens();
 
-        } else {
+		// Create XML document.
+		$this->oai = new DOMDocument('1.0', 'UTF-8');
 
-            // Create epicur element with unqualified namespace.
-            $epicur = $this->oai->createElement('epicur');
+		// Add processing instruction (aka XSL stylesheet).
+		if (!empty($this->conf['stylesheet'])) {
+			// Resolve "EXT:" prefix in file path.
+			if (substr($this->conf['stylesheet'], 0, 4) == 'EXT:') {
 
-            $epicur->setAttribute('xmlns', $this->formats['epicur']['namespace']);
+				list ($extKey, $filePath) = explode('/', substr($this->conf['stylesheet'], 4), 2);
 
-            // Add administrative data without qualified namespace.
-            $admin = $this->oai->createElement('administrative_data');
+				if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
+					$this->conf['stylesheet'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($extKey).$filePath;
+				}
+			}
 
-            $delivery = $this->oai->createElement('delivery');
+			$stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->conf['stylesheet']);
 
-            $update = $this->oai->createElement('update_status');
+		} else {
+			// Use default stylesheet if no custom stylesheet is given.
+			$stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
+		}
 
-            $transfer = $this->oai->createElement('transfer');
+		$this->oai->appendChild($this->oai->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="'.htmlspecialchars($stylesheet, ENT_NOQUOTES, 'UTF-8').'"'));
 
-            $format = $this->oai->createElement('format', 'text/html');
+		// Create root element.
+		$root = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'OAI-PMH');
 
-            // Add record data without qualified namespace.
-            $record = $this->oai->createElement('record');
+		$root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+		$root->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', 'http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd');
 
-            $identifier = $this->oai->createElement('identifier', htmlspecialchars($metadata['urn'], ENT_NOQUOTES, 'UTF-8'));
+		// Add response date.
+		$root->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'responseDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'])));
 
-            $resource = $this->oai->createElement('resource');
+		// Get response data.
+		switch ($this->piVars['verb']) {
+			case 'GetRecord':
+				$response = $this->verbGetRecord();
+				break;
 
-            $ident = $this->oai->createElement('identifier', htmlspecialchars($metadata['purl'], ENT_NOQUOTES, 'UTF-8'));
+			case 'Identify':
+				$response = $this->verbIdentify();
+				break;
 
-        }
+			case 'ListIdentifiers':
+				$response = $this->verbListIdentifiers();
+				break;
 
-        // Add attributes and build XML tree.
-        $epicur->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+			case 'ListMetadataFormats':
+				$response = $this->verbListMetadataFormats();
+				break;
 
-        $epicur->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', $this->formats['epicur']['namespace'].' '.$this->formats['epicur']['schema']);
+			case 'ListRecords':
+				$response = $this->verbListRecords();
+				break;
 
-        // Do we update an URN or register a new one?
-        if ($metadata['tstamp'] == $metadata['crdate']) {
+			case 'ListSets':
+				$response = $this->verbListSets();
+				break;
 
-            $update->setAttribute('type', 'urn_new');
+			default:
+				$response = $this->error('badVerb');
+		}
 
-        } else {
+		// Add request.
+		$linkConf = array (
+			'parameter' => $GLOBALS['TSFE']->id,
+			'forceAbsoluteUrl' => 1
+		);
 
-            $update->setAttribute('type', 'url_update_general');
+		$request = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'request', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8'));
 
-        }
+		if (!$this->error) {
+			foreach ($this->piVars as $key => $value) {
+				$request->setAttribute($key, htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8'));
+			}
+		}
 
-        $delivery->appendChild($update);
+		$root->appendChild($request);
+		$root->appendChild($response);
 
-        $transfer->setAttribute('type', 'http');
+		$this->oai->appendChild($root);
 
-        $delivery->appendChild($transfer);
+		$content = $this->oai->saveXML();
 
-        $admin->appendChild($delivery);
+		// Clean output buffer.
+		\TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
 
-        $epicur->appendChild($admin);
+		// Send headers.
+		header('HTTP/1.1 200 OK');
+		header('Cache-Control: no-cache');
+		header('Content-Length: '.strlen($content));
+		header('Content-Type: text/xml; charset=utf-8');
+		header('Date: '.date('r', $GLOBALS['EXEC_TIME']));
+		header('Expires: '.date('r', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
 
-        $identifier->setAttribute('scheme', 'urn:nbn:de');
+		echo $content;
 
-        $record->appendChild($identifier);
+		// Flush output buffer and end script processing.
+		ob_end_flush();
 
-        $ident->setAttribute('scheme', 'url');
+		exit;
+	}
 
-        $ident->setAttribute('type', 'frontpage');
+	/**
+	 * Continue with resumption token
+	 *
+	 * @access	protected
+	 *
+	 * @return	string		Substitution for subpart "###RESPONSE###"
+	 */
+	protected function resume() {
+		// Get resumption token.
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'tx_dlf_tokens.options AS options',
+			'tx_dlf_tokens',
+			'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.token='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['resumptionToken'], 'tx_dlf_tokens'),
+			'',
+			'',
+			'1'
+		);
 
-        $ident->setAttribute('role', 'primary');
+		if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+			// No resumption token found or resumption token expired.
+			return $this->error('badResumptionToken');
+		}
 
-        $resource->appendChild($ident);
+		$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-        $format->setAttribute('scheme', 'imt');
+		$resultSet = unserialize($resArray['options']);
 
-        $resource->appendChild($format);
+		return $this->generateOutputForDocumentList($resultSet);
 
-        $record->appendChild($resource);
+	}
 
-        $epicur->appendChild($record);
+	/**
+	 * Process verb "GetRecord"
+	 *
+	 * @access	protected
+	 *
+	 * @return	string		Substitution for subpart "###RESPONSE###"
+	 */
+	protected function verbGetRecord() {
 
-        return $epicur;
+		if (count($this->piVars) != 3 || empty($this->piVars['metadataPrefix']) || empty($this->piVars['identifier'])) {
+			return $this->error('badArgument');
+		}
 
-    }
+		if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
+			return $this->error('cannotDisseminateFormat');
+		}
 
-    /**
-     * Get METS data.
-     * @see http://www.loc.gov/standards/mets/docs/mets.v1-7.html
-     *
-     * @access	protected
-     *
-     * @param	array		$metadata: The metadata array
-     *
-     * @return	DOMElement		XML node to add to the OAI response
-     */
-    protected function getMetsData(array $metadata) {
+		$where = '';
 
-        $mets = NULL;
+		if (!$this->conf['show_userdefined']) {
+			$where .= ' AND tx_dlf_collections.fe_cruser_id=0';
+		}
 
-        // Load METS file.
-        $xml = new DOMDocument();
+		$record = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
+			'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
+			'tx_dlf_documents',
+			'tx_dlf_relations',
+			'tx_dlf_collections',
+			'AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents').' AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
+			'tx_dlf_documents.uid',
+			'tx_dlf_documents.tstamp',
+			'1'
+		);
 
-        if ($xml->load($metadata['location'])) {
+		if (!$GLOBALS['TYPO3_DB']->sql_num_rows($record)) {
+			return $this->error('idDoesNotExist');
+		}
 
-            // Get root element.
-            $root = $xml->getElementsByTagNameNS($this->formats['mets']['namespace'], 'mets');
+		$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($record);
 
-            if ($root->item(0) instanceof DOMNode) {
+		// Check for required fields.
+		foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
+			if (empty($resArray[$required])) {
+				return $this->error('cannotDisseminateFormat');
+			}
+		}
 
-                // Import node into DOMDocument.
-                $mets = $this->oai->importNode($root->item(0), TRUE);
+		$GetRecord = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'GetRecord');
 
-            } else {
+		$recordNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
 
-                if (TYPO3_DLOG) {
+		$headerNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
+		$headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
+		$headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
 
-                    \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->getMetsData([data])] No METS part found in document with location "'.$location.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $metadata);
+		// Handle deleted documents.
+		// TODO: Use TYPO3 API functions here!
+		if ($resArray['deleted'] || $resArray['hidden']) {
+			$headerNode->setAttribute('status', 'deleted');
 
-                }
+			$recordNode->appendChild($headerNode);
 
-            }
+		} else {
+			foreach (explode(' ', $resArray['collections']) as $spec) {
+				$headerNode->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
+			}
 
-        } else {
+			$recordNode->appendChild($headerNode);
 
-            if (TYPO3_DLOG) {
+			$metadataNode = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
 
-                \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->getMetsData([data])] Could not load XML file from "'.$location.'"', $this->extKey, SYSLOG_SEVERITY_ERROR, $metadata);
+			switch ($this->piVars['metadataPrefix']) {
+				case 'oai_dc':
+					$metadataNode->appendChild($this->getDcData($resArray));
+					break;
 
-            }
+				case 'epicur':
+					$metadataNode->appendChild($this->getEpicurData($resArray));
+					break;
 
-        }
-
-        if ($mets === NULL) {
-
-            $mets = $this->oai->createElementNS('http://kitodo.org/', 'kitodo:error', htmlspecialchars($this->pi_getLL('error', 'Error!', FALSE), ENT_NOQUOTES, 'UTF-8'));
-
-        }
-
-        return $mets;
-
-    }
-
-    /**
-     * The main method of the PlugIn
-     *
-     * @access	public
-     *
-     * @param	string		$content: The PlugIn content
-     * @param	array		$conf: The PlugIn configuration
-     *
-     * @return	void
-     */
-    public function main($content, $conf) {
-
-        // Initialize plugin.
-        $this->init($conf);
-
-        // Turn cache off.
-        $this->setCache(FALSE);
-
-        // Get GET and POST variables.
-        $this->getUrlParams();
-
-        // Delete expired resumption tokens.
-        $this->deleteExpiredTokens();
-
-        // Create XML document.
-        $this->oai = new DOMDocument('1.0', 'UTF-8');
-
-        // Add processing instruction (aka XSL stylesheet).
-        if (!empty($this->conf['stylesheet'])) {
-
-            // Resolve "EXT:" prefix in file path.
-            if (substr($this->conf['stylesheet'], 0, 4) == 'EXT:') {
-
-                list ($extKey, $filePath) = explode('/', substr($this->conf['stylesheet'], 4), 2);
-
-                if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($extKey)) {
-
-                    $this->conf['stylesheet'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($extKey).$filePath;
-
-                }
-
-            }
-
-            $stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->conf['stylesheet']);
-
-        } else {
-
-            // Use default stylesheet if no custom stylesheet is given.
-            $stylesheet = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'plugins/oai/transform.xsl');
-
-        }
-
-        $this->oai->appendChild($this->oai->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="'.htmlspecialchars($stylesheet, ENT_NOQUOTES, 'UTF-8').'"'));
-
-        // Create root element.
-        $root = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'OAI-PMH');
-
-        $root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-
-        $root->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', 'http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd');
-
-        // Add response date.
-        $root->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'responseDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'])));
-
-        // Get response data.
-        switch ($this->piVars['verb']) {
-
-            case 'GetRecord':
-
-                $response = $this->verbGetRecord();
-
-                break;
-
-            case 'Identify':
-
-                $response = $this->verbIdentify();
-
-                break;
-
-            case 'ListIdentifiers':
-
-                $response = $this->verbListIdentifiers();
-
-                break;
-
-            case 'ListMetadataFormats':
-
-                $response = $this->verbListMetadataFormats();
-
-                break;
-
-            case 'ListRecords':
-
-                $response = $this->verbListRecords();
-
-                break;
-
-            case 'ListSets':
-
-                $response = $this->verbListSets();
-
-                break;
-
-            default:
-
-                $response = $this->error('badVerb');
-
-        }
-
-        // Add request.
-        $linkConf = array (
-            'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
-        );
-
-        $request = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'request', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8'));
-
-        if (!$this->error) {
-
-            foreach ($this->piVars as $key => $value) {
-
-                $request->setAttribute($key, htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8'));
-
-            }
-
-        }
-
-        $root->appendChild($request);
-
-        // Add response data.
-        $root->appendChild($response);
-
-        // Build XML output.
-        $this->oai->appendChild($root);
-
-        $content = $this->oai->saveXML();
-
-        // Clean output buffer.
-        \TYPO3\CMS\Core\Utility\GeneralUtility::cleanOutputBuffers();
-
-        // Send headers.
-        header('HTTP/1.1 200 OK');
-
-        header('Cache-Control: no-cache');
-
-        header('Content-Length: '.strlen($content));
-
-        header('Content-Type: text/xml; charset=utf-8');
-
-        header('Date: '.date('r', $GLOBALS['EXEC_TIME']));
-
-        header('Expires: '.date('r', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
-
-        echo $content;
-
-        // Flush output buffer and end script processing.
-        ob_end_flush();
-
-        exit;
-
-    }
-
-    /**
-     * Continue with resumption token
-     *
-     * @access	protected
-     *
-     * @return	string		Substitution for subpart "###RESPONSE###"
-     */
-    protected function resume() {
-
-        // Get resumption token.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_tokens.options AS options',
-            'tx_dlf_tokens',
-            'tx_dlf_tokens.ident="oai" AND tx_dlf_tokens.token='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['resumptionToken'], 'tx_dlf_tokens'),
-            '',
-            '',
-            '1'
-        );
-
-        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-            // No resumption token found or resumption token expired.
-            return $this->error('badResumptionToken');
-
-        }
-
-        $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-        $resultSet = unserialize($resArray['options']);
-
-        $complete = FALSE;
-
-        $todo = array ();
-
-        $resume = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $this->piVars['verb']);
-
-        for ($i = $resultSet->metadata['offset'], $j = intval($resultSet->metadata['offset'] + $this->conf['limit']); $i < $j; $i++) {
-
-            $todo[] = $resultSet[$i];
-
-            if (empty($resultSet[$i + 1])) {
-
-                $complete = TRUE;
-
-                break;
-
-            }
-
-        }
-
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
-            'tx_dlf_collections',
-            'AND tx_dlf_documents.uid IN ('.implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($todo)).') AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-            'tx_dlf_documents.uid',
-            'tx_dlf_documents.tstamp',
-            $this->conf['limit']
-        );
-
-        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-            // Add header node.
-            $header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
-
-            $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
-
-            $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
-
-            // Check if document is deleted or hidden.
-            // TODO: Use TYPO3 API functions here!
-            if ($resArray['deleted'] || $resArray['hidden']) {
-
-                // Add "deleted" status.
-                $header->setAttribute('status', 'deleted');
-
-                if ($this->piVars['verb'] == 'ListRecords') {
-
-                    // Add record node.
-                    $record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
-
-                    $record->appendChild($header);
-
-                    $resume->appendChild($record);
-
-                } elseif ($this->piVars['verb'] == 'ListIdentifiers') {
-
-                    $resume->appendChild($header);
-
-                }
-
-            } else {
-
-                // Add sets.
-                foreach (explode(' ', $resArray['collections']) as $spec) {
-
-                    $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
-
-                }
-
-                if ($this->piVars['verb'] == 'ListRecords') {
-
-                    // Add record node.
-                    $record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
-
-                    $record->appendChild($header);
-
-                    // Add metadata node.
-                    $metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
-
-                    switch ($resultSet->metadata['metadataPrefix']) {
-
-                        case 'oai_dc':
-
-                            $metadata->appendChild($this->getDcData($resArray));
-
-                            break;
-
-                        case 'epicur':
-
-                            $metadata->appendChild($this->getEpicurData($resArray));
-
-                            break;
-
-                        case 'mets':
-
-                            $metadata->appendChild($this->getMetsData($resArray));
-
-                            break;
-
-                    }
-
-                    $record->appendChild($metadata);
-
-                    $resume->appendChild($record);
-
-                } elseif ($this->piVars['verb'] == 'ListIdentifiers') {
-
-                    $resume->appendChild($header);
-
-                }
-
-            }
-
-        }
-
-        if (!$complete) {
-
-            // Save result set to database and generate resumption token.
-            $token = uniqid();
-
-            $resultSet->metadata = array (
-                'offset' => intval($resultSet->metadata['offset'] + $this->conf['limit']),
-                'metadataPrefix' => $resultSet->metadata['metadataPrefix'],
-            );
-
-            $result = $GLOBALS['TYPO3_DB']->exec_INSERTquery(
-                'tx_dlf_tokens',
-                array (
-                    'tstamp' => $GLOBALS['EXEC_TIME'],
-                    'token' => $token,
-                    'options' => serialize($resultSet),
-                    'ident' => 'oai',
-                )
-            );
-
-            if ($GLOBALS['TYPO3_DB']->sql_affected_rows($result) == 1) {
-
-                $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
-
-            } else {
-
-                if (TYPO3_DLOG) {
-
-                    \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->resume()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
-
-                }
-
-            }
-
-        } else {
-
-            // Result set complete. No more resumption token needed.
-            $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
-
-        }
-
-        $resumptionToken->setAttribute('cursor', $resultSet->metadata['offset']);
-
-        $resumptionToken->setAttribute('completeListSize', count($resultSet));
-
-        $resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
-
-        $resume->appendChild($resumptionToken);
-
-        return $resume;
-
-    }
-
-    /**
-     * Process verb "GetRecord"
-     *
-     * @access	protected
-     *
-     * @return	string		Substitution for subpart "###RESPONSE###"
-     */
-    protected function verbGetRecord() {
-
-        // Check for invalid arguments.
-        if (count($this->piVars) != 3 || empty($this->piVars['metadataPrefix']) || empty($this->piVars['identifier'])) {
-
-            return $this->error('badArgument');
-
-        } else {
-
-            // Check "metadataPrefix" for valid value.
-            if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
-
-                return $this->error('cannotDisseminateFormat');
-
-            }
-
-            $where = '';
-
-            // Select records from database.
-            if (!$this->conf['show_userdefined']) {
-
-                $where .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-            }
-
-            $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents').' AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_documents.uid',
-                'tx_dlf_documents.tstamp',
-                '1'
-            );
-
-            if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-                return $this->error('idDoesNotExist');
-
-            } else {
-
-                $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-                // Check for required fields.
-                foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
-
-                    if (empty($resArray[$required])) {
-
-                        return $this->error('cannotDisseminateFormat');
-
-                    }
-
-                }
-
-                // Add record node.
-                $GetRecord = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'GetRecord');
-
-                $record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
-
-                // Add header node.
-                $header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
-
-                $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
-
-                $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
-
-                // Handle deleted documents.
-                // TODO: Use TYPO3 API functions here!
-                if ($resArray['deleted'] || $resArray['hidden']) {
-
-                    $header->setAttribute('status', 'deleted');
-
-                    $record->appendChild($header);
-
-                } else {
-
-                    foreach (explode(' ', $resArray['collections']) as $spec) {
-
-                        $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
-
-                    }
-
-                    $record->appendChild($header);
-
-                    // Add metadata node.
-                    $metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
-
-                    switch ($this->piVars['metadataPrefix']) {
-
-                        case 'oai_dc':
-
-                            $metadata->appendChild($this->getDcData($resArray));
-
-                            break;
-
-                        case 'epicur':
-
-                            $metadata->appendChild($this->getEpicurData($resArray));
-
-                            break;
-
-                        case 'mets':
-
-                            $metadata->appendChild($this->getMetsData($resArray));
-
-                            break;
-
-                    }
-
-                    $record->appendChild($metadata);
-
-                }
-
-                $GetRecord->appendChild($record);
-
-                return $GetRecord;
-
-            }
-
-        }
-
-    }
-
-    /**
-     * Process verb "Identify"
-     *
-     * @access	protected
-     *
-     * @return	DOMElement		XML node to add to the OAI response
-     */
-    protected function verbIdentify() {
-
-        // Check for invalid arguments.
-        if (count($this->piVars) > 1) {
-
-            return $this->error('badArgument');
-
-        }
-
-        // Get repository name and administrative contact.
-        // Use default values for an installation with incomplete plugin configuration.
-
-        $adminEmail = 'unknown@example.org';
-        $repositoryName = 'Kitodo.Presentation OAI-PMH interface (incomplete configuration)';
-
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_libraries.oai_label AS oai_label,tx_dlf_libraries.contact AS contact',
-            'tx_dlf_libraries',
-            'tx_dlf_libraries.pid='.intval($this->conf['pages']).' AND tx_dlf_libraries.uid='.intval($this->conf['library']).tx_dlf_helper::whereClause('tx_dlf_libraries'),
-            '',
-            '',
-            ''
-        );
-
-        if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-            $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-            $adminEmail = htmlspecialchars(trim(str_replace('mailto:', '', $resArray['contact'])), ENT_NOQUOTES);
-            $repositoryName = htmlspecialchars($resArray['oai_label'], ENT_NOQUOTES);
-
-        } else {
-
-            if (TYPO3_DLOG) {
-
-                \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbIdentify()] Incomplete plugin configuration',
-                            $this->extKey, SYSLOG_SEVERITY_NOTICE);
-
-            }
-
-        }
-
-        // Get earliest datestamp. Use a default value if that fails.
-
-        $earliestDatestamp = '0000-00-00T00:00:00Z';
-
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_documents.tstamp AS tstamp',
-            'tx_dlf_documents',
-            'tx_dlf_documents.pid='.intval($this->conf['pages']),
-            '',
-            'tx_dlf_documents.tstamp ASC',
-            '1'
-        );
-
-        if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-            list ($timestamp) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
-            $earliestDatestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
-
-        } else {
-
-            if (TYPO3_DLOG) {
-
-                \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "'.
-                            $this->conf['pages'].'"', $this->extKey, SYSLOG_SEVERITY_NOTICE);
-
-            }
-
-        }
-
-        $linkConf = array (
-            'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
-        );
-        $baseURL = htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES);
-
-        // Add identification node.
-        $Identify = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'Identify');
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'repositoryName', $repositoryName));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'baseURL', $baseURL));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'protocolVersion', '2.0'));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'adminEmail', $adminEmail));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'earliestDatestamp', $earliestDatestamp));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'deletedRecord', 'transient'));
-        $Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/',
-                                    'granularity', 'YYYY-MM-DDThh:mm:ssZ'));
-
-        return $Identify;
-    }
-
-    /**
-     * Process verb "ListIdentifiers"
-     *
-     * @access	protected
-     *
-     * @return	string		Substitution for subpart "###RESPONSE###"
-     */
-    protected function verbListIdentifiers() {
-
-        // Check for invalid arguments.
-        if (!empty($this->piVars['resumptionToken'])) {
-
-            // "resumptionToken" is an exclusive argument.
-            if (count($this->piVars) > 2) {
-
-                return $this->error('badArgument');
-
-            } else {
-
-                return $this->resume();
-
-            }
-
-        } elseif (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
-
-            // "metadataPrefix" is required and "identifier" is not allowed.
-            return $this->error('badArgument');
-
-        } else {
-
-            $where = '';
-
-            // Check "metadataPrefix" for valid value.
-            if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
-
-                return $this->error('cannotDisseminateFormat');
-
-            } else {
-
-                // Check for required fields.
-                foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
-
-                    $where .= ' AND NOT tx_dlf_documents.'.$required.'=\'\'';
-
-                }
-
-            }
-
-            // Check "set" for valid value.
-            if (!empty($this->piVars['set'])) {
-
-                // Get set information.
-                $additionalWhere = '';
-
-                if (!$this->conf['show_userdefined']) {
-
-                    $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
-                }
-
-                $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                    'tx_dlf_collections.uid AS uid',
-                    'tx_dlf_collections',
-                    'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.oai_name='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'], 'tx_dlf_collections').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
-                    '',
-                    '',
-                    '1'
-                );
-
-                if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-                    return $this->error('noSetHierarchy');
-
-                } else {
-
-                    $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-                    $where .= ' AND tx_dlf_collections.uid='.intval($resArray['uid']);
-
-                }
-
-            }
-
-            // Check "from" for valid value.
-            if (!empty($this->piVars['from'])) {
-
-                if (is_array($from = strptime($this->piVars['from'], '%Y-%m-%dT%H:%M:%SZ')) || is_array($from = strptime($this->piVars['from'], '%Y-%m-%d'))) {
-
-                    $from = gmmktime($from['tm_hour'], $from['tm_min'], $from['tm_sec'], $from['tm_mon'] + 1, $from['tm_mday'], $from['tm_year'] + 1900);
-
-                } else {
-
-                    return $this->error('badArgument');
-
-                }
-
-                $where .= ' AND tx_dlf_documents.tstamp>='.intval($from);
-
-            }
-
-            // Check "until" for valid value.
-            if (!empty($this->piVars['until'])) {
-
-                if (is_array($until = strptime($this->piVars['until'], '%Y-%m-%dT%H:%M:%SZ')) || is_array($until = strptime($this->piVars['until'], '%Y-%m-%d'))) {
-
-                    $until = gmmktime($until['tm_hour'], $until['tm_min'], $until['tm_sec'], $until['tm_mon'] + 1, $until['tm_mday'], $until['tm_year'] + 1900);
-
-                } else {
-
-                    return $this->error('badArgument');
-
-                }
-
-                if (!empty($from) && $from > $until) {
-
-                    return $this->error('badArgument');
-
-                }
-
-                $where .= ' AND tx_dlf_documents.tstamp<='.intval($until);
-
-            }
-
-            // Check "from" and "until" for same granularity.
-            if (!empty($this->piVars['from']) && !empty($this->piVars['until'])) {
-
-                if (strlen($this->piVars['from']) != strlen($this->piVars['until'])) {
-
-                    return $this->error('badArgument');
-
-                }
-
-            }
-
-        }
-
-        // Select records from database.
-        if (!$this->conf['show_userdefined']) {
-
-            $where .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        }
-
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_documents.uid',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
-            'tx_dlf_collections',
-            'AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-            'tx_dlf_documents.uid',
-            'tx_dlf_documents.tstamp',
-            ''
-        );
-
-        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-            return $this->error('noRecordsMatch');
-
-        } else {
-
-            // Build result set.
-            $results = array ();
-
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                // Save only UIDs for resumption token.
-                $results[] = $resArray['uid'];
-
-            }
-
-            if (empty($results)) {
-
-                return $this->error('noRecordsMatch');
-
-            }
-
-            $complete = FALSE;
-
-            $todo = array ();
-
-            $ListIdentifiers = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListIdentifiers');
-
-            for ($i = 0, $j = intval($this->conf['limit']); $i < $j; $i++) {
-
-                $todo[] = $results[$i];
-
-                if (empty($results[$i + 1])) {
-
-                    $complete = TRUE;
-
-                    break;
-
-                }
-
-            }
-
-            $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_documents.uid IN ('.implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($todo)).') AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_documents.uid',
-                'tx_dlf_documents.tstamp',
-                $this->conf['limit']
-            );
-
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                $header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
-
-                $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
-
-                $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
-
-                // Check if document is deleted or hidden.
-                // TODO: Use TYPO3 API functions here!
-                if ($resArray['deleted'] || $resArray['hidden']) {
-
-                    // Add "deleted" status.
-                    $header->setAttribute('status', 'deleted');
-
-                } else {
-
-                    // Add sets.
-                    foreach (explode(' ', $resArray['collections']) as $spec) {
-
-                        $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
-
-                    }
-
-                }
-
-                $ListIdentifiers->appendChild($header);
-
-            }
-
-            if (!$complete) {
-
-                // Save result set as list object.
-                $resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
-
-                $resultSet->reset();
-
-                $resultSet->add($results);
-
-                // Save result set to database and generate resumption token.
-                $token = uniqid();
-
-                $resultSet->metadata = array (
-                    'offset' => intval($this->conf['limit']),
-                    'metadataPrefix' => $this->piVars['metadataPrefix'],
-                );
-
-                $result = $GLOBALS['TYPO3_DB']->exec_INSERTquery(
-                    'tx_dlf_tokens',
-                    array (
-                        'tstamp' => $GLOBALS['EXEC_TIME'],
-                        'token' => $token,
-                        'options' => serialize($resultSet),
-                        'ident' => 'oai',
-                    )
-                );
-
-                if ($GLOBALS['TYPO3_DB']->sql_affected_rows($result) == 1) {
-
-                    $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
-
-                    $resumptionToken->setAttribute('cursor', '0');
-
-                    $resumptionToken->setAttribute('completeListSize', count($resultSet));
-
-                    $resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
-
-                    $ListIdentifiers->appendChild($resumptionToken);
-
-                } else {
-
-                    if (TYPO3_DLOG) {
-
-                        \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbListIdentifiers()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
-
-                    }
-
-                }
-
-            }
-
-            return $ListIdentifiers;
-
-        }
-
-    }
-
-    /**
-     * Process verb "ListMetadataFormats"
-     *
-     * @access	protected
-     *
-     * @return	DOMElement		XML node to add to the OAI response
-     */
-    protected function verbListMetadataFormats() {
-
-        $resArray = array ();
-
-        // Check for invalid arguments.
-        if (count($this->piVars) > 1) {
-
-            if (empty($this->piVars['identifier']) || count($this->piVars) > 2) {
-
-                return $this->error('badArgument');
-
-            } else {
-
-                // Check given identifier.
-                $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                    'tx_dlf_documents.*',
-                    'tx_dlf_documents',
-                    'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents'),
-                    '',
-                    '',
-                    '1'
-                );
-
-                if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-                    return $this->error('idDoesNotExist');
-
-                } else {
-
-                    $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-                }
-
-            }
-
-        }
-
-        // Add metadata formats node.
-        $ListMetadaFormats = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListMetadataFormats');
-
-        foreach ($this->formats as $prefix => $details) {
-
-            // Check for required fields.
-            if (!empty($resArray)) {
-
-                foreach ($details['requiredFields'] as $required) {
-
-                    if (empty($resArray[$required])) {
-
-                        // Skip metadata formats whose requirements are not met.
-                        continue 2;
-
-                    }
-
-                }
-
-            }
-
-            // Add format node.
-            $format = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataFormat');
-
-            $format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataPrefix', htmlspecialchars($prefix, ENT_NOQUOTES, 'UTF-8')));
-
-            $format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'schema', htmlspecialchars($details['schema'], ENT_NOQUOTES, 'UTF-8')));
-
-            $format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataNamespace', htmlspecialchars($details['namespace'], ENT_NOQUOTES, 'UTF-8')));
-
-            $ListMetadaFormats->appendChild($format);
-
-        }
-
-        return $ListMetadaFormats;
-
-    }
-
-    /**
-     * Process verb "ListRecords"
-     *
-     * @access	protected
-     *
-     * @return	string		Substitution for subpart "###RESPONSE###"
-     */
-    protected function verbListRecords() {
-
-        // Check for invalid arguments.
-        if (!empty($this->piVars['resumptionToken'])) {
-
-            // "resumptionToken" is an exclusive argument.
-            if (count($this->piVars) > 2) {
-
-                return $this->error('badArgument');
-
-            } else {
-
-                return $this->resume();
-
-            }
-
-        } elseif (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
-
-            // "metadataPrefix" is required and "identifier" is not allowed.
-            return $this->error('badArgument');
-
-        } else {
-
-            $where = '';
-
-            // Check "metadataPrefix" for valid value.
-            if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
-
-                return $this->error('cannotDisseminateFormat');
-
-            } else {
-
-                // Check for required fields.
-                foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
-
-                    $where .= ' AND NOT tx_dlf_documents.'.$required.'=\'\'';
-
-                }
-
-            }
-
-            // Check "set" for valid value.
-            if (!empty($this->piVars['set'])) {
-
-                // Get set information.
-                $additionalWhere = '';
-
-                if (!$this->conf['show_userdefined']) {
-
-                    $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
-                }
-
-                $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                    'tx_dlf_collections.uid AS uid',
-                    'tx_dlf_collections',
-                    'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.oai_name='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'], 'tx_dlf_collections').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
-                    '',
-                    '',
-                    '1'
-                );
-
-                if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-                    return $this->error('noSetHierarchy');
-
-                } else {
-
-                    $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
-
-                    $where .= ' AND tx_dlf_collections.uid='.intval($resArray['uid']);
-
-                }
-
-            }
-
-            // Check "from" for valid value.
-            if (!empty($this->piVars['from'])) {
-
-                if (is_array($from = strptime($this->piVars['from'], '%Y-%m-%dT%H:%M:%SZ')) || is_array($from = strptime($this->piVars['from'], '%Y-%m-%d'))) {
-
-                    $from = gmmktime($from['tm_hour'], $from['tm_min'], $from['tm_sec'], $from['tm_mon'] + 1, $from['tm_mday'], $from['tm_year'] + 1900);
-
-                } else {
-
-                    return $this->error('badArgument');
-
-                }
-
-                $where .= ' AND tx_dlf_documents.tstamp>='.intval($from);
-
-            }
-
-            // Check "until" for valid value.
-            if (!empty($this->piVars['until'])) {
-
-                if (is_array($until = strptime($this->piVars['until'], '%Y-%m-%dT%H:%M:%SZ')) || is_array($until = strptime($this->piVars['until'], '%Y-%m-%d'))) {
-
-                    $until = gmmktime($until['tm_hour'], $until['tm_min'], $until['tm_sec'], $until['tm_mon'] + 1, $until['tm_mday'], $until['tm_year'] + 1900);
-
-                } else {
-
-                    return $this->error('badArgument');
-
-                }
-
-                if (!empty($from) && $from > $until) {
-
-                    return $this->error('badArgument');
-
-                }
-
-                $where .= ' AND tx_dlf_documents.tstamp<='.intval($until);
-
-            }
-
-            // Check "from" and "until" for same granularity.
-            if (!empty($this->piVars['from']) && !empty($this->piVars['until'])) {
-
-                if (strlen($this->piVars['from']) != strlen($this->piVars['until'])) {
-
-                    return $this->error('badArgument');
-
-                }
-
-            }
-
-        }
-
-        // Select records from database.
-        if (!$this->conf['show_userdefined']) {
-
-            $where .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        }
-
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_documents.uid',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
-            'tx_dlf_collections',
-            'AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-            'tx_dlf_documents.uid',
-            'tx_dlf_documents.tstamp',
-            ''
-        );
-
-        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-            return $this->error('noRecordsMatch');
-
-        } else {
-
-            // Build result set.
-            $results = array ();
-
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                // Save only UIDs for resumption token.
-                $results[] = $resArray['uid'];
-
-            }
-
-            $complete = FALSE;
-
-            $todo = array ();
-
-            $ListRecords = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListRecords');
-
-            for ($i = 0, $j = intval($this->conf['limit']); $i < $j; $i++) {
-
-                $todo[] = $results[$i];
-
-                if (empty($results[$i + 1])) {
-
-                    $complete = TRUE;
-
-                    break;
-
-                }
-
-            }
-
-            $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_documents.uid IN ('.implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($todo)).') AND tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_documents.uid',
-                'tx_dlf_documents.tstamp',
-                $this->conf['limit']
-            );
-
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                // Add record node.
-                $record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
-
-                // Add header node.
-                $header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
-
-                $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
-
-                $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
-
-                // Check if document is deleted or hidden.
-                // TODO: Use TYPO3 API functions here!
-                if ($resArray['deleted'] || $resArray['hidden']) {
-
-                    // Add "deleted" status.
-                    $header->setAttribute('status', 'deleted');
-
-                    $record->appendChild($header);
-
-                } else {
-
-                    // Add sets.
-                    foreach (explode(' ', $resArray['collections']) as $spec) {
-
-                        $header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
-
-                    }
-
-                    $record->appendChild($header);
-
-                    // Add metadata node.
-                    $metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
-
-                    switch ($this->piVars['metadataPrefix']) {
-
-                        case 'oai_dc':
-
-                            $metadata->appendChild($this->getDcData($resArray));
-
-                            break;
-
-                        case 'epicur':
-
-                            $metadata->appendChild($this->getEpicurData($resArray));
-
-                            break;
-
-                        case 'mets':
-
-                            $metadata->appendChild($this->getMetsData($resArray));
-
-                            break;
-
-                    }
-
-                    $record->appendChild($metadata);
-
-                }
-
-                $ListRecords->appendChild($record);
-
-            }
-
-            if (!$complete) {
-
-                // Save result set as list object.
-                $resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
-
-                $resultSet->reset();
-
-                $resultSet->add($results);
-
-                // Save result set to database and generate resumption token.
-                $token = uniqid();
-
-                $resultSet->metadata = array (
-                    'offset' => intval($this->conf['limit']),
-                    'metadataPrefix' => $this->piVars['metadataPrefix'],
-                );
-
-                $result = $GLOBALS['TYPO3_DB']->exec_INSERTquery(
-                    'tx_dlf_tokens',
-                    array (
-                        'tstamp' => $GLOBALS['EXEC_TIME'],
-                        'token' => $token,
-                        'options' => serialize($resultSet),
-                        'ident' => 'oai',
-                    )
-                );
-
-                if ($GLOBALS['TYPO3_DB']->sql_affected_rows($result) == 1) {
-
-                    $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
-
-                    $resumptionToken->setAttribute('cursor', '0');
-
-                    $resumptionToken->setAttribute('completeListSize', count($resultSet));
-
-                    $resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
-
-                    $ListRecords->appendChild($resumptionToken);
-
-                } else {
-
-                    if (TYPO3_DLOG) {
-
-                        \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_oai->verbListRecords()] Could not create resumption token', $this->extKey, SYSLOG_SEVERITY_ERROR);
-
-                    }
-
-                }
-
-            }
-
-            return $ListRecords;
-
-        }
-
-    }
-
-    /**
-     * Process verb "ListSets"
-     *
-     * @access	protected
-     *
-     * @return	string		Substitution for subpart "###RESPONSE###"
-     */
-    protected function verbListSets() {
-
-        // Check for invalid arguments.
-        if (count($this->piVars) > 1) {
-
-            if (!empty($this->piVars['resumptionToken'])) {
-
-                return $this->error('badResumptionToken');
-
-            } else {
-
-                return $this->error('badArgument');
-
-            }
-
-        }
-
-        // Get set information.
-        $additionalWhere = '';
-
-        if (!$this->conf['show_userdefined']) {
-
-            $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        }
-
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_collections.oai_name AS oai_name,tx_dlf_collections.label AS label',
-            'tx_dlf_collections',
-            'tx_dlf_collections.sys_language_uid IN (-1,0) AND NOT tx_dlf_collections.oai_name=\'\' AND tx_dlf_collections.pid='.intval($this->conf['pages']).$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
-            'tx_dlf_collections.oai_name',
-            'tx_dlf_collections.oai_name',
-            ''
-        );
-
-        if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-
-            return $this->error('noSetHierarchy');
-
-        }
-
-        // Add set list node.
-        $ListSets = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListSets');
-
-        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-            // Add set node.
-            $set = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'set');
-
-            $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($resArray['oai_name'], ENT_NOQUOTES, 'UTF-8')));
-
-            $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setName', htmlspecialchars($resArray['label'], ENT_NOQUOTES, 'UTF-8')));
-
-            $ListSets->appendChild($set);
-
-        }
-
-        return $ListSets;
-
-    }
+				case 'mets':
+					$metadataNode->appendChild($this->getMetsData($resArray));
+					break;
+			}
+
+			$recordNode->appendChild($metadataNode);
+		}
+
+		$GetRecord->appendChild($recordNode);
+
+		return $GetRecord;
+	}
+
+	/**
+	 * Process verb "Identify"
+	 *
+	 * @access	protected
+	 *
+	 * @return	DOMElement		XML node to add to the OAI response
+	 */
+	protected function verbIdentify() {
+
+		// Check for invalid arguments.
+		if (count($this->piVars) > 1) {
+			return $this->error('badArgument');
+		}
+
+		// Get repository name and administrative contact.
+		// Use default values for an installation with incomplete plugin configuration.
+
+		$adminEmail = 'unknown@example.org';
+		$repositoryName = 'Kitodo.Presentation OAI-PMH interface (incomplete configuration)';
+
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'tx_dlf_libraries.oai_label AS oai_label,tx_dlf_libraries.contact AS contact',
+			'tx_dlf_libraries',
+			'tx_dlf_libraries.pid='.intval($this->conf['pages']).' AND tx_dlf_libraries.uid='.intval($this->conf['library']).tx_dlf_helper::whereClause('tx_dlf_libraries'),
+			'',
+			'',
+			''
+		);
+
+		if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+
+			$adminEmail = htmlspecialchars(trim(str_replace('mailto:', '', $resArray['contact'])), ENT_NOQUOTES);
+			$repositoryName = htmlspecialchars($resArray['oai_label'], ENT_NOQUOTES);
+
+		} else {
+			$this->devLog('[tx_dlf_oai->verbIdentify()] Incomplete plugin configuration', SYSLOG_SEVERITY_NOTICE);
+		}
+
+		// Get earliest datestamp. Use a default value if that fails.
+
+		$earliestDatestamp = '0000-00-00T00:00:00Z';
+
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'tx_dlf_documents.tstamp AS tstamp',
+			'tx_dlf_documents',
+			'tx_dlf_documents.pid=' . intval($this->conf['pages']),
+			'',
+			'tx_dlf_documents.tstamp ASC',
+			'1'
+		);
+
+		if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+			list ($timestamp) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
+			$earliestDatestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
+		} else {
+			$this->devLog('[tx_dlf_oai->verbIdentify()] No records found with PID "' . $this->conf['pages'] . '"',SYSLOG_SEVERITY_NOTICE);
+		}
+
+		$linkConf = array (
+			'parameter' => $GLOBALS['TSFE']->id,
+			'forceAbsoluteUrl' => 1
+		);
+		$baseURL = htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES);
+
+		// Add identification node.
+		$Identify = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'Identify');
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'repositoryName', $repositoryName));
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','baseURL', $baseURL));
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','protocolVersion', '2.0'));
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','adminEmail', $adminEmail));
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','earliestDatestamp', $earliestDatestamp));
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','deletedRecord', 'transient'));
+		$Identify->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/','granularity', 'YYYY-MM-DDThh:mm:ssZ'));
+
+		return $Identify;
+	}
+
+	/**
+	 * Process verb "ListIdentifiers"
+	 *
+	 * @access	protected
+	 *
+	 * @return	string		Substitution for subpart "###RESPONSE###"
+	 */
+	protected function verbListIdentifiers() {
+
+		// If we have a resumption token we can continue our work
+		if (!empty($this->piVars['resumptionToken'])) {
+			// "resumptionToken" is an exclusive argument.
+			if (count($this->piVars) > 2) {
+				return $this->error('badArgument');
+			} else {
+				return $this->resume();
+			}
+		}
+
+		// "metadataPrefix" is required and "identifier" is not allowed.
+		if (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
+			return $this->error('badArgument');
+		}
+
+		if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
+			return $this->error('cannotDisseminateFormat');
+		}
+
+		try {
+			$documentSet = $this->fetchDocumentUIDs();
+		} catch (Exception $exception) {
+			return $this->error($exception->getMessage());
+		}
+
+		$resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
+
+		$resultSet->reset();
+		$resultSet->add($documentSet);
+		$resultSet->metadata = array (
+			'completeListSize' => count($documentSet),
+			'metadataPrefix' => $this->piVars['metadataPrefix'],
+		);
+
+		return $this->generateOutputForDocumentList($resultSet);
+
+	}
+
+	/**
+	 * Process verb "ListMetadataFormats"
+	 *
+	 * @access	protected
+	 *
+	 * @return	DOMElement		XML node to add to the OAI response
+	 */
+	protected function verbListMetadataFormats() {
+
+		$resArray = array ();
+
+		// Check for invalid arguments.
+		if (count($this->piVars) > 1) {
+			if (empty($this->piVars['identifier']) || count($this->piVars) > 2) {
+				return $this->error('badArgument');
+			}
+
+			// Check given identifier.
+			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+				'tx_dlf_documents.*',
+				'tx_dlf_documents',
+				'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['identifier'], 'tx_dlf_documents'),
+				'',
+				'',
+				'1'
+			);
+
+			if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+				return $this->error('idDoesNotExist');
+			}
+
+			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+		}
+
+		// Add metadata formats node.
+		$ListMetadaFormats = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListMetadataFormats');
+
+		foreach ($this->formats as $prefix => $details) {
+			if (!empty($resArray)) {
+				foreach ($details['requiredFields'] as $required) {
+					if (empty($resArray[$required])) {
+						// Skip metadata formats whose requirements are not met.
+						continue 2;
+					}
+				}
+			}
+
+			// Add format node.
+			$format = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataFormat');
+
+			$format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataPrefix', htmlspecialchars($prefix, ENT_NOQUOTES, 'UTF-8')));
+			$format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'schema', htmlspecialchars($details['schema'], ENT_NOQUOTES, 'UTF-8')));
+			$format->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadataNamespace', htmlspecialchars($details['namespace'], ENT_NOQUOTES, 'UTF-8')));
+
+			$ListMetadaFormats->appendChild($format);
+		}
+
+		return $ListMetadaFormats;
+	}
+
+	/**
+	 * Process verb "ListRecords"
+	 *
+	 * @access	protected
+	 *
+	 * @return	string		Substitution for subpart "###RESPONSE###"
+	 */
+	protected function verbListRecords() {
+
+		// Check for invalid arguments.
+		if (!empty($this->piVars['resumptionToken'])) {
+			// "resumptionToken" is an exclusive argument.
+			if (count($this->piVars) > 2) {
+				return $this->error('badArgument');
+			} else {
+				return $this->resume();
+			}
+
+		}
+
+		if (empty($this->piVars['metadataPrefix']) || !empty($this->piVars['identifier'])) {
+			// "metadataPrefix" is required and "identifier" is not allowed.
+			return $this->error('badArgument');
+		}
+
+		// Check "metadataPrefix" for valid value.
+		if (!in_array($this->piVars['metadataPrefix'], array_keys($this->formats))) {
+			return $this->error('cannotDisseminateFormat');
+		}
+
+		try {
+			$documentSet = $this->fetchDocumentUIDs();
+		} catch (Exception $exception) {
+			return $this->error($exception->getMessage());
+		}
+
+		$resultSet = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('tx_dlf_list');
+
+		$resultSet->reset();
+		$resultSet->add($documentSet);
+		$resultSet->metadata = array (
+			'completeListSize' => count($documentSet),
+			'metadataPrefix' => $this->piVars['metadataPrefix'],
+		);
+
+		return $this->generateOutputForDocumentList($resultSet);
+	}
+
+	/**
+	 * Process verb "ListSets"
+	 *
+	 * @access	protected
+	 *
+	 * @return	string		Substitution for subpart "###RESPONSE###"
+	 */
+	protected function verbListSets() {
+
+		// Check for invalid arguments.
+		if (count($this->piVars) > 1) {
+			if (!empty($this->piVars['resumptionToken'])) {
+				return $this->error('badResumptionToken');
+			} else {
+				return $this->error('badArgument');
+			}
+		}
+
+		$where = '';
+
+		if (!$this->conf['show_userdefined']) {
+			$where = ' AND tx_dlf_collections.fe_cruser_id=0';
+		}
+
+		$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+			'tx_dlf_collections.oai_name AS oai_name,tx_dlf_collections.label AS label',
+			'tx_dlf_collections',
+			'tx_dlf_collections.sys_language_uid IN (-1,0) AND NOT tx_dlf_collections.oai_name=\'\' AND tx_dlf_collections.pid='.intval($this->conf['pages']).$where.tx_dlf_helper::whereClause('tx_dlf_collections'),
+			'tx_dlf_collections.oai_name',
+			'tx_dlf_collections.oai_name',
+			''
+		);
+
+		if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+			return $this->error('noSetHierarchy');
+		}
+
+		$ListSets = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListSets');
+
+		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+			$set = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'set');
+
+			$set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($resArray['oai_name'], ENT_NOQUOTES, 'UTF-8')));
+			$set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setName', htmlspecialchars($resArray['label'], ENT_NOQUOTES, 'UTF-8')));
+
+			$ListSets->appendChild($set);
+		}
+
+		return $ListSets;
+	}
+
+
+
+	/**
+	 * @return array
+	 * @throws Exception
+	 */
+	private function fetchDocumentUIDs()
+	{
+		$solr_query = '';
+
+		if (!$this->conf['show_userdefined']) {
+			$where = ' AND tx_dlf_collections.fe_cruser_id=0';
+		}
+
+		// Check "set" for valid value.
+		if (!empty($this->piVars['set'])) {
+
+			// For SOLR we need the index_name of the collection,
+			// For DB Query we need the UID of the collection
+			$result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+				'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.uid AS uid, tx_dlf_collections.index_search as index_query ',
+				'tx_dlf_collections',
+				'tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.oai_name=' . $GLOBALS['TYPO3_DB']->fullQuoteStr($this->piVars['set'],
+					'tx_dlf_collections') . $where . tx_dlf_helper::whereClause('tx_dlf_collections'),
+				'',
+				'',
+				'1'
+			);
+
+			if (!$GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+				throw new Exception('noSetHierarchy');
+			}
+
+			$resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+
+			if($resArray['index_query'] != "") {
+				$solr_query .= '(' . $resArray['index_query'] . ')';
+			} else {
+				$solr_query .= 'collection:' . '"' . $resArray['index_name'] . '"';
+			}
+
+		} else {
+			// If no set is specified we have to query for all collections
+			$solr_query .= 'collection:* NOT collection:""';
+
+		}
+
+		// Check for required fields.
+		foreach ($this->formats[$this->piVars['metadataPrefix']]['requiredFields'] as $required) {
+			$solr_query .= ' NOT ' . $required . ':""';
+		}
+
+		$from = "*";
+		// Check "from" for valid value.
+		if (!empty($this->piVars['from'])) {
+
+			// Is valid format?
+			if (is_array($date_array = strptime($this->piVars['from'],
+					'%Y-%m-%dT%H:%M:%SZ')) || is_array($date_array = strptime($this->piVars['from'], '%Y-%m-%d'))) {
+
+				$timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
+					$date_array['tm_mday'], $date_array['tm_year'] + 1900);
+
+			   $from = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) .'.000Z';
+
+			} else {
+				throw new Exception('badArgument');
+			}
+		}
+
+		$until = "*";
+		// Check "until" for valid value.
+		if (!empty($this->piVars['until'])) {
+
+			// Is valid format?
+			if (is_array($date_array = strptime($this->piVars['until'],
+					'%Y-%m-%dT%H:%M:%SZ')) || is_array($date_array = strptime($this->piVars['until'], '%Y-%m-%d'))) {
+
+				$timestamp = gmmktime($date_array['tm_hour'], $date_array['tm_min'], $date_array['tm_sec'], $date_array['tm_mon'] + 1,
+					$date_array['tm_mday'], $date_array['tm_year'] + 1900);
+
+				$until = date("Y-m-d", $timestamp) . 'T' . date("H:i:s", $timestamp) . '.999Z';
+
+				if ($from != "*" && $from > $until) {
+					throw new Exception('badArgument');
+				}
+
+			} else {
+				throw new Exception('badArgument');
+			}
+		}
+
+		// Check "from" and "until" for same granularity.
+		if (!empty($this->piVars['from']) && !empty($this->piVars['until'])) {
+			if (strlen($this->piVars['from']) != strlen($this->piVars['until'])) {
+				throw new Exception('badArgument');
+			}
+		}
+
+		$solr_query .= ' AND timestamp:[' . $from . ' TO ' . $until .']';
+
+		$documentSet = array();
+
+		$solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+
+		// We only care about the UID in the results and want them sorted
+		$parameters = array("fl" => "uid", "sort" => "uid asc");
+
+		$result = $solr->search_raw($solr_query, $parameters);
+
+		if (empty($result)) {
+			throw new Exception('noRecordsMatch');
+		}
+
+		foreach ($result as $doc) {
+			$documentSet[] = $doc->uid;
+		}
+
+		return $documentSet;
+	}
+
+	/**
+	 * @param tx_dlf_list $documentListSet
+	 * @return DOMElement
+	 */
+	private function generateOutputForDocumentList($documentListSet) {
+
+		 $documentsToProcess = $documentListSet->removeRange(0, intval($this->conf['limit']));
+		 $verb = $this->piVars['verb'];
+
+		$documents = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
+			'tx_dlf_documents.*,GROUP_CONCAT(DISTINCT tx_dlf_collections.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS collections',
+			'tx_dlf_documents',
+			'tx_dlf_relations',
+			'tx_dlf_collections',
+			'AND tx_dlf_documents.uid IN (' . implode(',', $GLOBALS['TYPO3_DB']->cleanIntArray($documentsToProcess)) . ') AND tx_dlf_documents.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_collections.pid=' . intval($this->conf['pages']) . ' AND tx_dlf_relations.ident=' . $GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations') . tx_dlf_helper::whereClause('tx_dlf_collections'),
+			'tx_dlf_documents.uid',
+			'tx_dlf_documents.tstamp',
+			$this->conf['limit']
+		);
+
+		$output = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $verb);
+
+		while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
+			// Add header node.
+			$header = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'header');
+
+			$header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'identifier', htmlspecialchars($resArray['record_id'], ENT_NOQUOTES, 'UTF-8')));
+			$header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'datestamp', gmdate('Y-m-d\TH:i:s\Z', $resArray['tstamp'])));
+
+			// Check if document is deleted or hidden.
+			// TODO: Use TYPO3 API functions here!
+			if ($resArray['deleted'] || $resArray['hidden']) {
+				// Add "deleted" status.
+				$header->setAttribute('status', 'deleted');
+
+				if ($verb == 'ListRecords') {
+					// Add record node.
+					$record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
+
+					$record->appendChild($header);
+					$output->appendChild($record);
+
+				} elseif ($verb == 'ListIdentifiers') {
+					$output->appendChild($header);
+				}
+
+			} else {
+				// Add sets.
+				foreach (explode(' ', $resArray['collections']) as $spec) {
+					$header->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($spec, ENT_NOQUOTES, 'UTF-8')));
+				}
+
+				if ($verb == 'ListRecords') {
+					// Add record node.
+					$record = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'record');
+
+					$record->appendChild($header);
+
+					// Add metadata node.
+					$metadata = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'metadata');
+
+					$metadataPrefix = $this->piVars['metadataPrefix'];
+					if(!$metadataPrefix) {
+						// If we resume an action the metadataPrefix is stored with the documentSet
+						$metadataPrefix = $documentListSet->metadata['metadataPrefix'];
+					}
+
+					switch ($metadataPrefix) {
+						case 'oai_dc':
+							$metadata->appendChild($this->getDcData($resArray));
+							break;
+
+						case 'epicur':
+							$metadata->appendChild($this->getEpicurData($resArray));
+							break;
+
+						case 'mets':
+							$metadata->appendChild($this->getMetsData($resArray));
+							break;
+					}
+
+					$record->appendChild($metadata);
+					$output->appendChild($record);
+
+				} elseif ($verb == 'ListIdentifiers') {
+					$output->appendChild($header);
+				}
+			}
+		}
+
+		$output->appendChild($this->generateResumptionTokenForDocumentListSet($documentListSet));
+
+		return $output;
+	}
+
+	/**
+	 * @param tx_dlf_list $documentListSet
+	 * @return DOMElement
+	 */
+	private function generateResumptionTokenForDocumentListSet($documentListSet)
+	{
+		$resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
+
+		if ($documentListSet->count() != 0) {
+
+			$token = uniqid();
+
+			$GLOBALS['TYPO3_DB']->exec_INSERTquery(
+				'tx_dlf_tokens',
+				array(
+					'tstamp' => $GLOBALS['EXEC_TIME'],
+					'token' => $token,
+					'options' => serialize($documentListSet),
+					'ident' => 'oai',
+				)
+			);
+
+			if($GLOBALS['TYPO3_DB']->sql_affected_rows() == 1) {
+				$resumptionToken->setAttribute('resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
+			} else {
+				$this->devLog('[tx_dlf_oai->verb'. $this->piVars['verb'] .'()] Could not create resumption token', SYSLOG_SEVERITY_ERROR);
+			}
+		}
+
+		$resumptionToken->setAttribute('cursor', intval($documentListSet->metadata['completeListSize']) - count($documentListSet));
+		$resumptionToken->setAttribute('completeListSize',	$documentListSet->metadata['completeListSize']);
+		$resumptionToken->setAttribute('expirationDate', gmdate('Y-m-d\TH:i:s\Z', $GLOBALS['EXEC_TIME'] + $this->conf['expired']));
+
+		return $resumptionToken;
+	}
+
+	private function devLog($message, $severity, $data = null) {
+		if (TYPO3_DLOG) {
+			\TYPO3\CMS\Core\Utility\GeneralUtility::devLog($message, $this->extKey, $severity, $data);
+		}
+	}
+
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php'])	{
+	include_once($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/dlf/plugins/oai/class.tx_dlf_oai.php']);
 
 }

--- a/plugins/oai/flexform.xml
+++ b/plugins/oai/flexform.xml
@@ -90,6 +90,21 @@
 							</config>
 						</TCEforms>
 					</show_userdefined>
+					<solrcore>
+						<TCEforms>
+							<displayCond>FIELD:pages:REQ:true</displayCond>
+							<exclude>1</exclude>
+							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.solrcore</label>
+							<config>
+								<type>select</type>
+								<items type="array"></items>
+								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_solrList</itemsProcFunc>
+								<size>1</size>
+								<maxitems>1</maxitems>
+								<minitems>0</minitems>
+							</config>
+						</TCEforms>
+					</solrcore>
 					<stylesheet>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/plugins/oai/flexform.xml
+++ b/plugins/oai/flexform.xml
@@ -49,6 +49,7 @@
 							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.library</label>
 							<config>
 								<type>select</type>
+								<renderType>selectSingle</renderType>
 								<items type="array"></items>
 								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_libraryList</itemsProcFunc>
 								<size>1</size>

--- a/plugins/oai/locallang.xml
+++ b/plugins/oai/locallang.xml
@@ -20,8 +20,10 @@
 			<label index="tt_content.pi_flexform.limit">Records per request</label>
 			<label index="tt_content.pi_flexform.expired">Expiration time for resumption token (seconds)</label>
 			<label index="tt_content.pi_flexform.show_userdefined">Show user-defined collections?</label>
+			<label index="tt_content.pi_flexform.solrcore">Solr Core</label>
 			<label index="tt_content.pi_flexform.stylesheet">Transformation stylesheet</label>
 			<label index="tt_content.pi_flexform.unqualified_epicur">Use unqualified epicur?</label>
+
 			<label index="badArgument">The request includes illegal arguments, is missing required arguments, or values for arguments have an illegal syntax.</label>
 			<label index="badResumptionToken">The value of the resumptionToken argument is invalid or expired.</label>
 			<label index="badVerb">Value of the verb argument is not a legal OAI-PMH verb or the verb argument is missing.</label>
@@ -38,6 +40,7 @@
 			<label index="tt_content.pi_flexform.limit">Datensätze pro Abfrage</label>
 			<label index="tt_content.pi_flexform.expired">Gültigkeitsdauer des Resumption Tokens (Sekunden)</label>
 			<label index="tt_content.pi_flexform.show_userdefined">Benutzerdefinierte Kollektionen anzeigen?</label>
+			<label index="tt_content.pi_flexform.solrcore">Solr Kern</label>
 			<label index="tt_content.pi_flexform.stylesheet">XSL-Stylesheet</label>
 			<label index="tt_content.pi_flexform.unqualified_epicur">Unqualifiziertes Epicur verwenden?</label>
 			<label index="badArgument">Die Anfrage enthält ungültige Parameter, es fehlen benötigte Parameter oder Parameter haben ungültige Werte.</label>

--- a/plugins/oai/transform.xsl
+++ b/plugins/oai/transform.xsl
@@ -377,7 +377,9 @@ p.intro {
 	Resumption Token
 -->
 <xsl:template match="oai:resumptionToken">
-	<p>There are more results.</p>
+	<xsl:if test="@resumptionToken">
+		<p>There are more results.</p>
+	</xsl:if>
 	<table class="values">
 		<tr><td class="key">Submitted Records</td>
 		<td class="value"><xsl:value-of select="@cursor"/></td></tr>
@@ -386,9 +388,13 @@ p.intro {
 		<tr><td class="key">Expiration Datestamp</td>
 		<td class="value"><xsl:value-of select="@expirationDate"/></td></tr>
 		<tr><td class="key">Resumption Token</td>
-		<td class="value"><xsl:value-of select="."/>
-		<xsl:text> </xsl:text>
-		<a class="link" href="?verb={/oai:OAI-PMH/oai:request/@verb}&amp;resumptionToken={.}">Resume</a></td></tr>
+		<td class="value">
+			<xsl:if test="@resumptionToken">
+				<xsl:value-of select="@resumptionToken"/>
+				<xsl:text> </xsl:text>
+				<a class="link" href="?verb={/oai:OAI-PMH/oai:request/@verb}&amp;resumptionToken={@resumptionToken}">Resume</a>
+			</xsl:if>
+		</td></tr>
 	</table>
 </xsl:template>
 
@@ -405,7 +411,7 @@ p.intro {
 <!--
 	DublinCore Metadata
 -->
-<xsl:template match="oai_dc:dc"  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" >
+<xsl:template match="oai_dc:dc" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" >
 	<div class="dcdata">
 		<h3>DublinCore Metadata</h3>
 		<table class="dcdata">


### PR DESCRIPTION
This is a duplicate of https://github.com/kitodo/kitodo-presentation/pull/244. Due to directory changes and changes in the files in the master branch I was not able to rebase my code. So I had to create this pull request instead.

Content-wise it is identical and I have already made some requested changes from https://github.com/kitodo/kitodo-presentation/pull/244.

For me two open questions remain:

1. Should the regular Expression for field queries enforce parenthesis or make them optional? They are not mandatory for a query so I’d recommend to make them optional here as well.
See: https://github.com/kitodo/kitodo-presentation/pull/244#discussion_r158266669) 
Commit: https://github.com/kitodo/kitodo-presentation/commit/de3000f8aeb4f1a7c709623246f9d8bcb71f15e0

2. Should the internal name of a Solr core be fixed or editable.
See: https://github.com/kitodo/kitodo-presentation/pull/244#discussion_r158270137
Commit: https://github.com/kitodo/kitodo-presentation/commit/31eb134f719b30c55a327719607b7e28a7fc2501


That should be all the changes for the OAI-Plugin. I will open a new PR were I add the Solr queries in the collection plugin.

For completeness the description of https://github.com/kitodo/kitodo-presentation/pull/244:

> This pull request contains refactoring and extension of dlf/plugins/oai/class.tx_dlf_oai.php.
> 
> The methods verbListIdentifiers(), verbListRecords() and resume() basically contained the same logic and duplicated a bunch of code. I extracted those parts into fetchDocumentUIDs(), generateOutputForDocumentList(…) and generateResumptionTokenForDocumentListSet(…).
> 
> verbListIdentifiers() and verbListRecords() follow the same basic structure.
> 
> check piVars
> fetchDocumentUIDs()
> Create a resultSet and generate output for it via generateOutputForDocumentList()
> if there are documents left a resumption token will be generated and added to the output.
> resume() acts accordingly but gets its documentSet via resumptionToken from the database.
> 
> The extracted method fetchDocumentUIDsis now able to get documents via Solr query. To be able to query all output formats the Solr schema had to be extended by record_id, purl, urn and location. Those are required fields in the various output formats. The collection field is now required as well.
> 
> The default case for exposed OAI sets is to query via the index_name of the collection (ie. collection:[index_name]). You are also able to specify a Solr query for a given collection in the TYPO3 backend. This enables to define a set by arbitrary conditions (e.g. add two collections together or restrict a set by specific parameters). The Solr query has precedence. For the Solr query itself I added a raw search method in dlf/common/class.tx_dlf_solr.php to fetch only what I need from Solr.
> 
> Currently, the 'old' database way of generating OAI is still supported and set as the default. You can change this behaviour by checking the Solr usage setting in the OAI plugin. To use Solr queries you have to re-index your collections due to the Solr schema changes.
> 
> Additionally, the handling of resumption tokens has been improved. We now only save the remaining document UIDs per resumption token in the database and not the whole set. I added a helper method in dlf/common/class.tx_dlf_list.php to remove a range of documents from a tx_dlf_list. That should improve database performance. The UIDs that have to be stored and fetched get less with every further call.
> 
> I started by taking the changes @albig made in https://github.com/albig/kitodo-presentation/tree/collections-oai-sor which contained some tangential changes.