### PR TITLE
Allow for IIIF 2 image profile to be a string instead of a list

### DIFF
--- a/plugins/pageview/tx_dlf_utils.js
+++ b/plugins/pageview/tx_dlf_utils.js
@@ -412,6 +412,12 @@ dlfUtils.iiifProfiles = {
  */
 dlfUtils.buildImageV2 = function buildImageV2(mimetype, uri, jsonld) {
 
+    if (typeof jsonld.profile == "string") {
+        jsonld.profile = [jsonld.profile, {}];
+    }
+    if (jsonld.profile !== undefined && jsonld.profile.length < 2) {
+        jsonld.profile.push({});
+    }
     var levelProfile = jsonld.profile === undefined || dlfUtils.iiifProfiles[jsonld.profile[0]] === undefined ? dlfUtils.iiifProfiles['none'] : dlfUtils.iiifProfiles[jsonld.profile[0]];
     return {
         src: uri,


### PR DESCRIPTION
While the [IIIF Image API 2 spec](https://iiif.io/api/image/2.1/#technical-properties) requires `profile` to be a list with a compliance level URI as first entry, some image servers just set `profile` to a string with the URI as value.