### PR TITLE
Fix configuration for eID callables

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -68,8 +68,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys'][$_EXTKEY] = [
     '_cli_'
 ];
 // Register AJAX eID handlers.
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_suggest'] = \Kitodo\Dlf\Plugin\Eid\SearchSuggest::class.'->main';
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_pageview_proxy'] = \Kitodo\Dlf\Plugin\Eid\PageViewProxy::class.'->main';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_suggest'] = \Kitodo\Dlf\Plugin\Eid\SearchSuggest::class.'::main';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_pageview_proxy'] = \Kitodo\Dlf\Plugin\Eid\PageViewProxy::class.'::main';
 // Register Typoscript user function.
 if (TYPO3_MODE === 'FE') {
     /**


### PR DESCRIPTION
The eID-Proxy is currently failing with a "Registered eID has invalid script path." `EidRequestHandler::dispatch` uses `is_callable` which does not work with `->`.