### PR TITLE
Fix #313 - unify used extents

### DIFF
--- a/plugins/pageview/tx_dlf_altoparser.js
+++ b/plugins/pageview/tx_dlf_altoparser.js
@@ -233,13 +233,12 @@ dlfAltoParser.prototype.parseGeometry_ = function(node) {
 
     // rescale coordinates
     var scale = this.image_.width / this.width_,
-        displayedImageHeight = this.image_.height,
         offset = dlfUtils.exists(this.offset_) ? this.offset_ : 0,
         coordinatesRescale = [];
 
     for (var i = 0; i < coordinatesWithoutScale[0].length; i++) {
         coordinatesRescale.push([offset + ( scale * coordinatesWithoutScale[0][i][0]),
-            displayedImageHeight - (scale * coordinatesWithoutScale[0][i][1])]);
+            0 - (scale * coordinatesWithoutScale[0][i][1])]);
     };
 
     return new ol.geom.Polygon([coordinatesRescale]);

--- a/plugins/pageview/tx_dlf_ol3_source.js
+++ b/plugins/pageview/tx_dlf_ol3_source.js
@@ -132,7 +132,7 @@ dlfViewerSource.IIIF = function(options) {
     }
 
     // define tilegrid with offset extent
-    var extent = [offset[0], offset[1] + -height, offset[0] + width, offset[1]];
+    var extent = [offset[0], offset[1] - height, offset[0] + width, offset[1]];
     var tileGrid = new ol.tilegrid.TileGrid({
             extent: extent,
             resolutions: resolutions.reverse(),
@@ -253,7 +253,7 @@ dlfViewerSource.IIP = function(options) {
     tierSizeInTiles.push( [1,1]);
     tierSizeInTiles.reverse();
 
-    var extent = [offset[0], offset[1] + -height, offset[0] + width, offset[1]];
+    var extent = [offset[0], offset[1] - height, offset[0] + width, offset[1]];
     var tileGrid = new ol.tilegrid.TileGrid({
         extent: extent,
         resolutions: resolutions.reverse(),

--- a/plugins/pageview/tx_dlf_utils.js
+++ b/plugins/pageview/tx_dlf_utils.js
@@ -688,7 +688,6 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, opt_off
     if (image === undefined) return [];
 
     var scale = image.scale,
-        displayImageHeight = imageObj.height,
         offset = opt_offset !== undefined ? opt_offset : 0;
 
     // do rescaling and set a id

--- a/plugins/pageview/tx_dlf_utils.js
+++ b/plugins/pageview/tx_dlf_utils.js
@@ -53,7 +53,7 @@ dlfUtils.createOl3Layers = function (imageSourceObjs, opt_origin) {
         //
         // Create layer
         //
-        var extent = [offsetWidth, 0, imageSourceObj.width + offsetWidth, imageSourceObj.height],
+        var extent = [offsetWidth, -imageSourceObj.height, imageSourceObj.width + offsetWidth, 0],
             layer = void 0;
 
         if (imageSourceObj.mimetype === dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY) {
@@ -151,11 +151,7 @@ dlfUtils.createOl3View = function (images) {
         maxLatY = images.reduce(function (prev, curr) {
         return Math.max(prev, curr.height);
     }, 0),
-        extent = images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.ZOOMIFY &&
-        images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIIF &&
-        images[0].mimetype !== dlfUtils.CUSTOM_MIMETYPE.IIP
-            ? [0, 0, maxLonX, maxLatY]
-            : [0, -maxLatY, maxLonX, 0];
+        extent = [0, -maxLatY, maxLonX, 0];
 
     // globally define max zoom
     window.OL3_MAX_ZOOM = 8;
@@ -703,7 +699,7 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, opt_off
 
         for (var j = 0; j < oldCoordinates.length; j++) {
             newCoordinates.push(
-              [offset + scale * oldCoordinates[j][0], displayImageHeight - scale * oldCoordinates[j][1]]);
+              [offset + scale * oldCoordinates[j][0], 0 - scale * oldCoordinates[j][1]]);
         }
 
         features[i].setGeometry(new ol.geom.Polygon([newCoordinates]));


### PR DESCRIPTION
- use extent `[0, -height, width, 0]` not only for Zoomify, IIIF and IIP but also for static images
- adjust coordinate calculation for fulltext highlight features to the new extent
