### PR TITLE
Fix using manually created collections as OAI sets

### DIFF
--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -910,7 +910,7 @@ final class tx_dlf_document {
                     'tx_dlf_documents',
                     'tx_dlf_relations',
                     'tx_dlf_collections',
-                    'AND tx_dlf_collections.pid='.intval($cPid).' AND tx_dlf_documents.uid='.intval($this->uid).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+                    'AND tx_dlf_collections.pid='.intval($cPid).' AND tx_dlf_documents.uid='.intval($this->uid).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
                     'tx_dlf_collections.index_name',
                     '',
                     ''

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -902,6 +902,32 @@ final class tx_dlf_document {
 
             }
 
+            // Add collections from database to toplevel element if document is already saved.
+            if (\TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($this->uid) && $id == $this->_getToplevelId()) {
+
+                $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
+                    'tx_dlf_collections.index_name AS index_name',
+                    'tx_dlf_documents',
+                    'tx_dlf_relations',
+                    'tx_dlf_collections',
+                    'AND tx_dlf_collections.pid='.intval($cPid).' AND tx_dlf_documents.uid='.intval($this->uid).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').' AND tx_dlf_collections.sys_language_uid IN (-1,0)'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+                    'tx_dlf_collections.index_name',
+                    '',
+                    ''
+                );
+
+                while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
+                    if (!in_array($resArray['index_name'], $metadata['collection'])) {
+
+                        $metadata['collection'][] = $resArray['index_name'];
+
+                    }
+
+                }
+
+            }
+
         } else {
 
             // There is no dmdSec for this structure node.
@@ -1381,9 +1407,7 @@ final class tx_dlf_document {
             ''
         );
 
-        for ($i = 0, $j = $GLOBALS['TYPO3_DB']->sql_num_rows($result); $i < $j; $i++) {
-
-            $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
 
             $collUid[$resArray['index_name']] = $resArray['uid'];
 
@@ -1405,7 +1429,7 @@ final class tx_dlf_document {
                     'pid' => $pid,
                     'label' => $collection,
                     'index_name' => $collection,
-                    'oai_name' => (!empty($conf['publishNewCollections']) ? $collection : ''),
+                    'oai_name' => (!empty($conf['publishNewCollections']) ? tx_dlf_helper::getCleanString($collection) : ''),
                     'description' => '',
                     'documents' => 0,
                     'owner' => 0,
@@ -1435,24 +1459,6 @@ final class tx_dlf_document {
                 }
 
             }
-
-        }
-
-        // Preserve user-defined collections.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
-            'tx_dlf_collections',
-            'AND tx_dlf_documents.pid='.intval($pid).' AND tx_dlf_collections.pid='.intval($pid).' AND tx_dlf_documents.uid='.$GLOBALS['TYPO3_DB']->fullQuoteStr($this->uid, 'tx_dlf_documents').' AND NOT (tx_dlf_collections.cruser_id='.intval($be_user).' AND tx_dlf_collections.fe_cruser_id=0) AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations'),
-            '',
-            '',
-            ''
-        );
-
-        for ($i = 0, $j = $GLOBALS['TYPO3_DB']->sql_num_rows($result); $i < $j; $i++) {
-
-            list ($collections[]) = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
 
         }
 

--- a/common/class.tx_dlf_helper.php
+++ b/common/class.tx_dlf_helper.php
@@ -362,6 +362,33 @@ class tx_dlf_helper {
     }
 
     /**
+     * Clean up a string to use in an URL.
+     *
+     * @access	public
+     *
+     * @param	string		$string: The string to clean up
+     *
+     * @return	string		The cleaned up string
+     */
+    public static function getCleanString($string) {
+
+        // Convert to lowercase.
+        $string = strtolower($string);
+
+        // Remove non-alphanumeric characters.
+        $string = preg_replace('/[^a-z0-9_\s-]/', '', $string);
+
+        // Remove multiple dashes or whitespaces.
+        $string = preg_replace('/[\s-]+/', ' ', $string);
+
+        // Convert whitespaces and underscore to dash.
+        $string = preg_replace('/[\s_]/', '-', $string);
+
+        return $string;
+
+    }
+
+    /**
      * Get the current frontend user object
      *
      * @access	public

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -793,6 +793,8 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('type', $physicalUnit['type'], self::$fields['fieldboost']['type']);
 
+            $solrDoc->setField('collection', $doc->metadataArray[$doc->toplevelId]['collection']);
+
             $solrDoc->setField('fulltext', tx_dlf_alto::getRawText($xml));
 
             // Add faceting information to physical sub-elements if applicable.
@@ -808,6 +810,14 @@ class tx_dlf_indexing {
                     }
 
                 }
+
+            }
+
+            // Add collection information to physical sub-elements if applicable.
+            if (in_array('collection', self::$fields['facets'])
+                && !empty($doc->metadataArray[$doc->toplevelId]['collection'])) {
+
+                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->toplevelId]['collection']);
 
             }
 


### PR DESCRIPTION
This should fix #271.

I did not implement automatic reindexing of documents after adding/removing them from collections, because that would be triggered by updating a collection record and would result in reindexing all documents of the collection everytime the collection gets updated...
So after manually creating or updating a collection, one has to remember to reindex that collection via the backend module if one wants to use it as an OAI set.