### PR TITLE
Fix 363: Check for empty toolbox configuration.

### DIFF
--- a/Classes/Plugin/Tools/AnnotationTool.php
+++ b/Classes/Plugin/Tools/AnnotationTool.php
@@ -45,7 +45,7 @@ class AnnotationTool extends AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        if (!empty($this->cObj->data)) {
+        if (!empty($this->cObj->data['conf'])) {
             $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
         }
         // Load current document.

--- a/Classes/Plugin/Tools/AnnotationTool.php
+++ b/Classes/Plugin/Tools/AnnotationTool.php
@@ -45,7 +45,9 @@ class AnnotationTool extends AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data)) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
         // Load current document.
         $this->loadDocument();
         if ($this->doc === NULL || $this->doc->numPages < 1) {

--- a/Classes/Plugin/Tools/FulltextTool.php
+++ b/Classes/Plugin/Tools/FulltextTool.php
@@ -38,7 +38,9 @@ class FulltextTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data)) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
         // Load current document.
         $this->loadDocument();
         if ($this->doc === NULL

--- a/Classes/Plugin/Tools/FulltextTool.php
+++ b/Classes/Plugin/Tools/FulltextTool.php
@@ -38,7 +38,7 @@ class FulltextTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        if (!empty($this->cObj->data)) {
+        if (!empty($this->cObj->data['conf'])) {
             $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
         }
         // Load current document.

--- a/Classes/Plugin/Tools/ImageDownloadTool.php
+++ b/Classes/Plugin/Tools/ImageDownloadTool.php
@@ -37,7 +37,9 @@ class ImageDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data)) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
         // Load current document.
         $this->loadDocument();
         if ($this->doc === NULL

--- a/Classes/Plugin/Tools/ImageDownloadTool.php
+++ b/Classes/Plugin/Tools/ImageDownloadTool.php
@@ -37,7 +37,7 @@ class ImageDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        if (!empty($this->cObj->data)) {
+        if (!empty($this->cObj->data['conf'])) {
             $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
         }
         // Load current document.

--- a/Classes/Plugin/Tools/ImageManipulationTool.php
+++ b/Classes/Plugin/Tools/ImageManipulationTool.php
@@ -37,7 +37,7 @@ class ImageManipulationTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        if (!empty($this->cObj->data)) {
+        if (!empty($this->cObj->data['conf'])) {
             $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
         }
         // Load template file.

--- a/Classes/Plugin/Tools/ImageManipulationTool.php
+++ b/Classes/Plugin/Tools/ImageManipulationTool.php
@@ -37,7 +37,9 @@ class ImageManipulationTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data)) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
         // Load template file.
         $this->getTemplate();
         $markerArray['###IMAGEMANIPULATION_SELECT###'] = '<span class="tx-dlf-tools-imagetools" id="tx-dlf-tools-imagetools" data-dic="imagemanipulation-on:'.$this->pi_getLL('imagemanipulation-on', '', TRUE).';imagemanipulation-off:'.$this->pi_getLL('imagemanipulation-off', '', TRUE).';reset:'.$this->pi_getLL('reset', '', TRUE).';saturation:'.$this->pi_getLL('saturation', '', TRUE).';hue:'.$this->pi_getLL('hue', '', TRUE).';contrast:'.$this->pi_getLL('contrast', '', TRUE).';brightness:'.$this->pi_getLL('brightness', '', TRUE).';invert:'.$this->pi_getLL('invert', '', TRUE).'" title="'.$this->pi_getLL('no-support', '', TRUE).'"></span>';

--- a/Classes/Plugin/Tools/PdfDownloadTool.php
+++ b/Classes/Plugin/Tools/PdfDownloadTool.php
@@ -38,7 +38,7 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        if (!empty($this->cObj->data)) {
+        if (!empty($this->cObj->data['conf'])) {
             $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
         }
         // Load current document.

--- a/Classes/Plugin/Tools/PdfDownloadTool.php
+++ b/Classes/Plugin/Tools/PdfDownloadTool.php
@@ -38,7 +38,9 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
     public function main($content, $conf) {
         $this->init($conf);
         // Merge configuration with conf array of toolbox.
-        $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data)) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
         // Load current document.
         $this->loadDocument();
         if ($this->doc === NULL


### PR DESCRIPTION
This patch makes it possible to use a single tool without the toolbox
e.g. in Fluid templates. Using the single tool in this way, the
$this->cobj->data array is NULL. This array is set usually by the
toolbox plugin.

The inclusion has to be done as follow:

> plugin.tx_dlf_fulltexttool {
  userFunc = Kitodo\Dlf\Plugin\Tools\FulltextTool->main
  templateFile = EXT:example/Resources/Private/Plugins/Kitodo/fulltext.tmpl
  pages = {$config.storagePid}
}

Inside the Fluid template:

> <f:cObject typoscriptObjectPath="plugin.tx_dlf_fulltexttool" />