### PR TITLE
handle ephemera in document type switch similar to newspaper

### DIFF
--- a/hooks/class.tx_dlf_doctype.php
+++ b/hooks/class.tx_dlf_doctype.php
@@ -78,12 +78,12 @@ class tx_dlf_doctype {
          * Get the document type
          *
          * 1. newspaper
-         *    case 1) - type=newspaper
+         *    case 1) - type=newspaper|ephemera
          *            - children array([0], [1], [2], ...) -> type = year --> Newspaper Anchor File
-         *    case 2) - type=newspaper
+         *    case 2) - type=newspaper|ephemera
          *            - children array([0]) --> type = year
          *            - children array([0], [1], [2], ...) --> type = month --> Year Anchor File
-         *    case 3) - type=newspaper
+         *    case 3) - type=newspaper|ephemera
          *            - children array([0]) --> type = year
          *            - children array([0]) --> type = month
          *            - children array([0], [1], [2], ...) --> type = day --> Issue
@@ -91,8 +91,9 @@ class tx_dlf_doctype {
         switch ($toc[0]['type']) {
 
             case 'newspaper':
+            case 'ephemera':
 
-                $nodes_year = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]');
+                $nodes_year = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]');
 
                 if (count($nodes_year) > 1) {
 
@@ -101,13 +102,13 @@ class tx_dlf_doctype {
 
                 } else {
 
-                    $nodes_month = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]');
+                    $nodes_month = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]');
 
-                    $nodes_day = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]/mets:div[@TYPE="day"]');
+                    $nodes_day = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]/mets:div[@TYPE="day"]');
 
-                    $nodes_issue = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]');
+                    $nodes_issue = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]');
 
-                    $nodes_issue_current = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]/@DMDID');
+                    $nodes_issue_current = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]/@DMDID');
 
                     if (count($nodes_year) == 1 && count($nodes_issue) == 0) {
 


### PR DESCRIPTION
Documents with type "ephemera" should be handled as of type "newspaper". The calendar module uses this check to deside, which plugin will be used for rendering the workview.

Pull request will be prepared for master too.