### PR TITLE
Tca migration and fixes

### DIFF
--- a/Classes/Common/DocumentTypeCheck.php
+++ b/Classes/Common/DocumentTypeCheck.php
@@ -77,27 +77,28 @@ class DocumentTypeCheck {
          * Get the document type
          *
          * 1. newspaper
-         *    case 1) - type=newspaper
+         *    case 1) - type=newspaper|ephemera
          *            - children array ([0], [1], [2], ...) -> type = year --> Newspaper Anchor File
-         *    case 2) - type=newspaper
+         *    case 2) - type=newspaper|ephemera
          *            - children array ([0]) --> type = year
          *            - children array ([0], [1], [2], ...) --> type = month --> Year Anchor File
-         *    case 3) - type=newspaper
+         *    case 3) - type=newspaper|ephemera
          *            - children array ([0]) --> type = year
          *            - children array ([0]) --> type = month
          *            - children array ([0], [1], [2], ...) --> type = day --> Issue
          */
         switch ($toc[0]['type']) {
             case 'newspaper':
-                $nodes_year = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]');
+            case 'ephemera':
+                $nodes_year = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]');
                 if (count($nodes_year) > 1) {
                     // Multiple years means this is a newspaper's anchor file.
                     return 'newspaper';
                 } else {
-                    $nodes_month = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]');
-                    $nodes_day = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]/mets:div[@TYPE="day"]');
-                    $nodes_issue = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]');
-                    $nodes_issue_current = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]/@DMDID');
+                    $nodes_month = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]');
+                    $nodes_day = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]/mets:div[@TYPE="month"]/mets:div[@TYPE="day"]');
+                    $nodes_issue = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]');
+                    $nodes_issue_current = $this->doc->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="newspaper" or @TYPE="ephemera"]/mets:div[@TYPE="year"]//mets:div[@TYPE="issue"]/@DMDID');
                     if (count($nodes_year) == 1
                         && count($nodes_issue) == 0) {
                         // It's possible to have only one year in the newspaper's anchor file.

--- a/Configuration/Flexforms/AudioPlayer.xml
+++ b/Configuration/Flexforms/AudioPlayer.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Basket.xml
+++ b/Configuration/Flexforms/Basket.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Calendar.xml
+++ b/Configuration/Flexforms/Calendar.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Collection.xml
+++ b/Configuration/Flexforms/Collection.xml
@@ -24,7 +24,7 @@
                         <TCEforms>
                             <onChange>reload</onChange>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Feeds.xml
+++ b/Configuration/Flexforms/Feeds.xml
@@ -24,7 +24,7 @@
                         <TCEforms>
                             <onChange>reload</onChange>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/ListView.xml
+++ b/Configuration/Flexforms/ListView.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Metadata.xml
+++ b/Configuration/Flexforms/Metadata.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Navigation.xml
+++ b/Configuration/Flexforms/Navigation.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/OaiPmh.xml
+++ b/Configuration/Flexforms/OaiPmh.xml
@@ -24,7 +24,7 @@
                         <TCEforms>
                             <onChange>reload</onChange>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <onChange>reload</onChange>
                             <config>
                                 <type>group</type>

--- a/Configuration/Flexforms/PageGrid.xml
+++ b/Configuration/Flexforms/PageGrid.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/PageView.xml
+++ b/Configuration/Flexforms/PageView.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Search.xml
+++ b/Configuration/Flexforms/Search.xml
@@ -24,7 +24,7 @@
                         <TCEforms>
                             <onChange>reload</onChange>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <onChange>reload</onChange>
                             <config>
                                 <type>group</type>

--- a/Configuration/Flexforms/Statistics.xml
+++ b/Configuration/Flexforms/Statistics.xml
@@ -24,7 +24,7 @@
                         <TCEforms>
                             <onChange>reload</onChange>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/TableOfContents.xml
+++ b/Configuration/Flexforms/TableOfContents.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Toolbox.xml
+++ b/Configuration/Flexforms/Toolbox.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/Flexforms/Validator.xml
+++ b/Configuration/Flexforms/Validator.xml
@@ -23,7 +23,7 @@
                     <pages>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/TCA/tx_dlf_actionlog.php
+++ b/Configuration/TCA/tx_dlf_actionlog.php
@@ -89,7 +89,7 @@ return [
         ]
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_actionlog.tab1, label;;;;1-1-1, name;;;;2-2-2, file_name;;;;2-2-2, crdate;;;;2-2-2, count_pages;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_actionlog.tab1,label,name,file_name,crdate,count_pages'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_basket.php
+++ b/Configuration/TCA/tx_dlf_basket.php
@@ -77,7 +77,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_basket.tab1, label;;;;1-1-1, session_id;;;;2-2-2, doc_ids;;;;2-2-2, fe_user_id;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_basket.tab1,label,session_id,doc_ids,fe_user_id'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -160,8 +160,8 @@ return [
                 'rows' => 10,
                 'wrap' => 'virtual',
                 'default' => '',
+                'enableRichtext' => true,
             ],
-            'defaultExtras' => 'richtext[undo,redo,cut,copy,paste,link,image,line,acronym,chMode,blockstylelabel,formatblock,blockstyle,textstylelabel,textstyle,bold,italic,unorderedlist,orderedlist]:rte_transform[mode=ts_css]',
         ],
         'thumbnail' => [
             'exclude' => 1,

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -27,7 +27,6 @@ return [
             'disabled' => 'hidden',
             'fe_group' => 'fe_group',
         ],
-        'requestUpdate' => 'sys_language_uid',
         'iconfile' => 'EXT:dlf/Resources/Public/Icons/txdlfcollections.png',
         'rootLevel' => 0,
         'dividers2tabs' => 2,
@@ -53,6 +52,7 @@ return [
                     ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
                 ],
                 'default' => 0,
+                'onchange' => 'reload',
             ],
         ],
         'l18n_parent' => [

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -42,15 +42,15 @@ return [
     'columns' => [
         'sys_language_uid' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.language',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'sys_language',
                 'foreign_table_where' => 'ORDER BY sys_language.title',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.allLanguages', -1],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.default_value', 0],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages', -1],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
                 ],
                 'default' => 0,
             ],
@@ -58,7 +58,7 @@ return [
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.l18n_parent',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -77,7 +77,7 @@ return [
         ],
         'hidden' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.hidden',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
                 'default' => 0,
@@ -85,15 +85,15 @@ return [
         ],
         'fe_group' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.fe_group',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectMultipleSideBySide',
                 'foreign_table' => 'fe_groups',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.hide_at_login', '-1'],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.any_login', '-2'],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.usergroups', '--div--'],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hide_at_login', '-1'],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.any_login', '-2'],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.usergroups', '--div--'],
                 ],
                 'size' => 5,
                 'autoSizeMax' => 15,

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -152,9 +152,12 @@ return [
         ],
         'description' => [
             'exclude' => 1,
-            'l10n_mode' => 'mergeIfNotBlank',
+            'l10n_mode' => 'mergeIfNotBlank', // deprecated in 8.7 but kept for upgrade wizard
             'label' => 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.description',
             'config' => [
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true
+                ],
                 'type' => 'text',
                 'cols' => 30,
                 'rows' => 10,

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -282,7 +282,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.tab1, label,--palette--;;1;;1-1-1, description,--palette--;;2;;2-2-2, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.tab2, sys_language_uid;;;;1-1-1, l18n_parent, l18n_diffsource, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.tab3, hidden;;;;1-1-1, fe_group;;;;2-2-2, status;;;;3-3-3, owner;;;;4-4-4, fe_cruser_id,--palette--;;3'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.tab1,label,--palette--;;1,description,--palette--;;2,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.tab2,sys_language_uid,l18n_parent,l18n_diffsource,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.tab3,hidden,fe_group,status,owner,fe_cruser_id,--palette--;;3'],
     ],
     'palettes' => [
         '1' => ['showitem' => 'index_name, --linebreak--, index_search, --linebreak--, oai_name', 'canNotCollapse' => 1],

--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -262,7 +262,6 @@ return [
                 'allowed' => 'tx_dlf_documents',
                 'prepend_tname' => 0,
                 'size' => 1,
-                'selectedListStyle' => 'width:400px;',
                 'minitems' => 0,
                 'maxitems' => 1,
                 'disable_controls' => 'browser,delete',

--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -363,7 +363,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab1, title,--palette--;;1;;1-1-1, author, year, place, structure, document_format,--palette--;;2;;2-2-2, collections;;;;3-3-3, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab2, location;;;;1-1-1, record_id, prod_id;;;;2-2-2, oai_id;;;;3-3-3, opac_id, union_id, urn, purl;;;;4-4-4, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab3, hidden,--palette--;;3;;1-1-1, fe_group;;;;2-2-2, status;;;;3-3-3, owner;;;;4-4-4'],
+        '0' => ['--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab1,title,--palette--;;1,author,year,place,structure,document_format,--palette--;;2,collections,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab2,location,record_id,prod_id,oai_id,opac_id,union_id,urn,purl,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab3,hidden,--palette--;;3,fe_group,status,owner'],
     ],
     'palettes' => [
         '1' => ['showitem' => 'title_sorting', 'canNotCollapse' => 1],

--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -51,8 +51,8 @@ return [
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputDateTime',
                 'size' => 13,
-                'max' => 20,
                 'eval' => 'datetime',
                 'default' => 0,
             ],
@@ -62,8 +62,8 @@ return [
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputDateTime',
                 'size' => 13,
-                'max' => 20,
                 'eval' => 'datetime',
                 'default' => 0,
             ],

--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -367,7 +367,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab1,title,--palette--;;1,author,year,place,structure,document_format,--palette--;;2,collections,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab2,location,record_id,prod_id,oai_id,opac_id,union_id,urn,purl,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab3,hidden,--palette--;;3,fe_group,status,owner'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab1,title,--palette--;;1,author,year,place,structure,document_format,--palette--;;2,collections,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab2,location,record_id,prod_id,oai_id,opac_id,union_id,urn,purl,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_documents.tab3,hidden,--palette--;;3,fe_group,status,owner'],
     ],
     'palettes' => [
         '1' => ['showitem' => 'title_sorting', 'canNotCollapse' => 1],

--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -40,7 +40,7 @@ return [
     'columns' => [
         'hidden' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.hidden',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
                 'default' => 0,
@@ -48,7 +48,7 @@ return [
         ],
         'starttime' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.starttime',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
                 'type' => 'input',
                 'size' => 13,
@@ -59,7 +59,7 @@ return [
         ],
         'endtime' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.endtime',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
                 'type' => 'input',
                 'size' => 13,
@@ -70,14 +70,14 @@ return [
         ],
         'fe_group' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.fe_group',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.fe_group',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectMultipleSideBySide',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.hide_at_login', '-1'],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.any_login', '-2'],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.usergroups', '--div--'],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hide_at_login', '-1'],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.any_login', '-2'],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.usergroups', '--div--'],
                 ],
                 'foreign_table' => 'fe_groups',
                 'size' => 5,

--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -264,9 +264,14 @@ return [
                 'size' => 1,
                 'minitems' => 0,
                 'maxitems' => 1,
-                'disable_controls' => 'browser,delete',
                 'default' => 0,
                 'readOnly' => 1,
+                'fieldControl' => [
+                    'elementBrowser' => [
+                        'disabled' => true
+                    ]
+                ],
+                'hideDeleteIcon' => true
             ],
         ],
         'volume' => [

--- a/Configuration/TCA/tx_dlf_formats.php
+++ b/Configuration/TCA/tx_dlf_formats.php
@@ -72,7 +72,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_formats.tab1, type;;;;1-1-1, root;;;;2-2-2, namespace, class;;;;3-3-3'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_formats.tab1,type,root,namespace,class'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_libraries.php
+++ b/Configuration/TCA/tx_dlf_libraries.php
@@ -35,15 +35,15 @@ return [
     'columns' => [
         'sys_language_uid' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.language',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'sys_language',
                 'foreign_table_where' => 'ORDER BY sys_language.title',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.allLanguages', -1],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.default_value', 0],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages', -1],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
                 ],
                 'default' => 0
             ],
@@ -51,7 +51,7 @@ return [
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.l18n_parent',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/Configuration/TCA/tx_dlf_libraries.php
+++ b/Configuration/TCA/tx_dlf_libraries.php
@@ -195,7 +195,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_libraries.tab1, label,--palette--;;1;;1-1-1, website;;;;2-2-2, contact, image;;;;3-3-3, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_libraries.tab2, sys_language_uid;;;;1-1-1, l18n_parent, l18n_diffsource, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_libraries.tab3, oai_label,--palette--;;2;;1-1-1, opac_label,--palette--;;3;;2-2-2, union_label,--palette--;;4;;3-3-3'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_libraries.tab1,label,--palette--;;1,website,contact,image,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_libraries.tab2,sys_language_uid,l18n_parent,l18n_diffsource,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_libraries.tab3,oai_label,--palette--;;2,opac_label,--palette--;;3,union_label,--palette--;;4'],
     ],
     'palettes' => [
         '1' => ['showitem' => 'index_name', 'canNotCollapse' => 1],

--- a/Configuration/TCA/tx_dlf_libraries.php
+++ b/Configuration/TCA/tx_dlf_libraries.php
@@ -121,7 +121,6 @@ return [
                 'allowed' => $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'],
                 'max_size' => 256,
                 'uploadfolder' => 'uploads/tx_dlf',
-                'show_thumbs' => 1,
                 'size' => 1,
                 'minitems' => 0,
                 'maxitems' => 1,

--- a/Configuration/TCA/tx_dlf_mail.php
+++ b/Configuration/TCA/tx_dlf_mail.php
@@ -58,7 +58,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_mail.tab1, label;;;;1-1-1, name;;;;2-2-2, mail;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_mail.tab1,label,name,mail'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -139,9 +139,12 @@ return [
         ],
         'wrap' => [
             'exclude' => 1,
-            'l10n_mode' => 'mergeIfNotBlank',
+            'l10n_mode' => 'mergeIfNotBlank', // deprecated in 8.7 but kept for upgrade wizard
             'label' => 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.wrap',
             'config' => [
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true
+                ],
                 'type' => 'text',
                 'cols' => 48,
                 'rows' => 20,

--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -244,7 +244,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.tab1, label,--palette--;;1;;1-1-1, format;;;;2-2-2, default_value;;;;3-3-3, wrap, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.tab2, sys_language_uid;;;;1-1-1, l18n_parent, l18n_diffsource, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.tab3, hidden;;;;1-1-1, status;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.tab1,label,--palette--;;1,format,default_value,wrap,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.tab2,sys_language_uid,l18n_parent,l18n_diffsource,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadata.tab3,hidden,status'],
     ],
     'palettes' => [
         '1' => ['showitem' => 'index_name, --linebreak--, index_tokenized, index_stored, index_indexed, index_boost, --linebreak--, is_sortable, is_facet, is_listed, index_autocomplete', 'canNotCollapse' => 1],

--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -151,8 +151,9 @@ return [
                 'wrap' => 'off',
                 'eval' => 'trim',
                 'default' => "key.wrap = <dt>|</dt>\nvalue.required = 1\nvalue.wrap = <dd>|</dd>",
+                'fixedFont' => true,
+                'enableTabulator' => true
             ],
-            'defaultExtras' => 'nowrap:fixed-font:enable-tab',
         ],
         'index_tokenized' => [
             'exclude' => 1,

--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -38,15 +38,15 @@ return [
     'columns' => [
         'sys_language_uid' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.language',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'sys_language',
                 'foreign_table_where' => 'ORDER BY sys_language.title',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.allLanguages', -1],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.default_value', 0],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages', -1],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
                 ],
                 'default' => 0,
             ],
@@ -54,7 +54,7 @@ return [
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.l18n_parent',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -73,7 +73,7 @@ return [
         ],
         'hidden' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.hidden',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
                 'default' => 0,

--- a/Configuration/TCA/tx_dlf_metadataformat.php
+++ b/Configuration/TCA/tx_dlf_metadataformat.php
@@ -83,7 +83,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadataformat.tab1, encoded;;;;1-1-1, xpath;;;;2-2-2, xpath_sorting, mandatory;;;;3-3-3'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_metadataformat.tab1,encoded,xpath,xpath_sorting,mandatory'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_printer.php
+++ b/Configuration/TCA/tx_dlf_printer.php
@@ -49,7 +49,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_printer.tab1, label;;;;1-1-1, print;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_printer.tab1,label,print'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -52,7 +52,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_solrcores.tab1, label;;;;1-1-1, index_name;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_solrcores.tab1,label,index_name'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],

--- a/Configuration/TCA/tx_dlf_structures.php
+++ b/Configuration/TCA/tx_dlf_structures.php
@@ -28,7 +28,6 @@ return [
         'rootLevel' => 0,
         'dividers2tabs' => 2,
         'searchFields' => 'label,index_name,oai_name',
-        'requestUpdate' => 'toplevel',
     ],
     'feInterface' => [
         'fe_admin_fieldList' => '',
@@ -87,6 +86,7 @@ return [
             'config' => [
                 'type' => 'check',
                 'default' => 0,
+                'onchange' => 'reload',
             ],
         ],
         'label' => [

--- a/Configuration/TCA/tx_dlf_structures.php
+++ b/Configuration/TCA/tx_dlf_structures.php
@@ -160,7 +160,7 @@ return [
         ],
     ],
     'types' => [
-        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_structures.tab1, toplevel;;;;1-1-1, label,--palette--;;1, thumbnail, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_structures.tab2, sys_language_uid;;;;1-1-1, l18n_parent, l18n_diffsource, --div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_structures.tab3, hidden;;;;1-1-1, status;;;;2-2-2'],
+        '0' => ['showitem' => '--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_structures.tab1,toplevel,label,--palette--;;1,thumbnail,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_structures.tab2,sys_language_uid,l18n_parent,l18n_diffsource,--div--;LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_structures.tab3,hidden,status'],
     ],
     'palettes' => [
         '1' => ['showitem' => 'index_name, --linebreak--, oai_name', 'canNotCollapse' => 1],

--- a/Configuration/TCA/tx_dlf_structures.php
+++ b/Configuration/TCA/tx_dlf_structures.php
@@ -39,15 +39,15 @@ return [
     'columns' => [
         'sys_language_uid' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.language',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'sys_language',
                 'foreign_table_where' => 'ORDER BY sys_language.title',
                 'items' => [
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.allLanguages', -1],
-                    ['LLL:EXT:lang/locallang_general.xml:LGL.default_value', 0],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages', -1],
+                    ['LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.default_value', 0],
                 ],
                 'default' => 0
             ],
@@ -55,7 +55,7 @@ return [
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.l18n_parent',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -74,7 +74,7 @@ return [
         ],
         'hidden' => [
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.hidden',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
                 'default' => 0,


### PR DESCRIPTION
Most hints of the TCA migration wizard are solved in the following commit.

The path to the locallang_general.xlf file has changed in TYPO3 8.7. This has been fixed in all TCA configurations, too.