### PR TITLE
Fix Image Manipulation Tool - select Toolbox element correctly

### DIFF
--- a/Resources/Public/Javascript/PageView/ImageManipulationControl.js
+++ b/Resources/Public/Javascript/PageView/ImageManipulationControl.js
@@ -71,7 +71,7 @@ dlfViewerImageManipulationControl = function(options) {
      * @type {Element}
      * @private
      */
-    this.toolContainerEl_ = dlfUtils.exists(options.toolContainer) ? options.toolContainer: $('.tx-dlf-toolbox')[0];
+    this.toolContainerEl_ = dlfUtils.exists(options.toolContainer) ? options.toolContainer: $('.tx-dlf-Toolbox')[0];
 
     //
     // Append open/close behavior to toolbox


### PR DESCRIPTION
The generation of the CSS class of the plugin HTML elements has changed. This does not only require an update of  any CSS resources using these classes, it also breaks the image manipulation tool.

Using lowercase CSS class generation in `Kitodo\Dlf\Common\AbstractPlugin` as an alternative would still require some CSS adjustments as `toc` has been renamed to `TableOfContents`, as well as `newspaper` to `Calendar`.
https://github.com/kitodo/kitodo-presentation/blob/ef3decf8ecd1c044b79e210734411d7f54ecee4d/Classes/Common/AbstractPlugin.php#L185