### PR TITLE
Fix issues with resumption token

### DIFF
--- a/plugins/oai/class.tx_dlf_oai.php
+++ b/plugins/oai/class.tx_dlf_oai.php
@@ -1097,7 +1097,6 @@ class tx_dlf_oai extends tx_dlf_plugin {
      * @return DOMElement
      */
     private function generateResumptionTokenForDocumentListSet($documentListSet) {
-        $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
 
         if ($documentListSet->count() != 0) {
 
@@ -1114,10 +1113,16 @@ class tx_dlf_oai extends tx_dlf_plugin {
             );
 
             if ($GLOBALS['TYPO3_DB']->sql_affected_rows() == 1) {
-                $resumptionToken->setAttribute('resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
+
+                $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken', htmlspecialchars($token, ENT_NOQUOTES, 'UTF-8'));
+
             } else {
                 $this->devLog('[tx_dlf_oai->verb'.$this->piVars['verb'].'()] Could not create resumption token', SYSLOG_SEVERITY_ERROR);
+
             }
+        } else {
+            // Result set complete. We don't need a token.
+            $resumptionToken = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'resumptionToken');
         }
 
         $resumptionToken->setAttribute('cursor', intval($documentListSet->metadata['completeListSize']) - count($documentListSet));

--- a/plugins/oai/transform.xsl
+++ b/plugins/oai/transform.xsl
@@ -377,7 +377,7 @@ p.intro {
 	Resumption Token
 -->
 <xsl:template match="oai:resumptionToken">
-	<xsl:if test="@resumptionToken">
+	<xsl:if test=". != ''">
 		<p>There are more results.</p>
 	</xsl:if>
 	<table class="values">
@@ -389,10 +389,8 @@ p.intro {
 		<td class="value"><xsl:value-of select="@expirationDate"/></td></tr>
 		<tr><td class="key">Resumption Token</td>
 		<td class="value">
-			<xsl:if test="@resumptionToken">
-				<xsl:value-of select="@resumptionToken"/>
-				<xsl:text> </xsl:text>
-				<a class="link" href="?verb={/oai:OAI-PMH/oai:request/@verb}&amp;resumptionToken={@resumptionToken}">Resume</a>
+			<xsl:if test=". != ''">
+				<a class="link" href="?verb={/oai:OAI-PMH/oai:request/@verb}&amp;resumptionToken={.}">Resume</a>
 			</xsl:if>
 		</td></tr>
 	</table>


### PR DESCRIPTION
In https://github.com/kitodo/kitodo-presentation/pull/261 I changed the output of the resumption token. But I made a mistake and set it as an attribute. It should have been the value of the element.

Harvesters are now seeing an empty token although the harvest is far from complete, because the attribute is not part of the standard. Thanks to Friedrich Summann from BASE for pointing this out.

The token is now the value of the node and in the XSLT I don’t check for the attribute but for the existence of a value.