### PR TITLE
fix broken SQL statement in updater script

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -281,7 +281,7 @@ class ext_update {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'index_name',
             'tx_dlf_solrcores',
-            Helper::whereClause('tx_dlf_solrcores')
+            '1=1'.Helper::whereClause('tx_dlf_solrcores')
         );
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             // Instantiate search object.
@@ -305,7 +305,7 @@ class ext_update {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'index_name',
             'tx_dlf_solrcores',
-            Helper::whereClause('tx_dlf_solrcores')
+            '1=1'.Helper::whereClause('tx_dlf_solrcores')
         );
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             // Instantiate search object.

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -281,7 +281,8 @@ class ext_update {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'index_name',
             'tx_dlf_solrcores',
-            '1=1'.Helper::whereClause('tx_dlf_solrcores')
+            '1=1'
+                .Helper::whereClause('tx_dlf_solrcores')
         );
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             // Instantiate search object.
@@ -305,7 +306,8 @@ class ext_update {
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
             'index_name',
             'tx_dlf_solrcores',
-            '1=1'.Helper::whereClause('tx_dlf_solrcores')
+            '1=1'
+                .Helper::whereClause('tx_dlf_solrcores')
         );
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             // Instantiate search object.


### PR DESCRIPTION
Opening the extension manager leads to a SQL error which is visible in
development mode:

>   You have an error in your SQL syntax; check the manual that corresponds
>   to your MySQL server version for the right syntax to use near
>   'AND `tx_dlf_solrcores`.`deleted` = 0' at line 1
> 

The query itself is

`  SELECT index_name FROM tx_dlf_solrcores WHERE AND `tx_dlf_solrcores`.`deleted` = 0'
`

The WHERE statement is wrong because it starts with AND from
Helper::whereClause().