### PR TITLE
Fix 369: output stream of search suggestions via output variable

### DIFF
--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -13,6 +13,7 @@ namespace Kitodo\Dlf\Plugin\Eid;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
+use \TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * eID search suggestions for plugin 'Search' of the 'dlf' extension
@@ -37,16 +38,13 @@ class SearchSuggest extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
      * @return string XML response of search suggestions
      */
     public function main($content = '', $conf = []) {
-        if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('encrypted') != ''
-            && \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('hashed') != '') {
-            $core = Helper::decrypt(\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('encrypted'), \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('hashed'));
+        if (GeneralUtility::_GP('encrypted') != ''
+            && GeneralUtility::_GP('hashed') != '') {
+            $core = Helper::decrypt(GeneralUtility::_GP('encrypted'), GeneralUtility::_GP('hashed'));
         }
         if (!empty($core)) {
-            $url = trim(Solr::getSolrUrl($core), '/').'/suggest/?wt=xml&q='.Solr::escapeQuery(\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q'));
-            if ($stream = fopen($url, 'r')) {
-                $output = stream_get_contents($stream);
-                fclose($stream);
-            }
+            $url = trim(Solr::getSolrUrl($core), '/').'/suggest/?wt=xml&q='.Solr::escapeQuery(GeneralUtility::_GP('q'));
+            $output = GeneralUtility::getUrl($url);
         }
         echo $output;
     }

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -13,7 +13,7 @@ namespace Kitodo\Dlf\Plugin\Eid;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * eID search suggestions for plugin 'Search' of the 'dlf' extension

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -44,10 +44,10 @@ class SearchSuggest extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
         if (!empty($core)) {
             $url = trim(Solr::getSolrUrl($core), '/').'/suggest/?wt=xml&q='.Solr::escapeQuery(\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('q'));
             if ($stream = fopen($url, 'r')) {
-                $content .= stream_get_contents($stream);
+                $output = stream_get_contents($stream);
                 fclose($stream);
             }
         }
-        echo $content;
+        echo $output;
     }
 }


### PR DESCRIPTION
* do not use the $content variable of type ServerRequest
* use the GeneralUtility:getUrl() instead native PHP stream_get_contents() as it is done in other eID-Skript