### PR TITLE
Fix usage of count for metadata array

### DIFF
--- a/plugins/metadata/class.tx_dlf_metadata.php
+++ b/plugins/metadata/class.tx_dlf_metadata.php
@@ -385,7 +385,7 @@ class tx_dlf_metadata extends tx_dlf_plugin {
 
                     }
 
-                } while (count($metadata[$index_name]));
+                } while (is_array($metadata[$index_name]) && count($metadata[$index_name]));
 
                 if (!empty($parsedValue)) {
 


### PR DESCRIPTION
Fix for exception thrown in PHP 7.2:

`
Exception: PHP Warning: count(): Parameter must be an array or an object that implements Countable in C:\\xampp\\htdocs\\typo3conf\\ext\\dlf\\plugins\\metadata\\class.tx_dlf_metadata.php line 388
`