### PR TITLE
Add Solr queries to collection plugin

### DIFF
--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -27,6 +27,7 @@ return array (
             'disabled' => 'hidden',
             'fe_group' => 'fe_group',
         ),
+        'requestUpdate' => 'sys_language_uid',
         'iconfile'	=> 'EXT:dlf/res/icons/txdlfcollections.png',
         'rootLevel'	=> 0,
         'dividers2tabs' => 2,
@@ -112,6 +113,7 @@ return array (
         ),
         'index_name' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.index_name',
             'config' => array (
                 'type' => 'none',
@@ -122,6 +124,7 @@ return array (
         ),
         'index_search' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.index_search',
             'config' => array (
             'type' => 'text',
@@ -132,6 +135,7 @@ return array (
         ),
         'oai_name' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.oai_name',
             'config' => array (
                 'type' => 'input',
@@ -142,6 +146,7 @@ return array (
         ),
         'description' => array (
             'exclude' => 1,
+            'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.description',
             'config' => array (
                 'type' => 'text',
@@ -153,6 +158,7 @@ return array (
         ),
         'thumbnail' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.thumbnail',
             'config' => array (
                 'type' => 'group',
@@ -165,6 +171,7 @@ return array (
         ),
         'priority' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.priority',
             'config' => array (
                 'type' => 'select',
@@ -184,6 +191,7 @@ return array (
         ),
         'documents' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.documents',
             'config' => array (
                 'type' => 'select',
@@ -203,6 +211,7 @@ return array (
         ),
         'owner' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.owner',
             'config' => array (
                 'type' => 'select',
@@ -219,6 +228,7 @@ return array (
         ),
         'fe_cruser_id' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.fe_cruser_id',
             'config' => array (
                 'type' => 'select',
@@ -235,6 +245,7 @@ return array (
         ),
         'fe_admin_lock' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.fe_admin_lock',
             'config' => array (
                 'type' => 'check',
@@ -243,6 +254,7 @@ return array (
         ),
         'status' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.status',
             'config' => array (
                 'type' => 'select',

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -34,7 +34,7 @@ Download of current version is `avaiable on GitHub <https://github.com/kitodo/ki
 Libraries using Kitodo.Presentation
 -----------------------------------
 
-The following libraries use KITODO.Presentation for their digital collections:
+The following libraries use Kitodo.Presentation for their digital collections:
 
 * `SLUB Dresden <http://digital.slub-dresden.de/>`_
 * `UB "Georgius Agricola" at the TU Bergakademie Freiberg <http://digital.ub.tu-freiberg.de/>`_
@@ -66,7 +66,7 @@ The software primarily consists of three modules:
 Commons
 ^^^^^^^
 is a group of classes that build upon the TYPO3 API, adding
-Goobi-specific functions, such as handling METS structures and library metadata
+Kitodo-specific functions, such as handling METS structures and library metadata
 in various formats, or linking external resources, such as OAI interfaces or
 Solr search engines. The API extensions are available to all TYPO3 extensions,
 which means that they can not only be used by Kitodo.Presentation, but by other

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -40,7 +40,7 @@ The following libraries use KITODO.Presentation for their digital collections:
 * `UB "Georgius Agricola" at the TU Bergakademie Freiberg <http://digital.ub.tu-freiberg.de/>`_
 * `SUB Hamburg <http://digitalisate.sub.uni-hamburg.de/>`_
 * `Gottfried Wilhelm Leibniz Library Hannover <http://digitale-sammlungen.gwlb.de/>`_
-* `UB Mannheim <http://digi.bib.uni-mannheim.de/>`_
+* `UB Mannheim <https://digi.bib.uni-mannheim.de/>`_
 * `Orff-Zentrum München <http://www.orff-zentrum.de/>`_
 * `Württembergische Landesbibliothek Stuttgart <http://digital.wlb-stuttgart.de/digitale-sammlungen/>`_
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -40,7 +40,7 @@ The following libraries use KITODO.Presentation for their digital collections:
 * `UB "Georgius Agricola" at the TU Bergakademie Freiberg <http://digital.ub.tu-freiberg.de/>`_
 * `SUB Hamburg <http://digitalisate.sub.uni-hamburg.de/>`_
 * `Gottfried Wilhelm Leibniz Library Hannover <http://digitale-sammlungen.gwlb.de/>`_
-* `UB Mannheim <http://goobi.bib.uni-mannheim.de/>`_
+* `UB Mannheim <http://digi.bib.uni-mannheim.de/>`_
 * `Orff-Zentrum München <http://www.orff-zentrum.de/>`_
 * `Württembergische Landesbibliothek Stuttgart <http://digital.wlb-stuttgart.de/digitale-sammlungen/>`_
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Kitodo.Presentation
 
 Kitodo.Presentation is a feature-rich framework for building a METS-based digital library. It is part of the Kitodo Digital Library Suite.
 
-Kitodo.Presentation is highly customizable through a user-friendly backend and flexible design templates. Since it is based on the great free and open source Content Management System [TYPO3](https://github.com/TYPO3/TYPO3.CMS), it integrates perfectly with your website and can easily be managed by editors. Kitodo.Presentation provides a comprehensive toolset covering all requirements for presenting digitized media. It implements international standards such as [IIIF Image API](http://iiif.io/api/image), [OAI Protocol for Metadata Harvesting](http://www.openarchives.org/OAI/openarchivesprotocol.html), [METS](http://www.loc.gov/standards/mets), [MODS](http://www.loc.gov/standards/mods), [TEI](http://www.tei-c.org), [ALTO](http://www.loc.gov/standards/alto), and can be configured to support any other descriptive XML format using simple XPath expressions.
+Kitodo.Presentation is highly customizable through a user-friendly backend and flexible design templates. Since it is based on the great free and open source Content Management System [TYPO3](https://typo3.org), it integrates perfectly with your website and can easily be managed by editors. Kitodo.Presentation provides a comprehensive toolset covering all requirements for presenting digitized media. It implements international standards such as [IIIF Image API](http://iiif.io/api/image), [OAI Protocol for Metadata Harvesting](http://www.openarchives.org/OAI/openarchivesprotocol.html), [METS](http://www.loc.gov/standards/mets), [MODS](http://www.loc.gov/standards/mods), [TEI](http://www.tei-c.org), [ALTO](http://www.loc.gov/standards/alto), and can be configured to support any other descriptive XML format using simple XPath expressions.
 
 <a href="https://www.codacy.com/app/kitodo/kitodo-presentation">
   <img alt="Codacy Grade" src="https://api.codacy.com/project/badge/Grade/1291eba67cb744c9ad04a74883d45d84"/>
@@ -14,6 +14,11 @@ Kitodo.Presentation is highly customizable through a user-friendly backend and f
 <a href="https://scrutinizer-ci.com/g/kitodo/kitodo-presentation/?branch=master">
   <img alt="Scrutinizer Code Quality" src="https://scrutinizer-ci.com/g/kitodo/kitodo-presentation/badges/quality-score.png?b=master"/>
 </a>
+
+Requirements
+------------
+
+Kitodo.Presentation requires [TYPO3 7 LTS](https://get.typo3.org) which in turn needs at least [PHP 5.5](https://secure.php.net) and [MySQL 5.5](https://www.mysql.com) or [MariaDB 5.5](https://mariadb.com). [Apache Solr](https://lucene.apache.org/solr) must be available at least in version 3.6.2, but any version up to 7.0.1 should be working as well.
 
 Kitodo. Digital Library Modules
 -------------------------------

--- a/common/class.tx_dlf_alto.php
+++ b/common/class.tx_dlf_alto.php
@@ -24,11 +24,11 @@ class tx_dlf_alto implements tx_dlf_fulltext {
      *
      * @access	public
      *
-     * @param	SimpleXMLElement		$xml: The XML to extract the metadata from
+     * @param	SimpleXMLElement		$xml: The XML to extract the raw text from
      *
      * @return	string			The raw unformatted fulltext
      */
-    public static function getRawText(SimpleXMLElement $xml) {
+    public function getRawText(SimpleXMLElement $xml) {
 
         $xml->registerXPathNamespace('alto', 'http://www.loc.gov/standards/alto/ns-v2#');
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -856,7 +856,7 @@ final class tx_dlf_document {
 
                 }
 
-                // Set default value if applicable, but only th the default value > 0.
+                // Set default value if applicable.
                 // '!empty($resArray['default_value'])' is not possible, because '0' is a valid default value.
                 // Setting an empty default value creates a lot of empty fields within the index.
                 // These empty fields are then shown within the search facets as 'empty'.

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -2119,7 +2119,7 @@ final class tx_dlf_document {
 
                 $physSeq[0] = (string) $physNode[0]['ID'];
 
-                $this->physicalStructureInfo[$physSeq[0]]['id'] = $physNode[0]['ID'];
+                $this->physicalStructureInfo[$physSeq[0]]['id'] = (string) $physNode[0]['ID'];
 
                 $this->physicalStructureInfo[$physSeq[0]]['dmdId'] = (isset($physNode[0]['DMDID']) ? (string) $physNode[0]['DMDID'] : '');
 
@@ -2148,7 +2148,7 @@ final class tx_dlf_document {
 
                     $elements[(int) $elementNode['ORDER']] = (string) $elementNode['ID'];
 
-                    $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['id'] = $elementNode['ID'];
+                    $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['id'] = (string) $elementNode['ID'];
 
                     $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['dmdId'] = (isset($elementNode['DMDID']) ? (string) $elementNode['DMDID'] : '');
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -910,7 +910,7 @@ final class tx_dlf_document {
                     'tx_dlf_documents',
                     'tx_dlf_relations',
                     'tx_dlf_collections',
-                    'AND tx_dlf_collections.pid='.intval($cPid).' AND tx_dlf_documents.uid='.intval($this->uid).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+                    'AND tx_dlf_collections.pid='.intval($cPid).' AND tx_dlf_documents.uid='.intval($this->uid).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
                     'tx_dlf_collections.index_name',
                     '',
                     ''

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -902,6 +902,32 @@ final class tx_dlf_document {
 
             }
 
+            // Add collections from database to toplevel element if document is already saved.
+            if (\TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($this->uid) && $id == $this->_getToplevelId()) {
+
+                $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
+                    'tx_dlf_collections.index_name AS index_name',
+                    'tx_dlf_documents',
+                    'tx_dlf_relations',
+                    'tx_dlf_collections',
+                    'AND tx_dlf_collections.pid='.intval($cPid).' AND tx_dlf_documents.uid='.intval($this->uid).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+                    'tx_dlf_collections.index_name',
+                    '',
+                    ''
+                );
+
+                while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+                    if (!in_array($resArray['index_name'], $metadata['collection'])) {
+
+                        $metadata['collection'][] = $resArray['index_name'];
+
+                    }
+
+                }
+
+            }
+
         } else {
 
             // There is no dmdSec for this structure node.
@@ -1381,9 +1407,7 @@ final class tx_dlf_document {
             ''
         );
 
-        for ($i = 0, $j = $GLOBALS['TYPO3_DB']->sql_num_rows($result); $i < $j; $i++) {
-
-            $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
             $collUid[$resArray['index_name']] = $resArray['uid'];
 
@@ -1405,7 +1429,7 @@ final class tx_dlf_document {
                     'pid' => $pid,
                     'label' => $collection,
                     'index_name' => $collection,
-                    'oai_name' => (!empty($conf['publishNewCollections']) ? $collection : ''),
+                    'oai_name' => (!empty($conf['publishNewCollections']) ? tx_dlf_helper::getCleanString($collection) : ''),
                     'description' => '',
                     'documents' => 0,
                     'owner' => 0,
@@ -1435,24 +1459,6 @@ final class tx_dlf_document {
                 }
 
             }
-
-        }
-
-        // Preserve user-defined collections.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
-            'tx_dlf_collections',
-            'AND tx_dlf_documents.pid='.intval($pid).' AND tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_documents.uid='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->uid, 'tx_dlf_documents').' AND NOT (tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0) AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations'),
-            '',
-            '',
-            ''
-        );
-
-        for ($i = 0, $j = $GLOBALS['TYPO3_DB']->sql_num_rows($result); $i < $j; $i++) {
-
-            list ($collections[]) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
 
         }
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -2421,16 +2421,16 @@ final class tx_dlf_document {
 
         } else {
 
-            // Cast to string for safety reasons.
-            $location = (string) $uid;
-
             // Try to load METS file.
-            if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl($location) && $this->load($location)) {
+            if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl($uid) && $this->load($uid)) {
 
                 // Initialize core METS object.
                 $this->init();
 
                 if ($this->mets !== NULL) {
+
+                    // Cast to string for safety reasons.
+                    $location = (string) $uid;
 
                     // Check for METS object @ID.
                     if (!empty($this->mets['OBJID'])) {
@@ -2469,11 +2469,17 @@ final class tx_dlf_document {
 
             if (!empty($this->recordId)) {
 
+                // Try to match record identifier first.
                 $whereClause = 'tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->recordId, 'tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_documents');
+
+            } elseif (!empty($location)) {
+
+                // There is no record identifier, try to match location instead.
+                $whereClause = 'tx_dlf_documents.location='.$GLOBALS['TYPO3_DB']->fullQuoteStr($location, 'tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_documents');
 
             } else {
 
-                // There is no record identifier and there should be no hit in the database.
+                // Can't persistently identify document, don't try to match at all.
                 $whereClause = '1=-1';
 
             }

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -1375,7 +1375,7 @@ final class tx_dlf_document {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.uid AS uid',
             'tx_dlf_collections',
-            'tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0'.tx_dlf_helper::whereClause('tx_dlf_collections').' AND tx_dlf_collections.sys_language_uid IN (-1,0)',
+            'tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
             '',
             ''

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -1375,7 +1375,7 @@ final class tx_dlf_document {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.uid AS uid',
             'tx_dlf_collections',
-            'tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0'.tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0'.tx_dlf_helper::whereClause('tx_dlf_collections').' AND tx_dlf_collections.sys_language_uid IN (-1,0)',
             '',
             '',
             ''

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -2404,6 +2404,7 @@ final class tx_dlf_document {
 
     /**
      * This is a singleton class, thus the constructor should be private/protected
+     * (Get an instance of this class by calling tx_dlf_document::getInstance())
      *
      * @access	protected
      *
@@ -2467,15 +2468,10 @@ final class tx_dlf_document {
 
             }
 
-            if (!empty($this->recordId)) {
+            if (!empty($location) && !empty($this->recordId)) {
 
-                // Try to match record identifier first.
-                $whereClause = 'tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->recordId, 'tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_documents');
-
-            } elseif (!empty($location)) {
-
-                // There is no record identifier, try to match location instead.
-                $whereClause = 'tx_dlf_documents.location='.$GLOBALS['TYPO3_DB']->fullQuoteStr($location, 'tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_documents');
+                // Try to match record identifier or location (both should be unique).
+                $whereClause = '(tx_dlf_documents.location='.$GLOBALS['TYPO3_DB']->fullQuoteStr($location, 'tx_dlf_documents').' OR tx_dlf_documents.record_id='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->recordId, 'tx_dlf_documents').')'.tx_dlf_helper::whereClause('tx_dlf_documents');
 
             } else {
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -856,8 +856,11 @@ final class tx_dlf_document {
 
                 }
 
-                // Set default value if applicable.
-                if (empty($metadata[$resArray['index_name']][0])) {
+                // Set default value if applicable, but only th the default value > 0.
+                // '!empty($resArray['default_value'])' is not possible, because '0' is a valid default value.
+                // Setting an empty default value creates a lot of empty fields within the index.
+                // These empty fields are then shown within the search facets as 'empty'.
+                if (empty($metadata[$resArray['index_name']][0]) && strlen($resArray['default_value']) > 0) {
 
                     $metadata[$resArray['index_name']] = array ($resArray['default_value']);
 

--- a/common/class.tx_dlf_fulltext.php
+++ b/common/class.tx_dlf_fulltext.php
@@ -29,6 +29,6 @@ interface tx_dlf_fulltext {
      *
      * @return	string			The raw unformatted fulltext
      */
-    public static function getRawText(SimpleXMLElement $xml);
+    public function getRawText(SimpleXMLElement $xml);
 
 }

--- a/common/class.tx_dlf_helper.php
+++ b/common/class.tx_dlf_helper.php
@@ -81,36 +81,6 @@ class tx_dlf_helper {
     }
 
     /**
-     * Searches the array recursively for a given value and returns the corresponding key if successful
-     * @see http://php.net/array_search
-     *
-     * @access	public
-     *
-     * @param	mixed		$needle: The searched value
-     * @param	array		$haystack: The array to search in
-     * @param	boolean		$strict: Check needle's type, too?
-     *
-     * @return	mixed		Returns the needle's key if found and FALSE otherwise
-     *
-     * @deprecated because of its inefficiency
-     */
-    public static function array_search_recursive($needle, $haystack, $strict = FALSE) {
-
-        foreach ($haystack as $key => $value) {
-
-            if (($strict && $value === $needle) || (!$strict && $value == $needle) || (is_array($value) && self::array_search_recursive($needle, $value, $strict) !== FALSE)) {
-
-                return $key;
-
-            }
-
-        }
-
-        return FALSE;
-
-    }
-
-    /**
      * Check if given identifier is a valid identifier of the German National Library
      * @see	http://support.d-nb.de/iltis/onlineRoutinen/Pruefziffernberechnung.htm
      *

--- a/common/class.tx_dlf_helper.php
+++ b/common/class.tx_dlf_helper.php
@@ -362,6 +362,33 @@ class tx_dlf_helper {
     }
 
     /**
+     * Clean up a string to use in an URL.
+     *
+     * @access	public
+     *
+     * @param	string		$string: The string to clean up
+     *
+     * @return	string		The cleaned up string
+     */
+    public static function getCleanString($string) {
+
+        // Convert to lowercase.
+        $string = strtolower($string);
+
+        // Remove non-alphanumeric characters.
+        $string = preg_replace('/[^a-z0-9_\s-]/', '', $string);
+
+        // Remove multiple dashes or whitespaces.
+        $string = preg_replace('/[\s-]+/', ' ', $string);
+
+        // Convert whitespaces and underscore to dash.
+        $string = preg_replace('/[\s_]/', '-', $string);
+
+        return $string;
+
+    }
+
+    /**
      * Get the current frontend user object
      *
      * @access	public

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -793,6 +793,8 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('type', $physicalUnit['type'], self::$fields['fieldboost']['type']);
 
+            $solrDoc->setField('collection', $doc->metadataArray[$doc->toplevelId]['collection']);
+
             $solrDoc->setField('fulltext', tx_dlf_alto::getRawText($xml));
 
             // Add faceting information to physical sub-elements if applicable.
@@ -808,6 +810,14 @@ class tx_dlf_indexing {
                     }
 
                 }
+
+            }
+
+            // Add collection information to physical sub-elements if applicable.
+            if (in_array('collection', self::$fields['facets'])
+                && !empty($doc->metadataArray[$doc->toplevelId]['collection'])) {
+
+                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->toplevelId]['collection']);
 
             }
 

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -793,7 +793,7 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('type', $physicalUnit['type'], self::$fields['fieldboost']['type']);
 
-            $solrDoc->setField('fulltext', tx_dlf_alto::getRawText($xml));
+            $solrDoc->setField('fulltext', $doc->getRawText($physicalUnit['id']));
 
             // Add faceting information to physical sub-elements if applicable.
             foreach ($doc->metadataArray[$doc->toplevelId] as $index_name => $data) {

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -599,7 +599,7 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('urn', $metadata['urn']);
 
-            $solrDoc->setField('collection', $metadata['collection']);
+            $solrDoc->setField('collection', $doc->metadataArray[$doc->toplevelId]['collection']);
 
             $autocomplete = array ();
 

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -241,7 +241,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                 if ($this->solrConnect()) {
 
-                    $params = array();
+                    $params = array ();
 
                     // Restrict the fields to the required ones
                     $params['fl'] = "uid,id,toplevel,thumbnail,page";
@@ -256,9 +256,9 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                     $result = $this->solr->service->search('uid:'.tx_dlf_solr::escapeQuery($record['uid']), 0, $this->solr->limit, $params);
 
                     // If it is a fulltext search, enable highlighting and fetch the results
-                    if($this->metadata['fulltextSearch']) {
+                    if ($this->metadata['fulltextSearch']) {
 
-                        $params = array();
+                        $params = array ();
 
                         $params['hl'] = 'true';
                         $params['hl.useFastVectorHighlighter'] = 'true';
@@ -296,10 +296,10 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         } elseif (isset($record['subparts'][$resArray->id])) {
 
-                        	$record['subparts'][$resArray->id] = array (
+                            $record['subparts'][$resArray->id] = array (
                                 'uid' => $resArray->uid,
                                 'page' => $resArray->page,
-                        	    'preview' => (!empty($result_highlights->highlighting->{$resArray->id}->fulltext[0])?$result_highlights->highlighting->{$resArray->id}->fulltext[0]:""),
+                                'preview' => (!empty($result_highlights->highlighting->{$resArray->id}->fulltext[0]) ? $result_highlights->highlighting->{$resArray->id}->fulltext[0] : ""),
                                 'thumbnail' => $resArray->thumbnail,
                                 'metadata' => $metadata
                             );

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -253,6 +253,21 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                     // Get document's thumbnail and metadata from Solr index.
                     $result = $this->solr->service->search('uid:'.tx_dlf_solr::escapeQuery($record['uid']), 0, $this->solr->limit);
 
+                    // If it is a fulltext search, enable highlighting and fetch the results
+                    if($this->metadata['fulltextSearch']) {
+
+                        $params = array();
+
+                        $params['hl'] = 'true';
+                        $params['hl.fl'] = 'fulltext';
+                        $params['fl'] = 'id';
+
+                        $query_highlights = 'uid:'.tx_dlf_solr::escapeQuery($record['uid']).' AND fulltext:('.tx_dlf_solr::escapeQuery($this->metadata['searchString']).')';
+
+                        $result_highlights = $this->solr->service->search($query_highlights, 0, $this->solr->limit, $params);
+
+                    }
+
                     // Process results.
                     foreach ($result->response->docs as $resArray) {
 
@@ -281,7 +296,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                         	$record['subparts'][$resArray->id] = array (
                                 'uid' => $resArray->uid,
                                 'page' => $resArray->page,
-                        		'preview' => (!empty($record['subparts'][$resArray->id]['h']) ? $record['subparts'][$resArray->id]['h'] : ''),
+                        	    'preview' => (!empty($result_highlights->highlighting->{$resArray->id}->fulltext[0])?$result_highlights->highlighting->{$resArray->id}->fulltext[0]:""),
                                 'thumbnail' => $resArray->thumbnail,
                                 'metadata' => $metadata
                             );

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -241,6 +241,15 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                 if ($this->solrConnect()) {
 
+                    // Restrict the fields to the required ones
+                    $params['fl'] = "uid,id,toplevel,thumbnail,page";
+
+                    foreach ($this->solrConfig as $solr_name) {
+
+                        $params['fl'] .= ",".$solr_name;
+
+                    }
+
                     // Get document's thumbnail and metadata from Solr index.
                     $result = $this->solr->service->search('uid:'.tx_dlf_solr::escapeQuery($record['uid']), 0, $this->solr->limit);
 

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -241,6 +241,8 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                 if ($this->solrConnect()) {
 
+                    $params = array();
+
                     // Restrict the fields to the required ones
                     $params['fl'] = "uid,id,toplevel,thumbnail,page";
 
@@ -251,7 +253,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                     }
 
                     // Get document's thumbnail and metadata from Solr index.
-                    $result = $this->solr->service->search('uid:'.tx_dlf_solr::escapeQuery($record['uid']), 0, $this->solr->limit);
+                    $result = $this->solr->service->search('uid:'.tx_dlf_solr::escapeQuery($record['uid']), 0, $this->solr->limit, $params);
 
                     // If it is a fulltext search, enable highlighting and fetch the results
                     if($this->metadata['fulltextSearch']) {

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -223,7 +223,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         $record['metadata'] = $metadata;
 
-                    } elseif (($key = tx_dlf_helper::array_search_recursive($resArray['uid'], $record['subparts'], TRUE)) !== FALSE) {
+                    } elseif (($key = array_search($resArray['uid'], $record['subparts'], TRUE)) !== FALSE) {
 
                         $record['subparts'][$key] = array (
                             'uid' => $resArray['uid'],
@@ -267,12 +267,12 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                             $record['metadata'] = $metadata;
 
-                        } elseif (($key = tx_dlf_helper::array_search_recursive($resArray->id, $record['subparts'], TRUE)) !== FALSE) {
+                        } elseif (isset($record['subparts'][$resArray->id])) {
 
-                            $record['subparts'][$key] = array (
+                        	$record['subparts'][$resArray->id] = array (
                                 'uid' => $resArray->uid,
                                 'page' => $resArray->page,
-                                'preview' => (!empty($record['subparts'][$key]['h']) ? $record['subparts'][$key]['h'] : ''),
+                        		'preview' => (!empty($record['subparts'][$resArray->id]['h']) ? $record['subparts'][$resArray->id]['h'] : ''),
                                 'thumbnail' => $resArray->thumbnail,
                                 'metadata' => $metadata
                             );

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -223,7 +223,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         $record['metadata'] = $metadata;
 
-                    } elseif (($key = array_search($resArray['uid'], array_column($record['subparts'], 'u'), TRUE)) !== FALSE) {
+                    } elseif (($key = array_search(array('u' => $resArray['uid']), $record['subparts'], TRUE)) !== FALSE) {
 
                         $record['subparts'][$key] = array (
                             'uid' => $resArray['uid'],

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -244,11 +244,11 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                     $params = array ();
 
                     // Restrict the fields to the required ones
-                    $params['fl'] = "uid,id,toplevel,thumbnail,page";
+                    $params['fl'] = 'uid,id,toplevel,thumbnail,page';
 
                     foreach ($this->solrConfig as $solr_name) {
 
-                        $params['fl'] .= ",".$solr_name;
+                        $params['fl'] .= ','.$solr_name;
 
                     }
 
@@ -299,7 +299,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                             $record['subparts'][$resArray->id] = array (
                                 'uid' => $resArray->uid,
                                 'page' => $resArray->page,
-                                'preview' => (!empty($result_highlights->highlighting->{$resArray->id}->fulltext[0]) ? $result_highlights->highlighting->{$resArray->id}->fulltext[0] : ""),
+                                'preview' => (!empty($result_highlights->highlighting->{$resArray->id}->fulltext[0]) ? $result_highlights->highlighting->{$resArray->id}->fulltext[0] : ''),
                                 'thumbnail' => $resArray->thumbnail,
                                 'metadata' => $metadata
                             );

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -259,6 +259,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
                         $params = array();
 
                         $params['hl'] = 'true';
+                        $params['hl.useFastVectorHighlighter'] = 'true';
                         $params['hl.fl'] = 'fulltext';
                         $params['fl'] = 'id';
 

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -223,7 +223,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         $record['metadata'] = $metadata;
 
-                    } elseif (($key = array_search($resArray['uid'], $record['subparts'], TRUE)) !== FALSE) {
+                    } elseif (($key = array_search($resArray['uid'], array_column($record['subparts'], 'u'), TRUE)) !== FALSE) {
 
                         $record['subparts'][$key] = array (
                             'uid' => $resArray['uid'],

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -348,7 +348,7 @@ class tx_dlf_solr {
         $checks = array ();
 
         // Restrict the fields to the required ones
-        $this->params['fl'] = "uid,id,toplevel";
+        $this->params['fl'] = 'uid,id,toplevel';
 
         // Get metadata configuration.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -343,36 +343,36 @@ class tx_dlf_solr {
      */
     public function search($query = '') {
 
-        // Perform search.
-        $results = $this->service->search((string) $query, 0, $this->limit, $this->params);
-
-        $this->numberOfHits = count($results->response->docs);
-
         $toplevel = array ();
 
         $checks = array ();
 
+        // Restrict the fields to the required ones
+        $this->params['fl'] = "uid,id,toplevel";
+
         // Get metadata configuration.
-        if ($this->numberOfHits > 0) {
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_metadata.index_name AS index_name',
+            'tx_dlf_metadata',
+            'tx_dlf_metadata.is_sortable=1 AND tx_dlf_metadata.pid='.intval($this->cPid).tx_dlf_helper::whereClause('tx_dlf_metadata'),
+            '',
+            '',
+            ''
+        );
 
-            $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                'tx_dlf_metadata.index_name AS index_name',
-                'tx_dlf_metadata',
-                'tx_dlf_metadata.is_sortable=1 AND tx_dlf_metadata.pid='.intval($this->cPid).tx_dlf_helper::whereClause('tx_dlf_metadata'),
-                '',
-                '',
-                ''
-            );
+        $sorting = array ();
 
-            $sorting = array ();
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                $sorting[$resArray['index_name']] = $resArray['index_name'].'_sorting';
-
-            }
+            $sorting[$resArray['index_name']] = $resArray['index_name'].'_sorting';
+            $this->params['fl'] .= ','.$sorting[$resArray['index_name']];
 
         }
+
+        // Perform search.
+        $results = $this->service->search((string) $query, 0, $this->limit, $this->params);
+
+        $this->numberOfHits = count($results->response->docs);
 
         // Keep track of relevance.
         $i = 0;

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -412,7 +412,7 @@ class tx_dlf_solr {
 
             } else {
 
-            	$toplevel[$doc->uid]['p'][$doc->id] = array (
+                $toplevel[$doc->uid]['p'][$doc->id] = array (
                     'u' => $doc->id,
                     'h' => (!empty($results->highlighting->{$doc->id}->fulltext) ? $results->highlighting->{$doc->id}->fulltext[0] : '')
                 );

--- a/common/class.tx_dlf_solr.php
+++ b/common/class.tx_dlf_solr.php
@@ -412,7 +412,7 @@ class tx_dlf_solr {
 
             } else {
 
-                $toplevel[$doc->uid]['p'][] = array (
+            	$toplevel[$doc->uid]['p'][$doc->id] = array (
                     'u' => $doc->id,
                     'h' => (!empty($results->highlighting->{$doc->id}->fulltext) ? $results->highlighting->{$doc->id}->fulltext[0] : '')
                 );

--- a/common/locallang.xml
+++ b/common/locallang.xml
@@ -56,7 +56,7 @@
 			<label index="flash.solrcoreOkay">Solr core found!</label>
 			<label index="flash.solrcoreOkayMsg">There are configuration records for Solr cores. They can be edited in the list module.</label>
 			<label index="flash.solrcoreDeprecated">Deprecated configuration found!</label>
-			<label index="flash.solrcoreDeprecatedMsg">A common Solr core was found in the root-page. This is deprecated since Goobi.Presentation 1.1. Solr cores should be stored in the client's SysFolder instead. Move a Solr core to this SysFolder (manually) or create a new one automatically.&lt;br /&gt;&lt;br /&gt;&lt;a href="%s"&gt;Create new Solr core!&lt;/a&gt;</label>
+			<label index="flash.solrcoreDeprecatedMsg">A common Solr core was found in the root-page. This is deprecated since Kitodo.Presentation 1.1. Solr cores should be stored in the client's SysFolder instead. Move a Solr core to this SysFolder (manually) or create a new one automatically.&lt;br /&gt;&lt;br /&gt;&lt;a href="%s"&gt;Create new Solr core!&lt;/a&gt;</label>
 			<label index="flash.solrcoreMissing">No Solr core found!</label>
 			<label index="flash.solrcoreMissingMsg">There is no Solr core configured. For the search plugin at least one Solr core is needed. It can be created automatically.&lt;br /&gt;&lt;br /&gt;&lt;a href="%s"&gt;Create new Solr core!&lt;/a&gt;</label>
 			<label index="flash.solrcoreAdded">Solr core created!</label>
@@ -109,7 +109,7 @@
 			<label index="flash.solrcoreOkay">Solr Kern gefunden!</label>
 			<label index="flash.solrcoreOkayMsg">Es wurde die Konfiguration für einen Solr Kern gefunden. Über das Listenmodul können neue Datensätze hinzugefügt und die vorhandenen editiert werden.</label>
 			<label index="flash.solrcoreDeprecated">Veraltete Konfiguration gefunden!</label>
-			<label index="flash.solrcoreDeprecatedMsg">Es wurde ein allgemeiner Solr Kern in der Root-Page gefunden. Das entspricht dem Verhalten von Goobi.Presentation 1.0. Seit Version 1.1 sollten Solr Kerne im SysOrdner des jeweiligen Mandanten konfiguriert werden. Es sollte entweder einer der Solr Kerne aus der Root-Page in diesen SysOrdner verschoben werden (manuell) oder ein neuer Solr Kern angelegt werden.&lt;br /&gt;&lt;br /&gt;&lt;a href="%s"&gt;Neuen Solr Kern jetzt anlegen!&lt;/a&gt;</label>
+			<label index="flash.solrcoreDeprecatedMsg">Es wurde ein allgemeiner Solr Kern in der Root-Page gefunden. Das entspricht dem Verhalten von Kitodo.Presentation 1.0. Seit Version 1.1 sollten Solr Kerne im SysOrdner des jeweiligen Mandanten konfiguriert werden. Es sollte entweder einer der Solr Kerne aus der Root-Page in diesen SysOrdner verschoben werden (manuell) oder ein neuer Solr Kern angelegt werden.&lt;br /&gt;&lt;br /&gt;&lt;a href="%s"&gt;Neuen Solr Kern jetzt anlegen!&lt;/a&gt;</label>
 			<label index="flash.solrcoreMissing">Kein Solr Kern gefunden!</label>
 			<label index="flash.solrcoreMissingMsg">Es wurde kein Solr Kern gefunden. Ohne Solr Kern kann das Plugin zur Recherche in den Meta- und Strukturdaten nicht verwendet werden. Ein Solr Kern kann automatisch angelegt werden.&lt;br /&gt;&lt;br /&gt;&lt;a href="%s"&gt;Solr Kern jetzt anlegen!&lt;/a&gt;</label>
 			<label index="flash.solrcoreAdded">Solr Kern angelegt!</label>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,20 @@
   "name": "kitodo/presentation",
   "description": "Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.",
   "homepage": "https://www.kitodo.org/",
-  "authors": "Kitodo. Key to digital objects e.V.",
+  "authors": [
+    {
+      "name": "Kitodo. Key to digital objects e.V.",
+      "email": "contact@kitodo.org",
+      "homepage": "https://www.kitodo.org/",
+      "role": "provider"
+    },
+    {
+      "name": "Sebastian Meyer",
+      "email": "sebastian.meyer@slub-dresden.de",
+      "homepage": "https://www.slub-dresden.de/",
+      "role": "maintainer"
+    }
+  ],
   "license": "GPL-3.0-or-later",
   "type": "typo3-cms-extension",
   "version": "2.2.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "type": "typo3-cms-extension",
   "version": "2.2.0",
   "require": {
-    "typo3/cms-core": ">=6.2.0 <7.9.99"
+    "typo3/cms": ">=6.2.0 <7.9.99"
   },
   "replace": {
     "dlf": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,61 @@
+{
+  "name": "kitodo/presentation",
+  "description": "Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.",
+  "homepage": "https://www.kitodo.org/",
+  "authors": "Kitodo. Key to digital objects e.V.",
+  "license": "GPL-3.0-or-later",
+  "type": "typo3-cms-extension",
+  "version": "2.2.0",
+  "require": {
+    "typo3/cms-core": ">=6.2.0 <7.9.99"
+  },
+  "replace": {
+    "dlf": "self.version",
+    "typo3-ter/dlf": "self.version"
+  },
+  "autoload": {
+    "classmap": [
+      "cli/class.tx_dlf_cli.php",
+      "common/class.tx_dlf_alto.php",
+      "common/class.tx_dlf_document.php",
+      "common/class.tx_dlf_format.php",
+      "common/class.tx_dlf_fulltext.php",
+      "common/class.tx_dlf_helper.php",
+      "common/class.tx_dlf_indexing.php",
+      "common/class.tx_dlf_list.php",
+      "common/class.tx_dlf_mods.php",
+      "common/class.tx_dlf_module.php",
+      "common/class.tx_dlf_plugin.php",
+      "common/class.tx_dlf_solr.php",
+      "common/class.tx_dlf_teihdr.php",
+      "hooks/class.tx_dlf_doctype.php",
+      "hooks/class.tx_dlf_em.php",
+      "hooks/class.tx_dlf_hacks.php",
+      "hooks/class.tx_dlf_tceforms.php",
+      "hooks/class.tx_dlf_tcemain.php",
+      "modules/indexing/index.php",
+      "modules/newclient/index.php",
+      "plugins/audioplayer/class.tx_dlf_audioplayer.php",
+      "plugins/basket/class.tx_dlf_basket.php",
+      "plugins/collection/class.tx_dlf_collection.php",
+      "plugins/feeds/class.tx_dlf_feeds.php",
+      "plugins/listview/class.tx_dlf_listview.php",
+      "plugins/metadata/class.tx_dlf_metadata.php",
+      "plugins/navigation/class.tx_dlf_navigation.php",
+      "plugins/newspaper/class.tx_dlf_newspaper.php",
+      "plugins/oai/class.tx_dlf_oai.php",
+      "plugins/pagegrid/class.tx_dlf_pagegrid.php",
+      "plugins/pageview/class.tx_dlf_pageview.php",
+      "plugins/search/class.tx_dlf_search.php",
+      "plugins/search/class.tx_dlf_search_suggest.php",
+      "plugins/statistics/class.tx_dlf_statistics.php",
+      "plugins/toc/class.tx_dlf_toc.php",
+      "plugins/toolbox/class.tx_dlf_toolbox.php",
+      "plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php",
+      "plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php",
+      "plugins/toolbox/tools/imagemanipulation/class.tx_dlf_toolsImagemanipulation.php",
+      "plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php",
+      "plugins/validator/class.tx_dlf_validator.php"
+    ]
+  }
+}

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = array (
     'category' => 'fe',
     'author' => 'Kitodo. Key to digital objects e.V.',
     'author_email' => 'contact@kitodo.org',
-    'author_company' => '<br /><a href="http://www.kitodo.org/" target="_blank">Kitodo.org</a><br /><a href="https://github.com/kitodo" target="_blank">Kitodo on GitHub</a>',
+    'author_company' => 'http://www.kitodo.org/',
     'shy' => '',
     'priority' => '',
     'module' => '',

--- a/lib/ApacheSolr/conf/schema.xml
+++ b/lib/ApacheSolr/conf/schema.xml
@@ -125,7 +125,7 @@ limitations under the License.
 		<!-- Autocomplete field for search form. -->
 		<field name="autocomplete" type="autocomplete" indexed="true" stored="false" multiValued="true" />
 		<!-- Fulltext field for OCR results. -->
-		<field name="fulltext" type="fulltext" indexed="true" stored="true" multiValued="false" default="" />
+		<field name="fulltext" type="fulltext" indexed="true" stored="true" multiValued="false" default="" termVectors="true" termPositions="true" termOffsets="true" />
 		<!-- Record ID of the document (required for OAI_DC output). -->
 		<field name="record_id" type="string" indexed="true" stored="true" required="true" multiValued="false" default="" />
 		<!-- Permanent URL of the document (required for EPICUR output). -->

--- a/modules/indexing/index.php
+++ b/modules/indexing/index.php
@@ -62,7 +62,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
         $_collections = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.label AS label,tx_dlf_collections.uid AS uid',
             'tx_dlf_collections',
-            'tx_dlf_collections.fe_cruser_id=0 AND tx_dlf_collections.pid='.intval($this->id).tx_dlf_helper::whereClause('tx_dlf_collections').' AND tx_dlf_collections.sys_language_uid IN (-1,0)',
+            'tx_dlf_collections.fe_cruser_id=0 AND tx_dlf_collections.pid='.intval($this->id).' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
             'tx_dlf_collections.label ASC',
             ''

--- a/modules/indexing/index.php
+++ b/modules/indexing/index.php
@@ -62,7 +62,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
         $_collections = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.label AS label,tx_dlf_collections.uid AS uid',
             'tx_dlf_collections',
-            'tx_dlf_collections.fe_cruser_id=0 AND tx_dlf_collections.pid='.intval($this->id).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.fe_cruser_id=0 AND tx_dlf_collections.pid='.intval($this->id).tx_dlf_helper::whereClause('tx_dlf_collections').' AND tx_dlf_collections.sys_language_uid IN (-1,0)',
             '',
             'tx_dlf_collections.label ASC',
             ''

--- a/modules/indexing/index.php
+++ b/modules/indexing/index.php
@@ -157,7 +157,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
     protected function indexLoop() {
 
         // Get document from list.
-        list ($uid, ) = $this->list->remove(0);
+        list ($uid,) = $this->list->remove(0);
 
         $this->list->save();
 

--- a/modules/newclient/metadata.inc.php
+++ b/modules/newclient/metadata.inc.php
@@ -316,12 +316,12 @@ $metadata = array (
         'format' => array (
             array (
                 'encoded' => 1,
-                'xpath' => './mods:identifier[@type="goobi"]',
+                'xpath' => './mods:identifier[@type="kitodo"]',
                 'xpath_sorting' => '',
             ),
             array (
                 'encoded' => 2,
-                'xpath' => './teihdr:fileDesc/teihdr:publicationStmt/teihdr:idno[@type="goobi"]',
+                'xpath' => './teihdr:fileDesc/teihdr:publicationStmt/teihdr:idno[@type="kitodo"]',
                 'xpath_sorting' => '',
             ),
         ),

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -343,8 +343,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($collectionData['collLabel']),
-                    'description' => $this->pi_RTEcssText($collectionData['collDesc']),
+                    'label' => !empty($l10nOverlay['label'])? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($collectionData['collLabel']),
+                    'description' => !empty($l10nOverlay['description']) ? $this->pi_RTEcssText($l10nOverlay['description']) : $this->pi_RTEcssText($collectionData['collDesc']),
                     'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (
                         'source' => 'collection',

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -95,53 +95,33 @@ class tx_dlf_collection extends tx_dlf_plugin {
      * @return	string		The list of collections ready to output
      */
     protected function showCollectionList() {
-
-        $additionalWhere = '';
-
+        $selectedCollections = 'tx_dlf_collections.uid != 0';
         $orderBy = 'tx_dlf_collections.label';
 
         // Handle collections set by configuration.
         if ($this->conf['collections']) {
 
             if (count(explode(',', $this->conf['collections'])) == 1 && empty($this->conf['dont_show_single'])) {
-
                 $this->showSingleCollection(intval(trim($this->conf['collections'], ' ,')));
-
             }
 
-            $additionalWhere .= ' AND tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
+            $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
         }
 
+        $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
+
         // Should user-defined collections be shown?
-        if (empty($this->conf['show_userdefined'])) {
-
-            $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        } elseif ($this->conf['show_userdefined'] > 0) {
-
-            if (!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-
-                $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
-
-            } else {
-
-                $additionalWhere .= ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
-            }
-
+        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0 && !empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+            $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
         }
 
         // Get collections.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
-            'tx_dlf_collections.uid',
+            $selectedCollections.$showUserDefinedCollections.' AND tx_dlf_collections.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            '',
             $orderBy,
             ''
         );
@@ -154,141 +134,130 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-            $this->showSingleCollection(intval($resArray['uid']));
+            return $this->showSingleCollection(intval($resArray['uid']));
+        }
 
-        } elseif ($count > 0) {
+        $collections = array ();
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+            $collections[$collectionData['uid']] = $collectionData;
+        }
 
-            // Get number of volumes per collection.
-            $resultVolumes = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_collections.uid AS uid,COUNT(tx_dlf_documents.uid) AS volumes',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_collections.uid',
-                '',
-                ''
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        // We only care about the UID in the results and want them sorted
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        // Process results.
+        foreach ($collections as $collection) {
+
+            $solr_query = '';
+
+            if ($collection['index_query'] != "") {
+                $solr_query .= '('.$collection['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+            }
+
+            $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+            $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
+
+            $titles = array ();
+
+            foreach ($partOfNothing as $doc) {
+                $titles[] = $doc->uid;
+            }
+
+            $volumes = $titles;
+
+            // All titles except those that are part of something
+            foreach ($partOfSomething as $doc) {
+                unset($volumes[$doc->uid]);
+            }
+
+            $collection['titles'] = $titles;
+            $collection['volumes'] = $volumes;
+
+            // Generate random but unique array key taking priority into account.
+            do {
+
+                $_key = ($collection['priority'] * 1000) + mt_rand(0, 1000);
+
+            } while (!empty($markerArray[$_key]));
+
+            // Merge plugin variables with new set of values.
+            $additionalParams = array ('collection' => $collection['uid']);
+
+            if (is_array($this->piVars)) {
+
+                $piVars = $this->piVars;
+
+                unset($piVars['DATA']);
+
+                $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
+            }
+
+            // Build typolink configuration array.
+            $conf = array (
+                'useCacheHash' => 1,
+                'parameter' => $GLOBALS['TSFE']->id,
+                'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
             );
 
-            $volumes = array ();
+            // Link collection's title to list view.
+            $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($collection['label']), $conf);
 
-            while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
-
-                $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
-
+            // Add feed link if applicable.
+            if (!empty($this->conf['targetFeed'])) {
+                $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+                $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $collection['uid'])), FALSE, $this->conf['targetFeed']);
+            } else {
+                $markerArray[$_key]['###FEED###'] = '';
             }
 
-            // Process results.
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
-
-                    $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
-
-                }
-
-                // Generate random but unique array key taking priority into account.
-                do {
-
-                    $_key = ($resArray['priority'] * 1000) + mt_rand(0, 1000);
-
-                } while (!empty($markerArray[$_key]));
-
-                // Merge plugin variables with new set of values.
-                $additionalParams = array ('collection' => $resArray['uid']);
-
-                if (is_array($this->piVars)) {
-
-                    $piVars = $this->piVars;
-
-                    unset($piVars['DATA']);
-
-                    $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
-
-                }
-
-                // Build typolink configuration array.
-                $conf = array (
-                    'useCacheHash' => 1,
-                    'parameter' => $GLOBALS['TSFE']->id,
-                    'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
-                );
-
-                // Link collection's title to list view.
-                $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($resArray['label']), $conf);
-
-                // Add feed link if applicable.
-                if (!empty($this->conf['targetFeed'])) {
-
-                    $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
-
-                    $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $resArray['uid'])), FALSE, $this->conf['targetFeed']);
-
-                } else {
-
-                    $markerArray[$_key]['###FEED###'] = '';
-
-                }
-
-                // Add thumbnail.
-                if (!empty($resArray['thumbnail'])) {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$resArray['thumbnail'].'" />';
-
-                } else {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '';
-
-                }
-
-                // Add description.
-                $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($resArray['description']);
-
-                // Build statistic's output.
-                $labelTitles = $this->pi_getLL(($resArray['titles'] > 1 ? 'titles' : 'title'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars($resArray['titles'].$labelTitles);
-
-                $labelVolumes = $this->pi_getLL(($volumes[$resArray['uid']] > 1 ? 'volumes' : 'volume'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars($volumes[$resArray['uid']].$labelVolumes);
-
+            // Add thumbnail.
+            if (!empty($resArray['thumbnail'])) {
+                $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+            } else {
+                $markerArray[$_key]['###THUMBNAIL###'] = '';
             }
 
-            // Randomize sorting?
-            if (!empty($this->conf['randomize'])) {
+            // Add description.
+            $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($collection['description']);
 
-                ksort($markerArray, SORT_NUMERIC);
+            // Build statistic's output.
+            $labelTitles = $this->pi_getLL((count($collection['titles']) > 1 ? 'titles' : 'title'), '', FALSE);
 
-                // Don't cache the output.
-                $this->setCache(FALSE);
+            $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars(count($collection['titles']).$labelTitles);
 
-            }
+            $labelVolumes = $this->pi_getLL((count($collection['volumes']) > 1 ? 'volumes' : 'volume'), '', FALSE);
 
-            $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
-
-            foreach ($markerArray as $marker) {
-
-                $content .= $this->cObj->substituteMarkerArray($entry, $marker);
-
-            }
-
-            // Hook for getting custom collection hierarchies/subentries (requested by SBB).
-            foreach ($this->hookObjects as $hookObj) {
-
-                if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
-
-                    $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
-
-                }
-
-            }
-
-            return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
+            $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars(count($collection['volumes']).$labelVolumes);
 
         }
 
-        return $content;
+        // Randomize sorting?
+        if (!empty($this->conf['randomize'])) {
+
+            ksort($markerArray, SORT_NUMERIC);
+
+            // Don't cache the output.
+            $this->setCache(FALSE);
+        }
+
+        $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
+
+        foreach ($markerArray as $marker) {
+            $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+        }
+
+        // Hook for getting custom collection hierarchies/subentries (requested by SBB).
+        foreach ($this->hookObjects as $hookObj) {
+
+            if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
+                $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
+            }
+        }
+
+        return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
 
     }
 
@@ -305,35 +274,56 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
-
             $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
         } elseif ($this->conf['show_userdefined'] > 0) {
-
             $additionalWhere = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
         }
 
-        // Get all documents in collection.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS label,tx_dlf_collections.description AS description,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS docUid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        // Get collection information from DB
+        $collection = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.label AS collLabel, tx_dlf_collections.description AS collDesc, tx_dlf_collections.thumbnail AS collThumb, tx_dlf_collections.fe_cruser_id',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.uid='.intval($id).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.uid='.intval($id).' '.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
-            'tx_dlf_documents.title_sorting ASC',
+            '',
+            '1'
+        );
+
+        // Fetch corresponding document UIDs from Solr
+        $solr_query = "";
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+            if ($collectionData['index_query'] != "") {
+                $solr_query .= '('.$collectionData['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+            }
+        }
+
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        $solrResult = $solr->search_raw($solr_query, $parameters);
+
+        foreach ($solrResult as $doc) {
+            $documentSet[] = $doc->uid;
+        }
+
+        //Fetch document info for UIDs in $documentSet from DB
+        $documents = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.metadata_sorting AS metadata_sorting, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.partof AS partof',
+            'tx_dlf_documents',
+            'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.uid IN ('.implode(',', $documentSet).')'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents'),
+            '',
+            '',
             ''
         );
 
         $toplevel = array ();
-
         $subparts = array ();
-
         $listMetadata = array ();
 
         // Process results.
-        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
 
             if (empty($l10nOverlay)) {
 
@@ -344,21 +334,20 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => !empty($l10nOverlay['label']) ? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($resArray['label']),
-                    'description' => !empty($l10nOverlay['description']) ? $this->pi_RTEcssText($l10nOverlay['description']) : $this->pi_RTEcssText($resArray['description']),
-                    'thumbnail' => htmlspecialchars($resArray['collThumb']),
+                    'label' => htmlspecialchars($collectionData['collLabel']),
+                    'description' => $this->pi_RTEcssText($collectionData['collDesc']),
+                    'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (
                         'source' => 'collection',
                         'select' => $id,
-                        'userid' => $resArray['userid'],
-                        'params' => array ('fq' => array ('collection_faceting:("'.$resArray['index_name'].'")')),
+                        'userid' => $collectionData['userid'],
+                        'params' => array ('fq' => array ('collection_faceting:("'.$collectionData['index_name'].'")')),
                         'core' => '',
                         'pid' => $this->conf['pages'],
                         'order' => 'title',
                         'order.asc' => TRUE
                     )
                 );
-
             }
 
             // Split toplevel documents from volumes.
@@ -393,11 +382,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 );
 
             } else {
-
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
-
             }
-
         }
 
         // Add volumes to the corresponding toplevel documents.
@@ -408,13 +394,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 ksort($parts);
 
                 foreach ($parts as $part) {
-
                     $toplevel[$partof]['p'][] = array ('u' => $part);
-
                 }
-
             }
-
         }
 
         // Save list of documents.
@@ -438,7 +420,5 @@ class tx_dlf_collection extends tx_dlf_plugin {
         ob_end_flush();
 
         exit;
-
     }
-
 }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -112,8 +112,13 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
 
         // Should user-defined collections be shown?
-        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0 && !empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-            $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0) {
+
+            if(!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+                $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+            } else {
+                $showUserDefinedCollections = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+            }
         }
 
         // Get collections.

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -335,17 +335,17 @@ class tx_dlf_collection extends tx_dlf_plugin {
         // Process results.
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
-            if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+            if (empty($l10nOverlay)) {
 
-                $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+                $l10nOverlay = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
 
             }
 
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($resArray['label']),
-                    'description' => $this->pi_RTEcssText($resArray['description']),
+                    'label' => !empty($l10nOverlay['label']) ? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($resArray['label']),
+                    'description' => !empty($l10nOverlay['description']) ? $this->pi_RTEcssText($l10nOverlay['description']) : $this->pi_RTEcssText($resArray['description']),
                     'thumbnail' => htmlspecialchars($resArray['collThumb']),
                     'options' => array (
                         'source' => 'collection',

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -164,7 +164,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 'tx_dlf_documents',
                 'tx_dlf_relations',
                 'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
+                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
                 'tx_dlf_collections.uid',
                 '',
                 ''
@@ -173,12 +173,6 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $volumes = array ();
 
             while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
-
-                if (is_array($resArrayVolumes) && $resArrayVolumes['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
-
-                    $resArrayVolumes = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArrayVolumes, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
-
-                }
 
                 $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
 
@@ -344,7 +338,6 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
 
                 $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
-                debug($resArray, '$resArray');
 
             }
 

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -95,17 +95,22 @@ class tx_dlf_collection extends tx_dlf_plugin {
      * @return	string		The list of collections ready to output
      */
     protected function showCollectionList() {
+
         $selectedCollections = 'tx_dlf_collections.uid != 0';
+
         $orderBy = 'tx_dlf_collections.label';
 
         // Handle collections set by configuration.
         if ($this->conf['collections']) {
 
             if (count(explode(',', $this->conf['collections'])) == 1 && empty($this->conf['dont_show_single'])) {
+
                 $this->showSingleCollection(intval(trim($this->conf['collections'], ' ,')));
+
             }
 
             $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
+
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
         }
 
@@ -115,9 +120,13 @@ class tx_dlf_collection extends tx_dlf_plugin {
         if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0) {
 
             if(!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+
                 $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+
             } else {
+
                 $showUserDefinedCollections = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+
             }
         }
 
@@ -143,12 +152,16 @@ class tx_dlf_collection extends tx_dlf_plugin {
         }
 
         $collections = array ();
+
         while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
             $collections[$collectionData['uid']] = $collectionData;
+
         }
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
-        // We only care about the UID in the results and want them sorted
+
+        // We only care about the UID and partOf in the results and want them sorted
         $parameters = array ("fl" => "uid, partof", "sort" => "uid asc");
 
         // Process results.
@@ -157,18 +170,26 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $solr_query = '';
 
             if ($collection['index_query'] != "") {
+
                 $solr_query .= '('.$collection['index_query'].')';
+
             } else {
+
                 $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+
             }
 
             $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+
             $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
 
             // Titles are all documents that are "root"-elements i.e. partof == 0;
             $titles = array();
+
             foreach ($partOfNothing as $doc) {
+
                 $titles[] = $doc->uid;
+
             }
 
             // Volumes are documents that are both
@@ -176,13 +197,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
             // b) "root"-elements that are not referenced by other documents ("root"-elements that have no descendants)
 
             $volumes = $titles;
+
             foreach ($partOfSomething as $doc) {
+
                 $volumes[] = $doc->uid;
+
                 // if a document is referenced via partof, it’s not a volume anymore
                 unset($volumes[$doc->partof]);
+
             }
 
             $collection['titles'] = $titles;
+
             $collection['volumes'] = $volumes;
 
             // Generate random but unique array key taking priority into account.
@@ -216,17 +242,26 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             // Add feed link if applicable.
             if (!empty($this->conf['targetFeed'])) {
+
                 $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+
                 $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $collection['uid'])), FALSE, $this->conf['targetFeed']);
+
             } else {
+
                 $markerArray[$_key]['###FEED###'] = '';
+
             }
 
             // Add thumbnail.
             if (!empty($resArray['thumbnail'])) {
+
                 $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+
             } else {
+
                 $markerArray[$_key]['###THUMBNAIL###'] = '';
+
             }
 
             // Add description.
@@ -255,14 +290,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
 
         foreach ($markerArray as $marker) {
+
             $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+
         }
 
         // Hook for getting custom collection hierarchies/subentries (requested by SBB).
         foreach ($this->hookObjects as $hookObj) {
 
             if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
+
                 $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
+
             }
         }
 
@@ -283,9 +322,13 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
+
             $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
+
         } elseif ($this->conf['show_userdefined'] > 0) {
+
             $additionalWhere = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+
         }
 
         // Get collection information from DB
@@ -300,21 +343,30 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Fetch corresponding document UIDs from Solr
         $solr_query = "";
+
         while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+
             if ($collectionData['index_query'] != "") {
+
                 $solr_query .= '('.$collectionData['index_query'].')';
+
             } else {
+
                 $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+
             }
         }
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+
         $parameters = array ("fl" => "uid", "sort" => "uid asc");
 
         $solrResult = $solr->search_raw($solr_query, $parameters);
 
         foreach ($solrResult as $doc) {
+
             $documentSet[] = $doc->uid;
+
         }
 
         //Fetch document info for UIDs in $documentSet from DB
@@ -328,7 +380,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
         );
 
         $toplevel = array ();
+
         $subparts = array ();
+
         $listMetadata = array ();
 
         // Process results.
@@ -391,7 +445,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 );
 
             } else {
+
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
+
             }
         }
 
@@ -403,7 +459,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 ksort($parts);
 
                 foreach ($parts as $part) {
+
                     $toplevel[$partof]['p'][] = array ('u' => $part);
+
                 }
             }
         }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -95,53 +95,33 @@ class tx_dlf_collection extends tx_dlf_plugin {
      * @return	string		The list of collections ready to output
      */
     protected function showCollectionList() {
-
-        $additionalWhere = '';
-
+        $selectedCollections = 'tx_dlf_collections.uid != 0';
         $orderBy = 'tx_dlf_collections.label';
 
         // Handle collections set by configuration.
         if ($this->conf['collections']) {
 
             if (count(explode(',', $this->conf['collections'])) == 1 && empty($this->conf['dont_show_single'])) {
-
                 $this->showSingleCollection(intval(trim($this->conf['collections'], ' ,')));
-
             }
 
-            $additionalWhere .= ' AND tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
+            $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
         }
 
+        $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
+
         // Should user-defined collections be shown?
-        if (empty($this->conf['show_userdefined'])) {
-
-            $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        } elseif ($this->conf['show_userdefined'] > 0) {
-
-            if (!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-
-                $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
-
-            } else {
-
-                $additionalWhere .= ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
-            }
-
+        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0 && !empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+            $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
         }
 
         // Get collections.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
-            'tx_dlf_collections.uid',
+            $selectedCollections.$showUserDefinedCollections.' AND tx_dlf_collections.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            '',
             $orderBy,
             ''
         );
@@ -154,135 +134,130 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-            $this->showSingleCollection(intval($resArray['uid']));
+            return $this->showSingleCollection(intval($resArray['uid']));
+        }
 
-        } elseif ($count > 0) {
+        $collections = array ();
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+            $collections[$collectionData['uid']] = $collectionData;
+        }
 
-            // Get number of volumes per collection.
-            $resultVolumes = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_collections.uid AS uid,COUNT(tx_dlf_documents.uid) AS volumes',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_collections.uid',
-                '',
-                ''
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        // We only care about the UID in the results and want them sorted
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        // Process results.
+        foreach ($collections as $collection) {
+
+            $solr_query = '';
+
+            if ($collection['index_query'] != "") {
+                $solr_query .= '('.$collection['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+            }
+
+            $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+            $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
+
+            $titles = array ();
+
+            foreach ($partOfNothing as $doc) {
+                $titles[] = $doc->uid;
+            }
+
+            $volumes = $titles;
+
+            // All titles except those that are part of something
+            foreach ($partOfSomething as $doc) {
+                unset($volumes[$doc->uid]);
+            }
+
+            $collection['titles'] = $titles;
+            $collection['volumes'] = $volumes;
+
+            // Generate random but unique array key taking priority into account.
+            do {
+
+                $_key = ($collection['priority'] * 1000) + mt_rand(0, 1000);
+
+            } while (!empty($markerArray[$_key]));
+
+            // Merge plugin variables with new set of values.
+            $additionalParams = array ('collection' => $collection['uid']);
+
+            if (is_array($this->piVars)) {
+
+                $piVars = $this->piVars;
+
+                unset($piVars['DATA']);
+
+                $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
+            }
+
+            // Build typolink configuration array.
+            $conf = array (
+                'useCacheHash' => 1,
+                'parameter' => $GLOBALS['TSFE']->id,
+                'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
             );
 
-            $volumes = array ();
+            // Link collection's title to list view.
+            $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($collection['label']), $conf);
 
-            while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
-
-                $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
-
+            // Add feed link if applicable.
+            if (!empty($this->conf['targetFeed'])) {
+                $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+                $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $collection['uid'])), FALSE, $this->conf['targetFeed']);
+            } else {
+                $markerArray[$_key]['###FEED###'] = '';
             }
 
-            // Process results.
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                // Generate random but unique array key taking priority into account.
-                do {
-
-                    $_key = ($resArray['priority'] * 1000) + mt_rand(0, 1000);
-
-                } while (!empty($markerArray[$_key]));
-
-                // Merge plugin variables with new set of values.
-                $additionalParams = array ('collection' => $resArray['uid']);
-
-                if (is_array($this->piVars)) {
-
-                    $piVars = $this->piVars;
-
-                    unset($piVars['DATA']);
-
-                    $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
-
-                }
-
-                // Build typolink configuration array.
-                $conf = array (
-                    'useCacheHash' => 1,
-                    'parameter' => $GLOBALS['TSFE']->id,
-                    'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
-                );
-
-                // Link collection's title to list view.
-                $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($resArray['label']), $conf);
-
-                // Add feed link if applicable.
-                if (!empty($this->conf['targetFeed'])) {
-
-                    $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
-
-                    $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $resArray['uid'])), FALSE, $this->conf['targetFeed']);
-
-                } else {
-
-                    $markerArray[$_key]['###FEED###'] = '';
-
-                }
-
-                // Add thumbnail.
-                if (!empty($resArray['thumbnail'])) {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$resArray['thumbnail'].'" />';
-
-                } else {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '';
-
-                }
-
-                // Add description.
-                $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($resArray['description']);
-
-                // Build statistic's output.
-                $labelTitles = $this->pi_getLL(($resArray['titles'] > 1 ? 'titles' : 'title'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars($resArray['titles'].$labelTitles);
-
-                $labelVolumes = $this->pi_getLL(($volumes[$resArray['uid']] > 1 ? 'volumes' : 'volume'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars($volumes[$resArray['uid']].$labelVolumes);
-
+            // Add thumbnail.
+            if (!empty($resArray['thumbnail'])) {
+                $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+            } else {
+                $markerArray[$_key]['###THUMBNAIL###'] = '';
             }
 
-            // Randomize sorting?
-            if (!empty($this->conf['randomize'])) {
+            // Add description.
+            $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($collection['description']);
 
-                ksort($markerArray, SORT_NUMERIC);
+            // Build statistic's output.
+            $labelTitles = $this->pi_getLL((count($collection['titles']) > 1 ? 'titles' : 'title'), '', FALSE);
 
-                // Don't cache the output.
-                $this->setCache(FALSE);
+            $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars(count($collection['titles']).$labelTitles);
 
-            }
+            $labelVolumes = $this->pi_getLL((count($collection['volumes']) > 1 ? 'volumes' : 'volume'), '', FALSE);
 
-            $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
-
-            foreach ($markerArray as $marker) {
-
-                $content .= $this->cObj->substituteMarkerArray($entry, $marker);
-
-            }
-
-            // Hook for getting custom collection hierarchies/subentries (requested by SBB).
-            foreach ($this->hookObjects as $hookObj) {
-
-                if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
-
-                    $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
-
-                }
-
-            }
-
-            return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
+            $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars(count($collection['volumes']).$labelVolumes);
 
         }
 
-        return $content;
+        // Randomize sorting?
+        if (!empty($this->conf['randomize'])) {
+
+            ksort($markerArray, SORT_NUMERIC);
+
+            // Don't cache the output.
+            $this->setCache(FALSE);
+        }
+
+        $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
+
+        foreach ($markerArray as $marker) {
+            $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+        }
+
+        // Hook for getting custom collection hierarchies/subentries (requested by SBB).
+        foreach ($this->hookObjects as $hookObj) {
+
+            if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
+                $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
+            }
+        }
+
+        return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
 
     }
 
@@ -299,54 +274,74 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
-
             $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
         } elseif ($this->conf['show_userdefined'] > 0) {
-
             $additionalWhere = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
         }
 
-        // Get all documents in collection.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS collLabel,tx_dlf_collections.description AS collDesc,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS uid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        // Get collection information from DB
+        $collection = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.label AS collLabel, tx_dlf_collections.description AS collDesc, tx_dlf_collections.thumbnail AS collThumb, tx_dlf_collections.fe_cruser_id',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.uid='.intval($id).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.uid='.intval($id).' '.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
-            'tx_dlf_documents.title_sorting ASC',
+            '',
+            '1'
+        );
+
+        // Fetch corresponding document UIDs from Solr
+        $solr_query = "";
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+            if ($collectionData['index_query'] != "") {
+                $solr_query .= '('.$collectionData['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+            }
+        }
+
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        $solrResult = $solr->search_raw($solr_query, $parameters);
+
+        foreach ($solrResult as $doc) {
+            $documentSet[] = $doc->uid;
+        }
+
+        //Fetch document info for UIDs in $documentSet from DB
+        $documents = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.metadata_sorting AS metadata_sorting, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.partof AS partof',
+            'tx_dlf_documents',
+            'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.uid IN ('.implode(',', $documentSet).')'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents'),
+            '',
+            '',
             ''
         );
 
         $toplevel = array ();
-
         $subparts = array ();
-
         $listMetadata = array ();
 
         // Process results.
-        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
 
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($resArray['collLabel']),
-                    'description' => $this->pi_RTEcssText($resArray['collDesc']),
-                    'thumbnail' => htmlspecialchars($resArray['collThumb']),
+                    'label' => htmlspecialchars($collectionData['collLabel']),
+                    'description' => $this->pi_RTEcssText($collectionData['collDesc']),
+                    'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (
                         'source' => 'collection',
                         'select' => $id,
-                        'userid' => $resArray['userid'],
-                        'params' => array ('fq' => array ('collection_faceting:("'.$resArray['index_name'].'")')),
+                        'userid' => $collectionData['userid'],
+                        'params' => array ('fq' => array ('collection_faceting:("'.$collectionData['index_name'].'")')),
                         'core' => '',
                         'pid' => $this->conf['pages'],
                         'order' => 'title',
                         'order.asc' => TRUE
                     )
                 );
-
             }
 
             // Split toplevel documents from volumes.
@@ -381,11 +376,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 );
 
             } else {
-
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
-
             }
-
         }
 
         // Add volumes to the corresponding toplevel documents.
@@ -396,13 +388,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 ksort($parts);
 
                 foreach ($parts as $part) {
-
                     $toplevel[$partof]['p'][] = array ('u' => $part);
-
                 }
-
             }
-
         }
 
         // Save list of documents.
@@ -426,7 +414,5 @@ class tx_dlf_collection extends tx_dlf_plugin {
         ob_end_flush();
 
         exit;
-
     }
-
 }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -136,11 +136,11 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Get collections.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
+            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
             'tx_dlf_documents',
             'tx_dlf_relations',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
             'tx_dlf_collections.uid',
             $orderBy,
             ''
@@ -164,7 +164,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 'tx_dlf_documents',
                 'tx_dlf_relations',
                 'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
                 'tx_dlf_collections.uid',
                 '',
                 ''
@@ -174,12 +174,24 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
 
+                if (is_array($resArrayVolumes) && $resArrayVolumes['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+
+                    $resArrayVolumes = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArrayVolumes, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+
+                }
+
                 $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
 
             }
 
             // Process results.
             while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+                if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+
+                    $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+
+                }
 
                 // Generate random but unique array key taking priority into account.
                 do {
@@ -310,7 +322,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Get all documents in collection.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS collLabel,tx_dlf_collections.description AS collDesc,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS uid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
+            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS label,tx_dlf_collections.description AS description,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS docUid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
             'tx_dlf_documents',
             'tx_dlf_relations',
             'tx_dlf_collections',
@@ -329,11 +341,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
         // Process results.
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
+            if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+
+                $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+                debug($resArray, '$resArray');
+
+            }
+
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($resArray['collLabel']),
-                    'description' => $this->pi_RTEcssText($resArray['collDesc']),
+                    'label' => htmlspecialchars($resArray['label']),
+                    'description' => $this->pi_RTEcssText($resArray['description']),
                     'thumbnail' => htmlspecialchars($resArray['collThumb']),
                     'options' => array (
                         'source' => 'collection',
@@ -373,8 +392,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
                 }
 
-                $toplevel[$resArray['uid']] = array (
-                    'u' => $resArray['uid'],
+                $toplevel[$resArray['docUid']] = array (
+                    'u' => $resArray['docUid'],
                     'h' => '',
                     's' => $sorting,
                     'p' => array ()
@@ -382,7 +401,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             } else {
 
-                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
+                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
 
             }
 

--- a/plugins/collection/flexform.xml
+++ b/plugins/collection/flexform.xml
@@ -57,6 +57,21 @@
 							</config>
 						</TCEforms>
 					</collections>
+					<solrcore>
+						<TCEforms>
+							<displayCond>FIELD:pages:REQ:true</displayCond>
+							<exclude>1</exclude>
+							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.solrcore</label>
+							<config>
+								<type>select</type>
+								<items type="array"></items>
+								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_solrList</itemsProcFunc>
+								<size>1</size>
+								<maxitems>1</maxitems>
+								<minitems>0</minitems>
+							</config>
+						</TCEforms>
+					</solrcore>
 					<show_userdefined>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/plugins/collection/flexform.xml
+++ b/plugins/collection/flexform.xml
@@ -61,7 +61,7 @@
 						<TCEforms>
 							<displayCond>FIELD:pages:REQ:true</displayCond>
 							<exclude>1</exclude>
-							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.solrcore</label>
+							<label>LLL:EXT:dlf/plugins/collection/locallang.xml:tt_content.pi_flexform.solrcore</label>
 							<config>
 								<type>select</type>
 								<items type="array"></items>

--- a/plugins/collection/flexform.xml
+++ b/plugins/collection/flexform.xml
@@ -68,7 +68,7 @@
 								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_solrList</itemsProcFunc>
 								<size>1</size>
 								<maxitems>1</maxitems>
-								<minitems>0</minitems>
+								<minitems>1</minitems>
 							</config>
 						</TCEforms>
 					</solrcore>

--- a/plugins/collection/locallang.xml
+++ b/plugins/collection/locallang.xml
@@ -26,6 +26,7 @@
 			<label index="tt_content.pi_flexform.targetPid">Target page (with "DLF: List View" plugin)</label>
 			<label index="tt_content.pi_flexform.targetFeed">Target page (with "DLF: Feeds" plugin)</label>
 			<label index="tt_content.pi_flexform.templateFile">Template file</label>
+			<label index="tt_content.pi_flexform.solrcore">Solr Core</label>
 			<label index="title"> title</label>
 			<label index="titles"> titles</label>
 			<label index="volume"> volume</label>
@@ -44,6 +45,7 @@
 			<label index="tt_content.pi_flexform.targetPid">Zielseite (mit Plugin "DLF: Listenansicht")</label>
 			<label index="tt_content.pi_flexform.targetFeed">Zielseite (mit Plugin "DLF: Feeds")</label>
 			<label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
+			<label index="tt_content.pi_flexform.solrcore">Solr Kern</label>
 			<label index="title"> Titel</label>
 			<label index="titles"> Titel</label>
 			<label index="volume"> Band</label>

--- a/plugins/listview/class.tx_dlf_listview.php
+++ b/plugins/listview/class.tx_dlf_listview.php
@@ -151,6 +151,8 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
         $imgAlt = '';
 
+        $noTitle = $this->pi_getLL('noTitle');
+
         $metadata = $this->list[$number]['metadata'];
 
         foreach ($this->metadata as $index_name => $metaConf) {
@@ -182,7 +184,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
                     // Set fake title if still not present.
                     if (empty($value)) {
 
-                        $value = $this->pi_getLL('noTitle');
+                        $value = $noTitle;
 
                     }
 
@@ -386,6 +388,10 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
         $content = '';
 
+        $noTitle = $this->pi_getLL('noTitle');
+
+        $highlight_word = preg_replace('/\s\s+/', ';', $this->list->metadata['searchString']);
+
         foreach ($this->list[$number]['subparts'] as $subpart) {
 
             $markerArray['###SUBMETADATA###'] = '';
@@ -425,7 +431,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
                         // Set fake title if still not present.
                         if (empty($value)) {
 
-                            $value = $this->pi_getLL('noTitle');
+                            $value = $noTitle;
 
                         }
 
@@ -434,7 +440,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
                         $additionalParams = array (
                             'id' => $subpart['uid'],
                             'page' => $subpart['page'],
-                            'highlight_word' => preg_replace('/\s\s+/', ';', $this->list->metadata['searchString'])
+                            'highlight_word' => $highlight_word
                         );
 
                         if (!empty($this->piVars['logicalPage'])) {
@@ -657,7 +663,10 @@ class tx_dlf_listview extends tx_dlf_plugin {
         // Load metadata configuration.
         $this->loadConfig();
 
-        for ($i = $this->piVars['pointer'] * $this->conf['limit'], $j = ($this->piVars['pointer'] + 1) * $this->conf['limit']; $i < $j; $i++) {
+        $i = $this->piVars['pointer'] * $this->conf['limit'];
+        $j = ($this->piVars['pointer'] + 1) * $this->conf['limit'];
+
+        for ($i, $j; $i < $j; $i++) {
 
             if (empty($this->list[$i])) {
 

--- a/plugins/listview/class.tx_dlf_listview.php
+++ b/plugins/listview/class.tx_dlf_listview.php
@@ -316,7 +316,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
      */
     private function getFieldWrap($index_name, $wrap) {
 
-        if(isset($this->fieldwrap[$index_name])) {
+        if (isset($this->fieldwrap[$index_name])) {
 
             return $this->fieldwrap[$index_name];
 

--- a/plugins/listview/class.tx_dlf_listview.php
+++ b/plugins/listview/class.tx_dlf_listview.php
@@ -23,6 +23,14 @@ class tx_dlf_listview extends tx_dlf_plugin {
     public $scriptRelPath = 'plugins/listview/class.tx_dlf_listview.php';
 
     /**
+     * This holds the field wrap of the metadata
+     *
+     * @var	array
+     * @access	private
+     */
+    private $fieldwrap = array ();
+
+    /**
      * This holds the list
      *
      * @var	tx_dlf_list
@@ -159,7 +167,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
             $parsedValue = '';
 
-            $fieldwrap = $this->parseTS($metaConf['wrap']);
+            $fieldwrap = $this->getFieldWrap($index_name, $metaConf['wrap']);
 
             do {
 
@@ -296,6 +304,31 @@ class tx_dlf_listview extends tx_dlf_plugin {
     }
 
     /**
+     * Returns the parsed fieldwrap of a metadata
+     *
+     * @access	private
+     *
+     * @param	string		$index_name: The index name of a metadata
+     * @param	string		$wrap: The configured metadata wrap
+     *
+     * @return	array		The parsed fieldwrap
+     * @return	array		The parsed fildwrap
+     */
+    private function getFieldWrap($index_name, $wrap) {
+
+        if(isset($this->fieldwrap[$index_name])) {
+
+            return $this->fieldwrap[$index_name];
+
+        } else {
+
+            return $this->fieldwrap[$index_name] = $this->parseTS($wrap);
+
+        }
+
+    }
+
+    /**
      * Renders sorting dialog
      *
      * @access	protected
@@ -406,7 +439,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
                 $parsedValue = '';
 
-                $fieldwrap = $this->parseTS($metaConf['wrap']);
+                $fieldwrap = $this->getFieldWrap($index_name, $metaConf['wrap']);
 
                 do {
 

--- a/plugins/listview/class.tx_dlf_listview.php
+++ b/plugins/listview/class.tx_dlf_listview.php
@@ -312,7 +312,6 @@ class tx_dlf_listview extends tx_dlf_plugin {
      * @param	string		$wrap: The configured metadata wrap
      *
      * @return	array		The parsed fieldwrap
-     * @return	array		The parsed fildwrap
      */
     private function getFieldWrap($index_name, $wrap) {
 

--- a/plugins/listview/class.tx_dlf_listview.php
+++ b/plugins/listview/class.tx_dlf_listview.php
@@ -696,18 +696,18 @@ class tx_dlf_listview extends tx_dlf_plugin {
         // Load metadata configuration.
         $this->loadConfig();
 
-        $i = $this->piVars['pointer'] * $this->conf['limit'];
-        $j = ($this->piVars['pointer'] + 1) * $this->conf['limit'];
+        $currentEntry = $this->piVars['pointer'] * $this->conf['limit'];
+        $lastEntry = ($this->piVars['pointer'] + 1) * $this->conf['limit'];
 
-        for ($i, $j; $i < $j; $i++) {
+        for ($currentEntry, $lastEntry; $currentEntry < $lastEntry; $currentEntry++) {
 
-            if (empty($this->list[$i])) {
+            if (empty($this->list[$currentEntry])) {
 
                 break;
 
             } else {
 
-                $content .= $this->getEntry($i, $subpartArray);
+                $content .= $this->getEntry($currentEntry, $subpartArray);
 
             }
 
@@ -727,9 +727,9 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
         }
 
-        if ($i) {
+        if ($currentEntry) {
 
-            $markerArray['###COUNT###'] = htmlspecialchars(sprintf($this->pi_getLL('count'), ($this->piVars['pointer'] * $this->conf['limit']) + 1, $i, count($this->list)));
+            $markerArray['###COUNT###'] = htmlspecialchars(sprintf($this->pi_getLL('count'), ($this->piVars['pointer'] * $this->conf['limit']) + 1, $currentEntry, count($this->list)));
 
         } else {
 

--- a/plugins/oai/class.tx_dlf_oai.php
+++ b/plugins/oai/class.tx_dlf_oai.php
@@ -977,6 +977,10 @@ class tx_dlf_oai extends tx_dlf_plugin {
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
 
+        if (intval($this->conf['solr_limit']) > 0) {
+            $solr->limit = intval($this->conf['solr_limit']);
+        }
+
         // We only care about the UID in the results and want them sorted
         $parameters = array ("fl" => "uid", "sort" => "uid asc");
 

--- a/plugins/oai/class.tx_dlf_oai.php
+++ b/plugins/oai/class.tx_dlf_oai.php
@@ -921,6 +921,9 @@ class tx_dlf_oai extends tx_dlf_plugin {
             $solr_query .= ' NOT '.$required.':""';
         }
 
+        // toplevel="true" is always required
+        $solr_query .= ' AND toplevel:"true"';
+
         $from = "*";
         // Check "from" for valid value.
         if (!empty($this->piVars['from'])) {

--- a/plugins/oai/flexform.xml
+++ b/plugins/oai/flexform.xml
@@ -105,6 +105,18 @@
 							</config>
 						</TCEforms>
 					</solrcore>
+					<solr_limit>
+						<TCEforms>
+							<displayCond>FIELD:pages:REQ:true</displayCond>
+							<exclude>1</exclude>
+							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.solr_limit</label>
+							<config>
+								<type>input</type>
+								<eval>required,num,int</eval>
+								<default>50000</default>
+							</config>
+						</TCEforms>
+					</solr_limit>
 					<stylesheet>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/plugins/oai/locallang.xml
+++ b/plugins/oai/locallang.xml
@@ -42,7 +42,7 @@
 			<label index="tt_content.pi_flexform.expired">Gültigkeitsdauer des Resumption Tokens (Sekunden)</label>
 			<label index="tt_content.pi_flexform.show_userdefined">Benutzerdefinierte Kollektionen anzeigen?</label>
 			<label index="tt_content.pi_flexform.solrcore">Solr Kern</label>
-			<label index="tt_content.pi_flexform.solr_limit">Maximale Solr-Ergebnissen</label>
+			<label index="tt_content.pi_flexform.solr_limit">Maximale Solr-Ergebnisse</label>
 			<label index="tt_content.pi_flexform.stylesheet">XSL-Stylesheet</label>
 			<label index="tt_content.pi_flexform.unqualified_epicur">Unqualifiziertes Epicur verwenden?</label>
 			<label index="badArgument">Die Anfrage enthält ungültige Parameter, es fehlen benötigte Parameter oder Parameter haben ungültige Werte.</label>

--- a/plugins/oai/locallang.xml
+++ b/plugins/oai/locallang.xml
@@ -21,6 +21,7 @@
 			<label index="tt_content.pi_flexform.expired">Expiration time for resumption token (seconds)</label>
 			<label index="tt_content.pi_flexform.show_userdefined">Show user-defined collections?</label>
 			<label index="tt_content.pi_flexform.solrcore">Solr Core</label>
+			<label index="tt_content.pi_flexform.solr_limit">Maximum Solr results</label>
 			<label index="tt_content.pi_flexform.stylesheet">Transformation stylesheet</label>
 			<label index="tt_content.pi_flexform.unqualified_epicur">Use unqualified epicur?</label>
 
@@ -41,6 +42,7 @@
 			<label index="tt_content.pi_flexform.expired">Gültigkeitsdauer des Resumption Tokens (Sekunden)</label>
 			<label index="tt_content.pi_flexform.show_userdefined">Benutzerdefinierte Kollektionen anzeigen?</label>
 			<label index="tt_content.pi_flexform.solrcore">Solr Kern</label>
+			<label index="tt_content.pi_flexform.solr_limit">Maximale Solr-Ergebnissen</label>
 			<label index="tt_content.pi_flexform.stylesheet">XSL-Stylesheet</label>
 			<label index="tt_content.pi_flexform.unqualified_epicur">Unqualifiziertes Epicur verwenden?</label>
 			<label index="badArgument">Die Anfrage enthält ungültige Parameter, es fehlen benötigte Parameter oder Parameter haben ungültige Werte.</label>

--- a/plugins/pageview/tx_dlf_pageview.js
+++ b/plugins/pageview/tx_dlf_pageview.js
@@ -569,7 +569,7 @@ dlfViewer.prototype.addMagnifier = function (rotation) {
     var extent = [0, 0, 1000, 1000];
 
     layerProj = new ol.proj.Projection({
-        code: 'goobi-image',
+        code: 'kitodo-image',
         units: 'pixels',
         extent: extent
     });

--- a/plugins/pageview/tx_dlf_utils.js
+++ b/plugins/pageview/tx_dlf_utils.js
@@ -379,11 +379,11 @@ dlfUtils.buildImageV2 = function buildImageV2(mimetype, uri, jsonld) {
         src: uri,
         width: jsonld.width,
         height: jsonld.height,
-        tilesize: [jsonld.tiles.map(function (a) {
+        tilesize: jsonld.tiles !== undefined ? [jsonld.tiles.map(function (a) {
             return a.width;
         })[0], jsonld.tiles.map(function (a) {
             return a.height;
-        })[0]],
+        })[0]] : [256,256],
         qualities: jsonld.profile.map(function (a) {
             return a;
         }).map(function (b) {
@@ -394,9 +394,9 @@ dlfUtils.buildImageV2 = function buildImageV2(mimetype, uri, jsonld) {
         }).map(function (b) {
             return b.formats;
         })[1],
-        resolutions: jsonld.tiles.map(function (a) {
+        resolutions: jsonld.tiles !== undefined ? jsonld.tiles.map(function (a) {
             return a.scaleFactors;
-        })[0],
+        })[0] : [1,2,4,8,16],
         mimetype: mimetype
     };
 };

--- a/plugins/pageview/tx_dlf_utils.js
+++ b/plugins/pageview/tx_dlf_utils.js
@@ -93,7 +93,7 @@ dlfUtils.createOl3Layers = function (imageSourceObjs, opt_origin) {
                     quality: quality,
                     offset: [offsetWidth, 0],
                     projection: new ol.proj.Projection({
-                        code: 'goobi-image',
+                        code: 'kitodo-image',
                         units: 'pixels',
                         extent: extent
                     })
@@ -120,7 +120,7 @@ dlfUtils.createOl3Layers = function (imageSourceObjs, opt_origin) {
                 source: new ol.source.ImageStatic({
                     url: imageSourceObj.src,
                     projection: new ol.proj.Projection({
-                        code: 'goobi-image',
+                        code: 'kitodo-image',
                         units: 'pixels',
                         extent: extent
                     }),
@@ -164,7 +164,7 @@ dlfUtils.createOl3View = function (images) {
 
     // define map projection
     var proj = new ol.proj.Projection({
-        code: 'goobi-image',
+        code: 'kitodo-image',
         units: 'pixels',
         extent: extent
     });

--- a/plugins/search/class.tx_dlf_search.php
+++ b/plugins/search/class.tx_dlf_search.php
@@ -561,11 +561,6 @@ class tx_dlf_search extends tx_dlf_plugin {
 
                 }
 
-                // Add highlighting for fulltext.
-                $params['hl'] = 'true';
-
-                $params['hl.fl'] = 'fulltext';
-
             } else {
                 // Retain given search field if valid.
                 $query = tx_dlf_solr::escapeQueryKeepField($this->piVars['query'], $this->conf['pages']);

--- a/plugins/search/class.tx_dlf_search.php
+++ b/plugins/search/class.tx_dlf_search.php
@@ -785,7 +785,7 @@ class tx_dlf_search extends tx_dlf_plugin {
         $search['params']['facet.limit'] = $this->conf['limitFacets'];
 
         // Perform search.
-        $results = $solr->service->search($search['query'], 0, $this->conf['limit'], $search['params']);
+        $results = $solr->service->search($search['query'], 0, 0, $search['params']);
 
         // Process results.
         foreach ($results->facet_counts->facet_fields as $field => $values) {

--- a/plugins/toc/flexform.xml
+++ b/plugins/toc/flexform.xml
@@ -110,7 +110,7 @@
 								<allowed>tmpl,tpl,html,htm,txt</allowed>
 								<size>1</size>
 								<maxitems>1</maxitems>
-								<minitems>1</minitems>
+								<minitems>0</minitems>
 								<disable_controls>upload</disable_controls>
 							</config>
 						</TCEforms>


### PR DESCRIPTION
This pull request adds Solr queries to the collection plugin. Since #261 allows to define virtual collections via a Solr query those collections should be able to be shown in the collection plugin.

To be able to query the Solr an additional field for selecting a Solr core has been added to the plugin configuration.

I cleaned up some code and replaced several database queries for the corresponding Solr queries to get the necessary data.

**CollectionList**
1. fetch information about selected collections from database
2. for each collection
-- query titles and volumes info from Solr
-- generate output

**SingleCollection**
1. fetch collection information from DB
2. fetch corresponding document UIDs from Solr
3. fetch info from those documents from DB
4. generate output

Step 3 could be eliminated. But we would have to make additional changes. This particular query contains the database field metadata_sorting. That field includes all information for sorting the list view if I got that right. I haven’t figured out how the sorting actually works so that might be wrong.

![image](https://user-images.githubusercontent.com/180686/36263188-ea502f08-1269-11e8-88ea-337c30de5bec.png)

We could probably fetch the values for sorting the documents from the index, but with the options in the selector we would have to add `author` and `year` to the Solr schema. At the moment they are only dynamic fields.