### PR TITLE
Add possibility to use different fulltext formats

### DIFF
--- a/common/class.tx_dlf_alto.php
+++ b/common/class.tx_dlf_alto.php
@@ -24,11 +24,11 @@ class tx_dlf_alto implements tx_dlf_fulltext {
      *
      * @access	public
      *
-     * @param	SimpleXMLElement		$xml: The XML to extract the metadata from
+     * @param	SimpleXMLElement		$xml: The XML to extract the raw text from
      *
      * @return	string			The raw unformatted fulltext
      */
-    public static function getRawText(SimpleXMLElement $xml) {
+    public function getRawText(SimpleXMLElement $xml) {
 
         $xml->registerXPathNamespace('alto', 'http://www.loc.gov/standards/alto/ns-v2#');
 

--- a/common/class.tx_dlf_fulltext.php
+++ b/common/class.tx_dlf_fulltext.php
@@ -29,6 +29,6 @@ interface tx_dlf_fulltext {
      *
      * @return	string			The raw unformatted fulltext
      */
-    public static function getRawText(SimpleXMLElement $xml);
+    public function getRawText(SimpleXMLElement $xml);
 
 }

--- a/common/class.tx_dlf_indexing.php
+++ b/common/class.tx_dlf_indexing.php
@@ -793,7 +793,7 @@ class tx_dlf_indexing {
 
             $solrDoc->setField('type', $physicalUnit['type'], self::$fields['fieldboost']['type']);
 
-            $solrDoc->setField('fulltext', tx_dlf_alto::getRawText($xml));
+            $solrDoc->setField('fulltext', $doc->getRawText($physicalUnit['id']));
 
             // Add faceting information to physical sub-elements if applicable.
             foreach ($doc->metadataArray[$doc->toplevelId] as $index_name => $data) {


### PR DESCRIPTION
This partially fixes #197 

Fulltext is now handled the same way as metadata loading from `dmdSec` is done. Thus it is possible to use different fulltext formats by simply providing a class implementing the `tx_dlf_fulltext` interface and registering this class via `tx_dlf_formats`.