### PR TITLE
Adjust the check if the zoomed / moved image is in the viewport

### DIFF
--- a/plugins/pageview/tx_dlf_pageview.js
+++ b/plugins/pageview/tx_dlf_pageview.js
@@ -389,7 +389,7 @@ dlfViewer.prototype.init = function(controlNames) {
             if (!dlfUtils.isNullEmptyUndefinedOrNoNumber(lon) && !dlfUtils.isNullEmptyUndefinedOrNoNumber(lat) && !dlfUtils.isNullEmptyUndefinedOrNoNumber(zoom)) {
                 // make sure, zoom center is on viewport
                 var center = this.map.getView().getCenter();
-                if ((lon < (2.2 * center[0])) && (lat < (2.2 * center[1]))) {
+                if ((lon < (2.2 * center[0])) && (lat < (-0.2 * center[1])) && (lat > (2.2 * center[1]))) {
                     this.map.zoomTo([lon, lat], zoom);
                 }
             }


### PR DESCRIPTION
This fixes a problem that I introduced for static images with the changes in #313 and that had been present for all tiled images even before. In both cases, the lat/lon/zoom values from the cookies where always ignored, except in some cases where they should have been ignored.

The current check `lat < (2.2 * center[1])` does only work for `[0, 0, width, height]` extends. It basically checks if the latitude / y value is no more than 10% outside of the map extent. A check for the lower end (lat below zero) was not necessary.

For `[0, -height, width, 0]` extends, the check does not work. Instead, we need to check if the `lat` value (a negative number) is greater than 110% of the negative height, and less than 10% of the positive height. I guess the latter will only happen with obsolete cookie values for `lat` that originate from a static image before the changes in #313.

Please review the change carefully; I might have my math wrong. ;)