### PR TITLE
Fix Toolbox Plugin tool TS

### DIFF
--- a/Classes/Hooks/ExtensionManagementUtility.php
+++ b/Classes/Hooks/ExtensionManagementUtility.php
@@ -11,8 +11,6 @@ namespace Kitodo\Dlf\Hooks;
  * LICENSE.txt file that was distributed with this source code.
  */
 
-use Kitodo\Dlf\Common\Helper;
-
 /**
  * Hooks and helper for \TYPO3\CMS\Core\Utility\ExtensionManagementUtility
  *
@@ -37,7 +35,7 @@ class ExtensionManagementUtility extends \TYPO3\CMS\Core\Utility\ExtensionManage
      * @return void
      */
     public static function addPItoST43($key, $class, $suffix = '', $type = 'list_type', $cached = FALSE) {
-        $internalName = 'tx_'.$key.'_'.strtolower(Helper::getUnqualifiedClassName($class));
+        $internalName = 'tx_'.$key.$suffix;
         // General plugin
         $typoscript = 'plugin.'.$internalName.' = USER'.($cached ? '' : '_INT')."\n";
         $typoscript .= 'plugin.'.$internalName.'.userFunc = '.$class.'->main'."\n";


### PR DESCRIPTION
The Toolbox plugin is currently not working. While all the tools can be selected in the plugin configuration UI in the Page configuration of the Typo3 backend, the Typoscript does not match.

For example, the fulltext tool is added to the Toolbox select array with 'tx_dlf_toolsFulltext':
https://github.com/kitodo/kitodo-presentation/blob/400a97a4b7b9c534da1a3dbb77b0fbaf46296740/ext_localconf.php#L51

But `Kitodo\Dlf\Hooks\ExtensionManagementUtility::addPItoST43` uses `tx_dlf_fulltexttool` for the added TypoScript.
https://github.com/kitodo/kitodo-presentation/blob/400a97a4b7b9c534da1a3dbb77b0fbaf46296740/Classes/Hooks/ExtensionManagementUtility.php#L40

`Kitodo\Dlf\Plugin\Toolbox::main` looks for the configured tools, i.e. `tx_dlf_toolsFulltext` but there's not matching TypoScript.
https://github.com/kitodo/kitodo-presentation/blob/400a97a4b7b9c534da1a3dbb77b0fbaf46296740/Classes/Plugin/Toolbox.php#L50-L57

Instead of the suggested solution, the `tools` array in `ext_localconf.php` could also be adjusted to `$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_fulltexttool']` etc. but this would break existing installations on update.