### PR TITLE
add filter configuration for collections

### DIFF
--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -567,7 +567,7 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin {
         );
 
         if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-            while($collection = $GLOBALS['TYPO3_DB']->sql_fetch_row($result)) {
+            while ($collection = $GLOBALS['TYPO3_DB']->sql_fetch_row($result)) {
                 $facetCollectionArray[] = $collection[0];
             }
         }

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -555,7 +555,7 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin {
         $facetCollectionArray = array();
 
         // replace everything expect numbers and comma
-        $facetCollections = preg_replace('/[^0-9|,]/', '', $this->conf['facetCollections']);
+        $facetCollections = preg_replace('/[^0-9,]/', '', $this->conf['facetCollections']);
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'tx_dlf_collections.index_name AS index_name',
             'tx_dlf_collections',

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -553,20 +553,21 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin {
         $facet = $results->getFacetSet();
 
         $facetCollectionArray = array();
-        foreach (\TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->conf['facetCollections'], TRUE) as $facetCollection) {
 
-            $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                'tx_dlf_collections.index_name AS index_name',
-                'tx_dlf_collections',
-                'tx_dlf_collections.uid='.intval($facetCollection)
-                .Helper::whereClause('tx_dlf_collections'),
-                '',
-                '',
-                ''
-            );
+        // replace everything expect numbers and comma
+        $facetCollections = preg_replace('/[^0-9|,]/', '', $this->conf['facetCollections']);
+        $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
+            'tx_dlf_collections.index_name AS index_name',
+            'tx_dlf_collections',
+            'tx_dlf_collections.uid IN (' . $facetCollections . ')'
+            .Helper::whereClause('tx_dlf_collections'),
+            '',
+            '',
+            ''
+        );
 
-            if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
-                $collection = $GLOBALS['TYPO3_DB']->sql_fetch_row($result);
+        if ($GLOBALS['TYPO3_DB']->sql_num_rows($result)) {
+            while($collection = $GLOBALS['TYPO3_DB']->sql_fetch_row($result)) {
                 $facetCollectionArray[] = $collection[0];
             }
         }

--- a/Configuration/Flexforms/Search.xml
+++ b/Configuration/Flexforms/Search.xml
@@ -176,7 +176,7 @@
                         <TCEforms>
                             <displayCond>FIELD:pages:REQ:true</displayCond>
                             <exclude>1</exclude>
-                            <label>Folgende Kollektionen als Facetten anzeigen</label>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/Search.xml:tt_content.pi_flexform.facetCollections</label>
                             <config>
                                 <type>select</type>
                                 <items type="array"/>

--- a/Configuration/Flexforms/Search.xml
+++ b/Configuration/Flexforms/Search.xml
@@ -172,6 +172,22 @@
                             </config>
                         </TCEforms>
                     </facets>
+                    <facetCollections>
+                        <TCEforms>
+                            <displayCond>FIELD:pages:REQ:true</displayCond>
+                            <exclude>1</exclude>
+                            <label>Folgende Kollektionen als Facetten anzeigen</label>
+                            <config>
+                                <type>select</type>
+                                <items type="array"/>
+                                <itemsProcFunc>Kitodo\Dlf\Hooks\FormEngine->itemsProcFunc_collectionList</itemsProcFunc>
+                                <size>5</size>
+                                <autoSizeMax>15</autoSizeMax>
+                                <maxitems>1024</maxitems>
+                                <minitems>0</minitems>
+                            </config>
+                        </TCEforms>
+                    </facetCollections>
                     <limitFacets>
                         <TCEforms>
                             <displayCond>FIELD:pages:REQ:true</displayCond>

--- a/Resources/Private/Language/Search.xml
+++ b/Resources/Private/Language/Search.xml
@@ -16,6 +16,7 @@
     <data type="array">
         <languageKey index="default" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Options</label>
+            <label index="tt_content.pi_flexform.facetCollections">Use only this collections as facet</label>
             <label index="tt_content.pi_flexform.fulltext">Enable fulltext search?</label>
             <label index="tt_content.pi_flexform.fulltext.yes">yes</label>
             <label index="tt_content.pi_flexform.fulltext.no">no</label>
@@ -56,6 +57,7 @@
         </languageKey>
         <languageKey index="de" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
+            <label index="tt_content.pi_flexform.facetCollections">Folgende Kollektionen als Facetten anzeigen</label>
             <label index="tt_content.pi_flexform.fulltext">Volltext-Suche aktivieren?</label>
             <label index="tt_content.pi_flexform.fulltext.yes">ja</label>
             <label index="tt_content.pi_flexform.fulltext.no">nein</label>


### PR DESCRIPTION
This PR adds the possibility to configure the collections shown as facet.
If no configuration is selected all collections are displayed like before.