### PR TITLE
remove forceAbsoluteUrl to make links relative

### DIFF
--- a/plugins/listview/class.tx_dlf_listview.php
+++ b/plugins/listview/class.tx_dlf_listview.php
@@ -348,8 +348,7 @@ class tx_dlf_listview extends tx_dlf_plugin {
 
         // Configure @action URL for form.
         $linkConf = array (
-            'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
+            'parameter' => $GLOBALS['TSFE']->id
         );
 
         if (!empty($this->piVars['logicalPage'])) {

--- a/plugins/navigation/class.tx_dlf_navigation.php
+++ b/plugins/navigation/class.tx_dlf_navigation.php
@@ -65,8 +65,7 @@ class tx_dlf_navigation extends tx_dlf_plugin {
 
         // Configure @action URL for form.
         $linkConf = array (
-            'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
+            'parameter' => $GLOBALS['TSFE']->id
         );
 
         $output = '<form action="'.$this->cObj->typoLink_URL($linkConf).'" method="get"><div><input type="hidden" name="id" value="'.$GLOBALS['TSFE']->id.'" />';

--- a/plugins/search/class.tx_dlf_search.php
+++ b/plugins/search/class.tx_dlf_search.php
@@ -490,8 +490,7 @@ class tx_dlf_search extends tx_dlf_plugin {
 
             // Configure @action URL for form.
             $linkConf = array (
-                'parameter' => $GLOBALS['TSFE']->id,
-                'forceAbsoluteUrl' => 1
+                'parameter' => $GLOBALS['TSFE']->id
             );
 
             // Fill markers.


### PR DESCRIPTION
This fixes #292.
The default value of forceAbsoluteUrl is "0". So we can omit this parameter.