### PR TITLE
Add <div class="tx-dlf-pagegrid"> as wrapper

### DIFF
--- a/Resources/Private/Templates/PageGrid.tmpl
+++ b/Resources/Private/Templates/PageGrid.tmpl
@@ -8,13 +8,15 @@
  * LICENSE.txt file that was distributed with this source code.
 -->
 <!-- ###TEMPLATE### -->
-<div class="tx-dlf-pagegrid-pagebrowser">###PAGEBROWSER###</div>
-<ol class="tx-dlf-pagegrid-list">
-    <!-- ###ENTRY### -->
-    <li class="tx-dlf-pagegrid-###STATE###" value="###NUMBER###">
-        <div class="tx-dlf-pagegrid-thumbnail">###THUMBNAIL###</div>
-        <div class="tx-dlf-pagegrid-pagination">###PAGINATION###</div>
-    </li>
-    <!-- ###ENTRY### -->
-</ol>
+<div class="tx-dlf-pagegrid">
+    <div class="tx-dlf-pagegrid-pagebrowser">###PAGEBROWSER###</div>
+    <ol class="tx-dlf-pagegrid-list">
+        <!-- ###ENTRY### -->
+        <li class="tx-dlf-pagegrid-###STATE###" value="###NUMBER###">
+            <div class="tx-dlf-pagegrid-thumbnail">###THUMBNAIL###</div>
+            <div class="tx-dlf-pagegrid-pagination">###PAGINATION###</div>
+        </li>
+        <!-- ###ENTRY### -->
+    </ol>
+</div>
 <!-- ###TEMPLATE### -->


### PR DESCRIPTION
As far as I've seen kitodo-demo and the SLUB and the UB Mannheim (perhaps more) use this additional div, so I would like to add it in the default template.