### PR TITLE
Add Solr queries to collection plugin

### DIFF
--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -1048,7 +1048,7 @@ final class tx_dlf_document {
 
                 if (TYPO3_DLOG) {
 
-                    \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getRawText('.$id.')] Invalid structure node @ID "'.$id.'"'.self::$extKey, SYSLOG_SEVERITY_WARNING);
+                    \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getRawText('.$id.')] Invalid structure node @ID "'.$id.'"', self::$extKey, SYSLOG_SEVERITY_WARNING);
 
                 }
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -1048,7 +1048,7 @@ final class tx_dlf_document {
 
                 if (TYPO3_DLOG) {
 
-                    \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getRawText('.$id.')] Invalid structure node @ID "'.$id.'"'. self::$extKey, SYSLOG_SEVERITY_WARNING);
+                    \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_document->getRawText('.$id.')] Invalid structure node @ID "'.$id.'"'.self::$extKey, SYSLOG_SEVERITY_WARNING);
 
                 }
 

--- a/common/class.tx_dlf_list.php
+++ b/common/class.tx_dlf_list.php
@@ -223,7 +223,7 @@ class tx_dlf_list implements ArrayAccess, Countable, Iterator, \TYPO3\CMS\Core\S
 
                         $record['metadata'] = $metadata;
 
-                    } elseif (($key = array_search(array('u' => $resArray['uid']), $record['subparts'], TRUE)) !== FALSE) {
+                    } elseif (($key = array_search(array ('u' => $resArray['uid']), $record['subparts'], TRUE)) !== FALSE) {
 
                         $record['subparts'][$key] = array (
                             'uid' => $resArray['uid'],

--- a/modules/indexing/index.php
+++ b/modules/indexing/index.php
@@ -157,7 +157,7 @@ class tx_dlf_modIndexing extends tx_dlf_module {
     protected function indexLoop() {
 
         // Get document from list.
-        list ($uid, ) = $this->list->remove(0);
+        list ($uid,) = $this->list->remove(0);
 
         $this->list->save();
 

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -343,8 +343,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($collectionData['collLabel']),
-                    'description' => $this->pi_RTEcssText($collectionData['collDesc']),
+                    'label' => !empty($l10nOverlay['label'])? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($collectionData['collLabel']),
+                    'description' => !empty($l10nOverlay['description']) ? $this->pi_RTEcssText($l10nOverlay['description']) : $this->pi_RTEcssText($collectionData['collDesc']),
                     'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (
                         'source' => 'collection',

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -95,53 +95,33 @@ class tx_dlf_collection extends tx_dlf_plugin {
      * @return	string		The list of collections ready to output
      */
     protected function showCollectionList() {
-
-        $additionalWhere = '';
-
+        $selectedCollections = 'tx_dlf_collections.uid != 0';
         $orderBy = 'tx_dlf_collections.label';
 
         // Handle collections set by configuration.
         if ($this->conf['collections']) {
 
             if (count(explode(',', $this->conf['collections'])) == 1 && empty($this->conf['dont_show_single'])) {
-
                 $this->showSingleCollection(intval(trim($this->conf['collections'], ' ,')));
-
             }
 
-            $additionalWhere .= ' AND tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
+            $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
         }
 
+        $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
+
         // Should user-defined collections be shown?
-        if (empty($this->conf['show_userdefined'])) {
-
-            $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        } elseif ($this->conf['show_userdefined'] > 0) {
-
-            if (!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-
-                $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
-
-            } else {
-
-                $additionalWhere .= ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
-            }
-
+        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0 && !empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+            $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
         }
 
         // Get collections.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections').' AND (tx_dlf_collections.sys_language_uid IN (-1,0) OR (tx_dlf_collections.sys_language_uid = '.$GLOBALS['TSFE']->sys_language_uid.' AND tx_dlf_collections.l18n_parent = 0))',
-            'tx_dlf_collections.uid',
+            $selectedCollections.$showUserDefinedCollections.' AND tx_dlf_collections.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            '',
             $orderBy,
             ''
         );
@@ -154,141 +134,130 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-            $this->showSingleCollection(intval($resArray['uid']));
+            return $this->showSingleCollection(intval($resArray['uid']));
+        }
 
-        } elseif ($count > 0) {
+        $collections = array ();
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+            $collections[$collectionData['uid']] = $collectionData;
+        }
 
-            // Get number of volumes per collection.
-            $resultVolumes = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_collections.uid AS uid,COUNT(tx_dlf_documents.uid) AS volumes',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_collections.uid',
-                '',
-                ''
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        // We only care about the UID in the results and want them sorted
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        // Process results.
+        foreach ($collections as $collection) {
+
+            $solr_query = '';
+
+            if ($collection['index_query'] != "") {
+                $solr_query .= '('.$collection['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+            }
+
+            $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+            $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
+
+            $titles = array ();
+
+            foreach ($partOfNothing as $doc) {
+                $titles[] = $doc->uid;
+            }
+
+            $volumes = $titles;
+
+            // All titles except those that are part of something
+            foreach ($partOfSomething as $doc) {
+                unset($volumes[$doc->uid]);
+            }
+
+            $collection['titles'] = $titles;
+            $collection['volumes'] = $volumes;
+
+            // Generate random but unique array key taking priority into account.
+            do {
+
+                $_key = ($collection['priority'] * 1000) + mt_rand(0, 1000);
+
+            } while (!empty($markerArray[$_key]));
+
+            // Merge plugin variables with new set of values.
+            $additionalParams = array ('collection' => $collection['uid']);
+
+            if (is_array($this->piVars)) {
+
+                $piVars = $this->piVars;
+
+                unset($piVars['DATA']);
+
+                $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
+            }
+
+            // Build typolink configuration array.
+            $conf = array (
+                'useCacheHash' => 1,
+                'parameter' => $GLOBALS['TSFE']->id,
+                'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
             );
 
-            $volumes = array ();
+            // Link collection's title to list view.
+            $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($collection['label']), $conf);
 
-            while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
-
-                $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
-
+            // Add feed link if applicable.
+            if (!empty($this->conf['targetFeed'])) {
+                $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+                $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $collection['uid'])), FALSE, $this->conf['targetFeed']);
+            } else {
+                $markerArray[$_key]['###FEED###'] = '';
             }
 
-            // Process results.
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
-
-                    $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_collections', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
-
-                }
-
-                // Generate random but unique array key taking priority into account.
-                do {
-
-                    $_key = ($resArray['priority'] * 1000) + mt_rand(0, 1000);
-
-                } while (!empty($markerArray[$_key]));
-
-                // Merge plugin variables with new set of values.
-                $additionalParams = array ('collection' => $resArray['uid']);
-
-                if (is_array($this->piVars)) {
-
-                    $piVars = $this->piVars;
-
-                    unset($piVars['DATA']);
-
-                    $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
-
-                }
-
-                // Build typolink configuration array.
-                $conf = array (
-                    'useCacheHash' => 1,
-                    'parameter' => $GLOBALS['TSFE']->id,
-                    'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
-                );
-
-                // Link collection's title to list view.
-                $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($resArray['label']), $conf);
-
-                // Add feed link if applicable.
-                if (!empty($this->conf['targetFeed'])) {
-
-                    $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
-
-                    $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $resArray['uid'])), FALSE, $this->conf['targetFeed']);
-
-                } else {
-
-                    $markerArray[$_key]['###FEED###'] = '';
-
-                }
-
-                // Add thumbnail.
-                if (!empty($resArray['thumbnail'])) {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$resArray['thumbnail'].'" />';
-
-                } else {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '';
-
-                }
-
-                // Add description.
-                $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($resArray['description']);
-
-                // Build statistic's output.
-                $labelTitles = $this->pi_getLL(($resArray['titles'] > 1 ? 'titles' : 'title'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars($resArray['titles'].$labelTitles);
-
-                $labelVolumes = $this->pi_getLL(($volumes[$resArray['uid']] > 1 ? 'volumes' : 'volume'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars($volumes[$resArray['uid']].$labelVolumes);
-
+            // Add thumbnail.
+            if (!empty($resArray['thumbnail'])) {
+                $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+            } else {
+                $markerArray[$_key]['###THUMBNAIL###'] = '';
             }
 
-            // Randomize sorting?
-            if (!empty($this->conf['randomize'])) {
+            // Add description.
+            $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($collection['description']);
 
-                ksort($markerArray, SORT_NUMERIC);
+            // Build statistic's output.
+            $labelTitles = $this->pi_getLL((count($collection['titles']) > 1 ? 'titles' : 'title'), '', FALSE);
 
-                // Don't cache the output.
-                $this->setCache(FALSE);
+            $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars(count($collection['titles']).$labelTitles);
 
-            }
+            $labelVolumes = $this->pi_getLL((count($collection['volumes']) > 1 ? 'volumes' : 'volume'), '', FALSE);
 
-            $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
-
-            foreach ($markerArray as $marker) {
-
-                $content .= $this->cObj->substituteMarkerArray($entry, $marker);
-
-            }
-
-            // Hook for getting custom collection hierarchies/subentries (requested by SBB).
-            foreach ($this->hookObjects as $hookObj) {
-
-                if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
-
-                    $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
-
-                }
-
-            }
-
-            return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
+            $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars(count($collection['volumes']).$labelVolumes);
 
         }
 
-        return $content;
+        // Randomize sorting?
+        if (!empty($this->conf['randomize'])) {
+
+            ksort($markerArray, SORT_NUMERIC);
+
+            // Don't cache the output.
+            $this->setCache(FALSE);
+        }
+
+        $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
+
+        foreach ($markerArray as $marker) {
+            $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+        }
+
+        // Hook for getting custom collection hierarchies/subentries (requested by SBB).
+        foreach ($this->hookObjects as $hookObj) {
+
+            if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
+                $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
+            }
+        }
+
+        return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
 
     }
 
@@ -305,35 +274,56 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
-
             $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
         } elseif ($this->conf['show_userdefined'] > 0) {
-
             $additionalWhere = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
         }
 
-        // Get all documents in collection.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.pid AS pid,tx_dlf_collections.sys_language_uid AS sys_language_uid,tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS label,tx_dlf_collections.description AS description,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS docUid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        // Get collection information from DB
+        $collection = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.label AS collLabel, tx_dlf_collections.description AS collDesc, tx_dlf_collections.thumbnail AS collThumb, tx_dlf_collections.fe_cruser_id',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.uid='.intval($id).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.uid='.intval($id).' '.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
-            'tx_dlf_documents.title_sorting ASC',
+            '',
+            '1'
+        );
+
+        // Fetch corresponding document UIDs from Solr
+        $solr_query = "";
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+            if ($collectionData['index_query'] != "") {
+                $solr_query .= '('.$collectionData['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+            }
+        }
+
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        $solrResult = $solr->search_raw($solr_query, $parameters);
+
+        foreach ($solrResult as $doc) {
+            $documentSet[] = $doc->uid;
+        }
+
+        //Fetch document info for UIDs in $documentSet from DB
+        $documents = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.metadata_sorting AS metadata_sorting, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.partof AS partof',
+            'tx_dlf_documents',
+            'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.uid IN ('.implode(',', $documentSet).')'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents'),
+            '',
+            '',
             ''
         );
 
         $toplevel = array ();
-
         $subparts = array ();
-
         $listMetadata = array ();
 
         // Process results.
-        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
 
             if (empty($l10nOverlay)) {
 
@@ -344,21 +334,20 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => !empty($l10nOverlay['label']) ? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($resArray['label']),
-                    'description' => !empty($l10nOverlay['description']) ? $this->pi_RTEcssText($l10nOverlay['description']) : $this->pi_RTEcssText($resArray['description']),
-                    'thumbnail' => htmlspecialchars($resArray['collThumb']),
+                    'label' => htmlspecialchars($collectionData['collLabel']),
+                    'description' => $this->pi_RTEcssText($collectionData['collDesc']),
+                    'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (
                         'source' => 'collection',
                         'select' => $id,
-                        'userid' => $resArray['userid'],
-                        'params' => array ('fq' => array ('collection_faceting:("'.$resArray['index_name'].'")')),
+                        'userid' => $collectionData['userid'],
+                        'params' => array ('fq' => array ('collection_faceting:("'.$collectionData['index_name'].'")')),
                         'core' => '',
                         'pid' => $this->conf['pages'],
                         'order' => 'title',
                         'order.asc' => TRUE
                     )
                 );
-
             }
 
             // Split toplevel documents from volumes.
@@ -393,11 +382,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 );
 
             } else {
-
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
-
             }
-
         }
 
         // Add volumes to the corresponding toplevel documents.
@@ -408,13 +394,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 ksort($parts);
 
                 foreach ($parts as $part) {
-
                     $toplevel[$partof]['p'][] = array ('u' => $part);
-
                 }
-
             }
-
         }
 
         // Save list of documents.
@@ -438,7 +420,5 @@ class tx_dlf_collection extends tx_dlf_plugin {
         ob_end_flush();
 
         exit;
-
     }
-
 }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -112,8 +112,13 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
 
         // Should user-defined collections be shown?
-        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0 && !empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-            $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0) {
+
+            if(!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+                $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+            } else {
+                $showUserDefinedCollections = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+            }
         }
 
         // Get collections.

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -210,11 +210,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             }
 
-            $collection['titles'] = $titles;
+            $collection['titles'] = array_unique($titles);
 
-            $volumes = array_unique($volumes);
-
-            $collection['volumes'] = $volumes;
+            $collection['volumes'] = array_unique($volumes);
 
             // Generate random but unique array key taking priority into account.
             do {

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -184,7 +184,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
 
             // Titles are all documents that are "root"-elements i.e. partof == 0;
-            $titles = array();
+            $titles = array ();
 
             foreach ($partOfNothing as $doc) {
 
@@ -396,7 +396,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => !empty($l10nOverlay['label'])? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($collectionData['collLabel']),
+                    'label' => !empty($l10nOverlay['label']) ? htmlspecialchars($l10nOverlay['label']) : htmlspecialchars($collectionData['collLabel']),
                     'description' => !empty($l10nOverlay['description']) ? $this->pi_RTEcssText($l10nOverlay['description']) : $this->pi_RTEcssText($collectionData['collDesc']),
                     'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -112,6 +112,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
 
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
+
         }
 
         $showUserDefinedColls = ' AND tx_dlf_collections.fe_cruser_id=0';
@@ -128,6 +129,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 $showUserDefinedColls = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
 
             }
+ 
         }
 
         // Get collections.
@@ -149,6 +151,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
             return $this->showSingleCollection(intval($resArray['uid']));
+
         }
 
         $collections = array ();
@@ -162,24 +165,24 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
 
         // We only care about the UID and partOf in the results and want them sorted
-        $parameters = array ("fl" => "uid, partof", "sort" => "uid asc");
+        $parameters = array ("fl" => "uid,partof", "sort" => "uid asc");
 
         // Process results.
         foreach ($collections as $collection) {
 
             $solr_query = '';
 
-            if ($collection['index_query'] != "") {
+            if ($collection['index_query'] != '') {
 
                 $solr_query .= '('.$collection['index_query'].')';
 
             } else {
 
-                $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+                $solr_query .= 'collection:"'.$collection['index_name'].'"';
 
             }
 
-            $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+            $partOfNothing = $solr->search_raw($solr_query.' AND partof:0', $parameters);
 
             $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
 
@@ -228,6 +231,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 unset($piVars['DATA']);
 
                 $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
+
             }
 
             // Build typolink configuration array.
@@ -285,6 +289,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             // Don't cache the output.
             $this->setCache(FALSE);
+
         }
 
         $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
@@ -303,6 +308,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
 
             }
+
         }
 
         return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
@@ -410,6 +416,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                         'order.asc' => TRUE
                     )
                 );
+
             }
 
             // Split toplevel documents from volumes.
@@ -448,6 +455,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
 
             }
+
         }
 
         // Add volumes to the corresponding toplevel documents.
@@ -462,7 +470,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                     $toplevel[$partof]['p'][] = array ('u' => $part);
 
                 }
+
             }
+
         }
 
         // Save list of documents.
@@ -486,5 +496,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
         ob_end_flush();
 
         exit;
+
     }
+
 }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -114,18 +114,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
         }
 
-        $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
+        $showUserDefinedColls = ' AND tx_dlf_collections.fe_cruser_id=0';
 
         // Should user-defined collections be shown?
         if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0) {
 
-            if(!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+            if (!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
 
-                $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+                $showUserDefinedColls = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
 
             } else {
 
-                $showUserDefinedCollections = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+                $showUserDefinedColls = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
 
             }
         }
@@ -134,7 +134,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority',
             'tx_dlf_collections',
-            $selectedCollections.$showUserDefinedCollections.' AND tx_dlf_collections.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            $selectedCollections.$showUserDefinedColls.' AND tx_dlf_collections.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
             $orderBy,
             ''
@@ -344,7 +344,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
         // Fetch corresponding document UIDs from Solr
         $solr_query = "";
 
-       $collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection);
+        $collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection);
 
         if ($collectionData['index_query'] != "") {
 
@@ -355,7 +355,6 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
 
         }
-
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
 

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -366,9 +366,24 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
 
+        if (!$solr->ready) {
+
+            if (TYPO3_DLOG) {
+
+                \TYPO3\CMS\Core\Utility\GeneralUtility::devLog('[tx_dlf_collection->showSingleCollection('.$content.', [data])] Apache Solr not available', $this->extKey, SYSLOG_SEVERITY_ERROR, $conf);
+
+            }
+
+            return $content;
+
+        }
+
         $parameters = array ("fl" => "uid", "sort" => "uid asc");
 
         $solrResult = $solr->search_raw($solr_query, $parameters);
+
+        // initialize array
+        $documentSet = [];
 
         foreach ($solrResult as $doc) {
 

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -344,18 +344,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
         // Fetch corresponding document UIDs from Solr
         $solr_query = "";
 
-        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+       $collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection);
 
-            if ($collectionData['index_query'] != "") {
+        if ($collectionData['index_query'] != "") {
 
-                $solr_query .= '('.$collectionData['index_query'].')';
+            $solr_query .= '('.$collectionData['index_query'].')';
 
-            } else {
+        } else {
 
-                $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+            $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
 
-            }
         }
+
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
 
@@ -437,8 +437,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
                 }
 
-                $toplevel[$resArray['docUid']] = array (
-                    'u' => $resArray['docUid'],
+                $toplevel[$resArray['uid']] = array (
+                    'u' => $resArray['uid'],
                     'h' => '',
                     's' => $sorting,
                     'p' => array ()
@@ -446,7 +446,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             } else {
 
-                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
+                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
 
             }
         }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -95,17 +95,22 @@ class tx_dlf_collection extends tx_dlf_plugin {
      * @return	string		The list of collections ready to output
      */
     protected function showCollectionList() {
+
         $selectedCollections = 'tx_dlf_collections.uid != 0';
+
         $orderBy = 'tx_dlf_collections.label';
 
         // Handle collections set by configuration.
         if ($this->conf['collections']) {
 
             if (count(explode(',', $this->conf['collections'])) == 1 && empty($this->conf['dont_show_single'])) {
+
                 $this->showSingleCollection(intval(trim($this->conf['collections'], ' ,')));
+
             }
 
             $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
+
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
         }
 
@@ -115,9 +120,13 @@ class tx_dlf_collection extends tx_dlf_plugin {
         if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0) {
 
             if(!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+
                 $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
+
             } else {
+
                 $showUserDefinedCollections = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+
             }
         }
 
@@ -143,12 +152,16 @@ class tx_dlf_collection extends tx_dlf_plugin {
         }
 
         $collections = array ();
+
         while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+
             $collections[$collectionData['uid']] = $collectionData;
+
         }
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
-        // We only care about the UID in the results and want them sorted
+
+        // We only care about the UID and partOf in the results and want them sorted
         $parameters = array ("fl" => "uid, partof", "sort" => "uid asc");
 
         // Process results.
@@ -157,18 +170,26 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $solr_query = '';
 
             if ($collection['index_query'] != "") {
+
                 $solr_query .= '('.$collection['index_query'].')';
+
             } else {
+
                 $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+
             }
 
             $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+
             $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
 
             // Titles are all documents that are "root"-elements i.e. partof == 0;
             $titles = array();
+
             foreach ($partOfNothing as $doc) {
+
                 $titles[] = $doc->uid;
+
             }
 
             // Volumes are documents that are both
@@ -176,13 +197,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
             // b) "root"-elements that are not referenced by other documents ("root"-elements that have no descendants)
 
             $volumes = $titles;
+
             foreach ($partOfSomething as $doc) {
+
                 $volumes[] = $doc->uid;
+
                 // if a document is referenced via partof, it’s not a volume anymore
                 unset($volumes[$doc->partof]);
+
             }
 
             $collection['titles'] = $titles;
+
             $collection['volumes'] = $volumes;
 
             // Generate random but unique array key taking priority into account.
@@ -216,17 +242,26 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             // Add feed link if applicable.
             if (!empty($this->conf['targetFeed'])) {
+
                 $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+
                 $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $collection['uid'])), FALSE, $this->conf['targetFeed']);
+
             } else {
+
                 $markerArray[$_key]['###FEED###'] = '';
+
             }
 
             // Add thumbnail.
             if (!empty($resArray['thumbnail'])) {
+
                 $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+
             } else {
+
                 $markerArray[$_key]['###THUMBNAIL###'] = '';
+
             }
 
             // Add description.
@@ -255,14 +290,18 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
 
         foreach ($markerArray as $marker) {
+
             $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+
         }
 
         // Hook for getting custom collection hierarchies/subentries (requested by SBB).
         foreach ($this->hookObjects as $hookObj) {
 
             if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
+
                 $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
+
             }
         }
 
@@ -283,9 +322,13 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
+
             $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
+
         } elseif ($this->conf['show_userdefined'] > 0) {
+
             $additionalWhere = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
+
         }
 
         // Get collection information from DB
@@ -300,21 +343,30 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Fetch corresponding document UIDs from Solr
         $solr_query = "";
+
         while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+
             if ($collectionData['index_query'] != "") {
+
                 $solr_query .= '('.$collectionData['index_query'].')';
+
             } else {
+
                 $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+
             }
         }
 
         $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+
         $parameters = array ("fl" => "uid", "sort" => "uid asc");
 
         $solrResult = $solr->search_raw($solr_query, $parameters);
 
         foreach ($solrResult as $doc) {
+
             $documentSet[] = $doc->uid;
+
         }
 
         //Fetch document info for UIDs in $documentSet from DB
@@ -328,7 +380,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
         );
 
         $toplevel = array ();
+
         $subparts = array ();
+
         $listMetadata = array ();
 
         // Process results.
@@ -391,7 +445,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 );
 
             } else {
+
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['docUid'];
+
             }
         }
 
@@ -403,7 +459,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 ksort($parts);
 
                 foreach ($parts as $part) {
+
                     $toplevel[$partof]['p'][] = array ('u' => $part);
+
                 }
             }
         }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -95,53 +95,33 @@ class tx_dlf_collection extends tx_dlf_plugin {
      * @return	string		The list of collections ready to output
      */
     protected function showCollectionList() {
-
-        $additionalWhere = '';
-
+        $selectedCollections = 'tx_dlf_collections.uid != 0';
         $orderBy = 'tx_dlf_collections.label';
 
         // Handle collections set by configuration.
         if ($this->conf['collections']) {
 
             if (count(explode(',', $this->conf['collections'])) == 1 && empty($this->conf['dont_show_single'])) {
-
                 $this->showSingleCollection(intval(trim($this->conf['collections'], ' ,')));
-
             }
 
-            $additionalWhere .= ' AND tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
+            $selectedCollections = 'tx_dlf_collections.uid IN ('.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
             $orderBy = 'FIELD(tx_dlf_collections.uid, '.$GLOBALS['TYPO3_DB']->cleanIntList($this->conf['collections']).')';
-
         }
 
+        $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id=0';
+
         // Should user-defined collections be shown?
-        if (empty($this->conf['show_userdefined'])) {
-
-            $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id=0';
-
-        } elseif ($this->conf['show_userdefined'] > 0) {
-
-            if (!empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
-
-                $additionalWhere .= ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
-
-            } else {
-
-                $additionalWhere .= ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
-            }
-
+        if (!empty($this->conf['show_userdefined']) && $this->conf['show_userdefined'] > 0 && !empty($GLOBALS['TSFE']->fe_user->user['uid'])) {
+            $showUserDefinedCollections = ' AND tx_dlf_collections.fe_cruser_id='.intval($GLOBALS['TSFE']->fe_user->user['uid']);
         }
 
         // Get collections.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority,COUNT(tx_dlf_documents.uid) AS titles',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.uid AS uid,tx_dlf_collections.label AS label,tx_dlf_collections.thumbnail AS thumbnail,tx_dlf_collections.description AS description,tx_dlf_collections.priority AS priority',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.partof=0 AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
-            'tx_dlf_collections.uid',
+            $selectedCollections.$showUserDefinedCollections.' AND tx_dlf_collections.pid='.intval($this->conf['pages']).tx_dlf_helper::whereClause('tx_dlf_collections'),
+            '',
             $orderBy,
             ''
         );
@@ -154,135 +134,130 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             $resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result);
 
-            $this->showSingleCollection(intval($resArray['uid']));
+            return $this->showSingleCollection(intval($resArray['uid']));
+        }
 
-        } elseif ($count > 0) {
+        $collections = array ();
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+            $collections[$collectionData['uid']] = $collectionData;
+        }
 
-            // Get number of volumes per collection.
-            $resultVolumes = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-                'tx_dlf_collections.uid AS uid,COUNT(tx_dlf_documents.uid) AS volumes',
-                'tx_dlf_documents',
-                'tx_dlf_relations',
-                'tx_dlf_collections',
-                'AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND NOT tx_dlf_documents.uid IN (SELECT DISTINCT tx_dlf_documents.partof FROM tx_dlf_documents WHERE NOT tx_dlf_documents.partof=0'.tx_dlf_helper::whereClause('tx_dlf_documents').') AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
-                'tx_dlf_collections.uid',
-                '',
-                ''
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        // We only care about the UID in the results and want them sorted
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        // Process results.
+        foreach ($collections as $collection) {
+
+            $solr_query = '';
+
+            if ($collection['index_query'] != "") {
+                $solr_query .= '('.$collection['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collection['index_name'].'"';
+            }
+
+            $partOfNothing = $solr->search_raw($solr_query.' partof:0', $parameters);
+            $partOfSomething = $solr->search_raw($solr_query.' AND NOT partof:0', $parameters);
+
+            $titles = array ();
+
+            foreach ($partOfNothing as $doc) {
+                $titles[] = $doc->uid;
+            }
+
+            $volumes = $titles;
+
+            // All titles except those that are part of something
+            foreach ($partOfSomething as $doc) {
+                unset($volumes[$doc->uid]);
+            }
+
+            $collection['titles'] = $titles;
+            $collection['volumes'] = $volumes;
+
+            // Generate random but unique array key taking priority into account.
+            do {
+
+                $_key = ($collection['priority'] * 1000) + mt_rand(0, 1000);
+
+            } while (!empty($markerArray[$_key]));
+
+            // Merge plugin variables with new set of values.
+            $additionalParams = array ('collection' => $collection['uid']);
+
+            if (is_array($this->piVars)) {
+
+                $piVars = $this->piVars;
+
+                unset($piVars['DATA']);
+
+                $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
+            }
+
+            // Build typolink configuration array.
+            $conf = array (
+                'useCacheHash' => 1,
+                'parameter' => $GLOBALS['TSFE']->id,
+                'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
             );
 
-            $volumes = array ();
+            // Link collection's title to list view.
+            $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($collection['label']), $conf);
 
-            while ($resArrayVolumes = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($resultVolumes)) {
-
-                $volumes[$resArrayVolumes['uid']] = $resArrayVolumes['volumes'];
-
+            // Add feed link if applicable.
+            if (!empty($this->conf['targetFeed'])) {
+                $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
+                $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $collection['uid'])), FALSE, $this->conf['targetFeed']);
+            } else {
+                $markerArray[$_key]['###FEED###'] = '';
             }
 
-            // Process results.
-            while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
-
-                // Generate random but unique array key taking priority into account.
-                do {
-
-                    $_key = ($resArray['priority'] * 1000) + mt_rand(0, 1000);
-
-                } while (!empty($markerArray[$_key]));
-
-                // Merge plugin variables with new set of values.
-                $additionalParams = array ('collection' => $resArray['uid']);
-
-                if (is_array($this->piVars)) {
-
-                    $piVars = $this->piVars;
-
-                    unset($piVars['DATA']);
-
-                    $additionalParams = tx_dlf_helper::array_merge_recursive_overrule($piVars, $additionalParams);
-
-                }
-
-                // Build typolink configuration array.
-                $conf = array (
-                    'useCacheHash' => 1,
-                    'parameter' => $GLOBALS['TSFE']->id,
-                    'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', TRUE, FALSE)
-                );
-
-                // Link collection's title to list view.
-                $markerArray[$_key]['###TITLE###'] = $this->cObj->typoLink(htmlspecialchars($resArray['label']), $conf);
-
-                // Add feed link if applicable.
-                if (!empty($this->conf['targetFeed'])) {
-
-                    $img = '<img src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'res/icons/txdlffeeds.png" alt="'.$this->pi_getLL('feedAlt', '', TRUE).'" title="'.$this->pi_getLL('feedTitle', '', TRUE).'" />';
-
-                    $markerArray[$_key]['###FEED###'] = $this->pi_linkTP($img, array ($this->prefixId => array ('collection' => $resArray['uid'])), FALSE, $this->conf['targetFeed']);
-
-                } else {
-
-                    $markerArray[$_key]['###FEED###'] = '';
-
-                }
-
-                // Add thumbnail.
-                if (!empty($resArray['thumbnail'])) {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$resArray['thumbnail'].'" />';
-
-                } else {
-
-                    $markerArray[$_key]['###THUMBNAIL###'] = '';
-
-                }
-
-                // Add description.
-                $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($resArray['description']);
-
-                // Build statistic's output.
-                $labelTitles = $this->pi_getLL(($resArray['titles'] > 1 ? 'titles' : 'title'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars($resArray['titles'].$labelTitles);
-
-                $labelVolumes = $this->pi_getLL(($volumes[$resArray['uid']] > 1 ? 'volumes' : 'volume'), '', FALSE);
-
-                $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars($volumes[$resArray['uid']].$labelVolumes);
-
+            // Add thumbnail.
+            if (!empty($resArray['thumbnail'])) {
+                $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+            } else {
+                $markerArray[$_key]['###THUMBNAIL###'] = '';
             }
 
-            // Randomize sorting?
-            if (!empty($this->conf['randomize'])) {
+            // Add description.
+            $markerArray[$_key]['###DESCRIPTION###'] = $this->pi_RTEcssText($collection['description']);
 
-                ksort($markerArray, SORT_NUMERIC);
+            // Build statistic's output.
+            $labelTitles = $this->pi_getLL((count($collection['titles']) > 1 ? 'titles' : 'title'), '', FALSE);
 
-                // Don't cache the output.
-                $this->setCache(FALSE);
+            $markerArray[$_key]['###COUNT_TITLES###'] = htmlspecialchars(count($collection['titles']).$labelTitles);
 
-            }
+            $labelVolumes = $this->pi_getLL((count($collection['volumes']) > 1 ? 'volumes' : 'volume'), '', FALSE);
 
-            $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
-
-            foreach ($markerArray as $marker) {
-
-                $content .= $this->cObj->substituteMarkerArray($entry, $marker);
-
-            }
-
-            // Hook for getting custom collection hierarchies/subentries (requested by SBB).
-            foreach ($this->hookObjects as $hookObj) {
-
-                if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
-
-                    $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
-
-                }
-
-            }
-
-            return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
+            $markerArray[$_key]['###COUNT_VOLUMES###'] = htmlspecialchars(count($collection['volumes']).$labelVolumes);
 
         }
 
-        return $content;
+        // Randomize sorting?
+        if (!empty($this->conf['randomize'])) {
+
+            ksort($markerArray, SORT_NUMERIC);
+
+            // Don't cache the output.
+            $this->setCache(FALSE);
+        }
+
+        $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
+
+        foreach ($markerArray as $marker) {
+            $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+        }
+
+        // Hook for getting custom collection hierarchies/subentries (requested by SBB).
+        foreach ($this->hookObjects as $hookObj) {
+
+            if (method_exists($hookObj, 'showCollectionList_getCustomCollectionList')) {
+                $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
+            }
+        }
+
+        return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
 
     }
 
@@ -299,54 +274,74 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
-
             $additionalWhere = ' AND tx_dlf_collections.fe_cruser_id=0';
-
         } elseif ($this->conf['show_userdefined'] > 0) {
-
             $additionalWhere = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
-
         }
 
-        // Get all documents in collection.
-        $result = $GLOBALS['TYPO3_DB']->exec_SELECT_mm_query(
-            'tx_dlf_collections.index_name AS index_name,tx_dlf_collections.label AS collLabel,tx_dlf_collections.description AS collDesc,tx_dlf_collections.thumbnail AS collThumb,tx_dlf_collections.fe_cruser_id AS userid,tx_dlf_documents.uid AS uid,tx_dlf_documents.metadata_sorting AS metadata_sorting,tx_dlf_documents.volume_sorting AS volume_sorting,tx_dlf_documents.partof AS partof',
-            'tx_dlf_documents',
-            'tx_dlf_relations',
+        // Get collection information from DB
+        $collection = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.label AS collLabel, tx_dlf_collections.description AS collDesc, tx_dlf_collections.thumbnail AS collThumb, tx_dlf_collections.fe_cruser_id',
             'tx_dlf_collections',
-            'AND tx_dlf_collections.uid='.intval($id).' AND tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_relations.ident='.$GLOBALS['TYPO3_DB']->fullQuoteStr('docs_colls', 'tx_dlf_relations').$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents').tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.uid='.intval($id).' '.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
-            'tx_dlf_documents.title_sorting ASC',
+            '',
+            '1'
+        );
+
+        // Fetch corresponding document UIDs from Solr
+        $solr_query = "";
+        while ($collectionData = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($collection)) {
+            if ($collectionData['index_query'] != "") {
+                $solr_query .= '('.$collectionData['index_query'].')';
+            } else {
+                $solr_query .= 'collection:'.'"'.$collectionData['index_name'].'"';
+            }
+        }
+
+        $solr = tx_dlf_solr::getInstance($this->conf['solrcore']);
+        $parameters = array ("fl" => "uid", "sort" => "uid asc");
+
+        $solrResult = $solr->search_raw($solr_query, $parameters);
+
+        foreach ($solrResult as $doc) {
+            $documentSet[] = $doc->uid;
+        }
+
+        //Fetch document info for UIDs in $documentSet from DB
+        $documents = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.metadata_sorting AS metadata_sorting, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.partof AS partof',
+            'tx_dlf_documents',
+            'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.uid IN ('.implode(',', $documentSet).')'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents'),
+            '',
+            '',
             ''
         );
 
         $toplevel = array ();
-
         $subparts = array ();
-
         $listMetadata = array ();
 
         // Process results.
-        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
+        while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($documents)) {
 
             if (empty($listMetadata)) {
 
                 $listMetadata = array (
-                    'label' => htmlspecialchars($resArray['collLabel']),
-                    'description' => $this->pi_RTEcssText($resArray['collDesc']),
-                    'thumbnail' => htmlspecialchars($resArray['collThumb']),
+                    'label' => htmlspecialchars($collectionData['collLabel']),
+                    'description' => $this->pi_RTEcssText($collectionData['collDesc']),
+                    'thumbnail' => htmlspecialchars($collectionData['collThumb']),
                     'options' => array (
                         'source' => 'collection',
                         'select' => $id,
-                        'userid' => $resArray['userid'],
-                        'params' => array ('fq' => array ('collection_faceting:("'.$resArray['index_name'].'")')),
+                        'userid' => $collectionData['userid'],
+                        'params' => array ('fq' => array ('collection_faceting:("'.$collectionData['index_name'].'")')),
                         'core' => '',
                         'pid' => $this->conf['pages'],
                         'order' => 'title',
                         'order.asc' => TRUE
                     )
                 );
-
             }
 
             // Split toplevel documents from volumes.
@@ -381,11 +376,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 );
 
             } else {
-
                 $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
-
             }
-
         }
 
         // Add volumes to the corresponding toplevel documents.
@@ -396,13 +388,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 ksort($parts);
 
                 foreach ($parts as $part) {
-
                     $toplevel[$partof]['p'][] = array ('u' => $part);
-
                 }
-
             }
-
         }
 
         // Save list of documents.
@@ -426,7 +414,5 @@ class tx_dlf_collection extends tx_dlf_plugin {
         ob_end_flush();
 
         exit;
-
     }
-
 }

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -212,6 +212,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
             $collection['titles'] = $titles;
 
+            $volumes = array_unique($volumes);
+
             $collection['volumes'] = $volumes;
 
             // Generate random but unique array key taking priority into account.
@@ -390,6 +392,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
             $documentSet[] = $doc->uid;
 
         }
+
+        $documentSet = array_unique($documentSet);
 
         //Fetch document info for UIDs in $documentSet from DB
         $documents = $GLOBALS['TYPO3_DB']->exec_SELECTquery(

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -326,6 +326,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
      */
     protected function showSingleCollection($id) {
 
+        $additionalWhere = '';
+
         // Should user-defined collections be shown?
         if (empty($this->conf['show_userdefined'])) {
 
@@ -341,7 +343,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $collection = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.index_name AS index_name, tx_dlf_collections.index_search as index_query, tx_dlf_collections.label AS collLabel, tx_dlf_collections.description AS collDesc, tx_dlf_collections.thumbnail AS collThumb, tx_dlf_collections.fe_cruser_id',
             'tx_dlf_collections',
-            'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.uid='.intval($id).' '.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
+            'tx_dlf_collections.pid='.intval($this->conf['pages']).' AND tx_dlf_collections.uid='.intval($id).$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_collections'),
             '',
             '',
             '1'

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -258,9 +258,9 @@ class tx_dlf_collection extends tx_dlf_plugin {
             }
 
             // Add thumbnail.
-            if (!empty($resArray['thumbnail'])) {
+            if (!empty($collection['thumbnail'])) {
 
-                $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($resArray['label']).'" src="'.$collection['thumbnail'].'" />';
+                $markerArray[$_key]['###THUMBNAIL###'] = '<img alt="" title="'.htmlspecialchars($collection['label']).'" src="'.$collection['thumbnail'].'" />';
 
             } else {
 

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -399,7 +399,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
         $documents = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_documents.uid AS uid, tx_dlf_documents.metadata_sorting AS metadata_sorting, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.partof AS partof',
             'tx_dlf_documents',
-            'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.uid IN ('.implode(',', $documentSet).')'.$additionalWhere.tx_dlf_helper::whereClause('tx_dlf_documents'),
+            'tx_dlf_documents.pid='.intval($this->conf['pages']).' AND tx_dlf_documents.uid IN ('.implode(',', $documentSet).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',
             '',
             ''

--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -129,7 +129,7 @@ class tx_dlf_collection extends tx_dlf_plugin {
                 $showUserDefinedColls = ' AND NOT tx_dlf_collections.fe_cruser_id=0';
 
             }
- 
+
         }
 
         // Get collections.

--- a/plugins/collection/flexform.xml
+++ b/plugins/collection/flexform.xml
@@ -57,6 +57,21 @@
 							</config>
 						</TCEforms>
 					</collections>
+					<solrcore>
+						<TCEforms>
+							<displayCond>FIELD:pages:REQ:true</displayCond>
+							<exclude>1</exclude>
+							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.solrcore</label>
+							<config>
+								<type>select</type>
+								<items type="array"></items>
+								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_solrList</itemsProcFunc>
+								<size>1</size>
+								<maxitems>1</maxitems>
+								<minitems>0</minitems>
+							</config>
+						</TCEforms>
+					</solrcore>
 					<show_userdefined>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/plugins/collection/flexform.xml
+++ b/plugins/collection/flexform.xml
@@ -61,7 +61,7 @@
 						<TCEforms>
 							<displayCond>FIELD:pages:REQ:true</displayCond>
 							<exclude>1</exclude>
-							<label>LLL:EXT:dlf/plugins/oai/locallang.xml:tt_content.pi_flexform.solrcore</label>
+							<label>LLL:EXT:dlf/plugins/collection/locallang.xml:tt_content.pi_flexform.solrcore</label>
 							<config>
 								<type>select</type>
 								<items type="array"></items>

--- a/plugins/collection/flexform.xml
+++ b/plugins/collection/flexform.xml
@@ -68,7 +68,7 @@
 								<itemsProcFunc>tx_dlf_tceforms->itemsProcFunc_solrList</itemsProcFunc>
 								<size>1</size>
 								<maxitems>1</maxitems>
-								<minitems>0</minitems>
+								<minitems>1</minitems>
 							</config>
 						</TCEforms>
 					</solrcore>

--- a/plugins/collection/locallang.xml
+++ b/plugins/collection/locallang.xml
@@ -26,6 +26,7 @@
 			<label index="tt_content.pi_flexform.targetPid">Target page (with "DLF: List View" plugin)</label>
 			<label index="tt_content.pi_flexform.targetFeed">Target page (with "DLF: Feeds" plugin)</label>
 			<label index="tt_content.pi_flexform.templateFile">Template file</label>
+			<label index="tt_content.pi_flexform.solrcore">Solr Core</label>
 			<label index="title"> title</label>
 			<label index="titles"> titles</label>
 			<label index="volume"> volume</label>
@@ -44,6 +45,7 @@
 			<label index="tt_content.pi_flexform.targetPid">Zielseite (mit Plugin "DLF: Listenansicht")</label>
 			<label index="tt_content.pi_flexform.targetFeed">Zielseite (mit Plugin "DLF: Feeds")</label>
 			<label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
+			<label index="tt_content.pi_flexform.solrcore">Solr Kern</label>
 			<label index="title"> Titel</label>
 			<label index="titles"> Titel</label>
 			<label index="volume"> Band</label>


### PR DESCRIPTION
This is basically #268 with the requested changes.

> This pull request adds Solr queries to the collection plugin. Since #261 allows to define virtual collections via a Solr query those collections should be able to be shown in the collection plugin.
> 
> To be able to query the Solr an additional field for selecting a Solr core has been added to the plugin configuration.
> 
> I cleaned up some code and replaced several database queries for the corresponding Solr queries to get the necessary data.
> 
> **CollectionList**
> 1. fetch information about selected collections from database
> 2. for each collection
> -- query titles and volumes info from Solr
> -- generate output
> 
> **SingleCollection**
> 1. fetch collection information from DB
> 2. fetch corresponding document UIDs from Solr
> 3. fetch info from those documents from DB
> 4. generate output
> 
> Step 3 could be eliminated. But we would have to make additional changes. This particular query contains the database field metadata_sorting. That field includes all information for sorting the list view if I got that right. I haven’t figured out how the sorting actually works so that might be wrong.
> 
> ![image](https://user-images.githubusercontent.com/180686/36263188-ea502f08-1269-11e8-88ea-337c30de5bec.png)
> 
> We could probably fetch the values for sorting the documents from the index, but with the options in the selector we would have to add `author` and `year` to the Solr schema. At the moment they are only dynamic fields.

I made the following changes:

- Added missing case for determining userDefinedCollections
- Fixed process of determining volumes
- Referenced the correct language file (and added a new string)
- Made Solr core selection mandatory for the plugin
- Re-added empty lines for requested formatting