### PR TITLE
fix #283: compare value with simple array

### DIFF
--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -223,7 +223,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         $record['metadata'] = $metadata;
 
-                    } elseif (($key = array_search($resArray['uid'], array_column($record['subparts'], 'u'), TRUE)) !== FALSE) {
+                    } elseif (($key = array_search(array('u' => $resArray['uid']), $record['subparts'], TRUE)) !== FALSE) {
 
                         $record['subparts'][$key] = array (
                             'uid' => $resArray['uid'],

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -223,7 +223,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         $record['metadata'] = $metadata;
 
-                    } elseif (($key = array_search($resArray['uid'], $record['subparts'], TRUE)) !== FALSE) {
+                    } elseif (($key = array_search($resArray['uid'], array_column($record['subparts'], 'u'), TRUE)) !== FALSE) {
 
                         $record['subparts'][$key] = array (
                             'uid' => $resArray['uid'],


### PR DESCRIPTION
The comparision is done at this point with the following values/arrays:

$resArray['uid'] = 3123;

$record['subparts'][0]['u'] = 4123;
$record['subparts'][1]['u'] = 2123;
$record['subparts'][2]['u'] = 3123;

array_search(3123, $record['subparts']) --> no result

Solutions:

array_search(3123, array_column($record['subparts'], 'u') --> 2

or

array_search(array('u' => 3123), $record['subparts']) --> 2