### PR TITLE
Fix #273 multilanguage support of collection records

### DIFF
--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -27,6 +27,7 @@ return array (
             'disabled' => 'hidden',
             'fe_group' => 'fe_group',
         ),
+        'requestUpdate' => 'sys_language_uid',
         'iconfile'	=> 'EXT:dlf/res/icons/txdlfcollections.png',
         'rootLevel'	=> 0,
         'dividers2tabs' => 2,
@@ -112,6 +113,7 @@ return array (
         ),
         'index_name' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.index_name',
             'config' => array (
                 'type' => 'none',
@@ -122,6 +124,7 @@ return array (
         ),
         'index_search' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.index_search',
             'config' => array (
             'type' => 'text',
@@ -132,6 +135,7 @@ return array (
         ),
         'oai_name' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.oai_name',
             'config' => array (
                 'type' => 'input',
@@ -142,6 +146,7 @@ return array (
         ),
         'description' => array (
             'exclude' => 1,
+            'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.description',
             'config' => array (
                 'type' => 'text',
@@ -153,6 +158,7 @@ return array (
         ),
         'thumbnail' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.thumbnail',
             'config' => array (
                 'type' => 'group',
@@ -165,6 +171,7 @@ return array (
         ),
         'priority' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.priority',
             'config' => array (
                 'type' => 'select',
@@ -184,6 +191,7 @@ return array (
         ),
         'documents' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.documents',
             'config' => array (
                 'type' => 'select',
@@ -203,6 +211,7 @@ return array (
         ),
         'owner' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.owner',
             'config' => array (
                 'type' => 'select',
@@ -219,6 +228,7 @@ return array (
         ),
         'fe_cruser_id' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.fe_cruser_id',
             'config' => array (
                 'type' => 'select',
@@ -235,6 +245,7 @@ return array (
         ),
         'fe_admin_lock' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.fe_admin_lock',
             'config' => array (
                 'type' => 'check',
@@ -243,6 +254,7 @@ return array (
         ),
         'status' => array (
             'exclude' => 1,
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_collections.status',
             'config' => array (
                 'type' => 'select',

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -1375,7 +1375,7 @@ final class tx_dlf_document {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.uid AS uid',
             'tx_dlf_collections',
-            'tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0'.tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0'.tx_dlf_helper::whereClause('tx_dlf_collections').' AND tx_dlf_collections.sys_language_uid IN (-1,0)',
             '',
             '',
             ''

--- a/modules/indexing/index.php
+++ b/modules/indexing/index.php
@@ -62,7 +62,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
         $_collections = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.label AS label,tx_dlf_collections.uid AS uid',
             'tx_dlf_collections',
-            'tx_dlf_collections.fe_cruser_id=0 AND tx_dlf_collections.pid='.intval($this->id).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.fe_cruser_id=0 AND tx_dlf_collections.pid='.intval($this->id).tx_dlf_helper::whereClause('tx_dlf_collections').' AND tx_dlf_collections.sys_language_uid IN (-1,0)',
             '',
             'tx_dlf_collections.label ASC',
             ''

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -164,7 +164,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 'tx_dlf_documents',
                 'tx_dlf_relations',
                 'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
+                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
                 'tx_dlf_collections.uid',
                 '',
                 ''
@@ -173,12 +173,6 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $volumes = array ();
 
             while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
-
-                if (is_array($resArrayVolumes) && $resArrayVolumes['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
-
-                    $resArrayVolumes = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArrayVolumes, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
-
-                }
 
                 $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
 
@@ -344,7 +338,6 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
 
                 $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
-                debug($resArray, '$resArray');
 
             }
 

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -136,11 +136,11 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Get collections.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
+            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
             'tx_dlf_documents',
             'tx_dlf_relations',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
             'tx_dlf_collections.uid',
             $orderBy,
             ''
@@ -164,7 +164,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 'tx_dlf_documents',
                 'tx_dlf_relations',
                 'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
                 'tx_dlf_collections.uid',
                 '',
                 ''
@@ -174,12 +174,24 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
 
+                if (is_array($resArrayVolumes) && $resArrayVolumes['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+
+                    $resArrayVolumes = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArrayVolumes, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+
+                }
+
                 $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
 
             }
 
             // Process results.
             while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+                if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+
+                    $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+
+                }
 
                 // Generate random but unique array key taking priority into account.
                 do {
@@ -310,7 +322,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Get all documents in collection.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS collLabel,tx_dlf_collections.description AS collDesc,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS uid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
+            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS label,tx_dlf_collections.description AS description,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS docUid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
             'tx_dlf_documents',
             'tx_dlf_relations',
             'tx_dlf_collections',
@@ -329,11 +341,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
         // Process results.
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
+            if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
+
+                $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
+                debug($resArray, '$resArray');
+
+            }
+
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($resArray['collLabel']),
-                    'description' => $this->pi_RTEcssText($resArray['collDesc']),
+                    'label' => htmlspecialchars($resArray['label']),
+                    'description' => $this->pi_RTEcssText($resArray['description']),
                     'thumbnail' => htmlspecialchars($resArray['collThumb']),
                     'options' => array (
                         'source' => 'collection',
@@ -373,8 +392,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
                 }
 
-                $toplevel[$resArray['uid']] = array (
-                    'u' => $resArray['uid'],
+                $toplevel[$resArray['docUid']] = array (
+                    'u' => $resArray['docUid'],
                     'h' => '',
                     's' => $sorting,
                     'p' => array ()
@@ -382,7 +401,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             } else {
 
-                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
+                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
 
             }
 


### PR DESCRIPTION
This is a solution for #273. Is uses the same approach as the metadata plugin.

Used settings:

* config.sys_language_mode = content_fallback
* config.sys_language_overlay = 1 (or hideNonTranslated)
* add translation to page (collection page AND listview page)
* translate the Kitodo.Presentation plugins
* translate (==copy) a collection record --> set new lanuage, set origin, set label and description