### PR TITLE
Replace deprecated marker related methods and make getTemplate more generic

### DIFF
--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -50,7 +50,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin 
     /**
      * This holds the plugin's service for template
      *
-     * @var MarkerBasedTemplateService
+     * @var \TYPO3\CMS\Core\Service\MarkerBasedTemplateService
      * @access protected
      */
     protected $templateService;

--- a/Classes/Plugin/AudioPlayer.php
+++ b/Classes/Plugin/AudioPlayer.php
@@ -106,7 +106,7 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin {
         $markerArray = [
             '###PLAYER_JS###' => $this->addPlayerJS()
         ];
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/Basket.php
+++ b/Classes/Plugin/Basket.php
@@ -41,7 +41,7 @@ class Basket extends \Kitodo\Dlf\Common\AbstractPlugin {
         $this->setCache(FALSE);
         // Load template file.
         $this->getTemplate();
-        $subpartArray['entry'] = $this->cObj->getSubpart($this->template, '###ENTRY###');
+        $subpartArray['entry'] = $this->templateService->getSubpart($this->template, '###ENTRY###');
         $markerArray['###JS###'] = '';
         // get user session
         $sessionId = $GLOBALS['TSFE']->fe_user->id;
@@ -199,7 +199,7 @@ class Basket extends \Kitodo\Dlf\Common\AbstractPlugin {
         } else {
             $markerArray['###BASKET###'] = '';
         }
-        $content = $this->cObj->substituteMarkerArray($this->cObj->substituteSubpart($this->template, '###ENTRY###', $entries, TRUE), $markerArray);
+        $content = $this->templateService->substituteMarkerArray($this->templateService->substituteSubpart($this->template, '###ENTRY###', $entries, TRUE), $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 
@@ -248,7 +248,7 @@ class Basket extends \Kitodo\Dlf\Common\AbstractPlugin {
         // return one entry
         $markerArray['###CONTROLS###'] = $controlMark;
         $markerArray['###NUMBER###'] = $docData['record_id'];
-        return $this->cObj->substituteMarkerArray($this->cObj->substituteSubpart($template['entry'], '###ENTRY###', '', TRUE), $markerArray);
+        return $this->templateService->substituteMarkerArray($this->templateService->substituteSubpart($template['entry'], '###ENTRY###', '', TRUE), $markerArray);
     }
 
     /**

--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -84,10 +84,10 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
         $allIssues = [];
         // Get subpart templates.
-        $subparts['list'] = $this->cObj->getSubpart($this->template, '###ISSUELIST###');
-        $subparts['month'] = $this->cObj->getSubpart($this->template, '###CALMONTH###');
-        $subparts['week'] = $this->cObj->getSubpart($subparts['month'], '###CALWEEK###');
-        $subparts['singleday'] = $this->cObj->getSubpart($subparts['list'], '###SINGLEDAY###');
+        $subparts['list'] = $this->templateService->getSubpart($this->template, '###ISSUELIST###');
+        $subparts['month'] = $this->templateService->getSubpart($this->template, '###CALMONTH###');
+        $subparts['week'] = $this->templateService->getSubpart($subparts['month'], '###CALWEEK###');
+        $subparts['singleday'] = $this->templateService->getSubpart($subparts['list'], '###SINGLEDAY###');
         // Build calendar for given year.
         $year = date('Y', strtotime($issues[0]['year']));
         $subPartContent = '';
@@ -181,12 +181,12 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
                     }
                 }
                 // Fill the weeks.
-                $subWeekPartContent .= $this->cObj->substituteMarkerArray($subparts['week'], $weekArray);
+                $subWeekPartContent .= $this->templateService->substituteMarkerArray($subparts['week'], $weekArray);
             }
             // Fill the month markers.
-            $subPartContent .= $this->cObj->substituteMarkerArray($subparts['month'], $markerArray);
+            $subPartContent .= $this->templateService->substituteMarkerArray($subparts['month'], $markerArray);
             // Fill the week markers with the week entries.
-            $subPartContent = $this->cObj->substituteSubpart($subPartContent, '###CALWEEK###', $subWeekPartContent);
+            $subPartContent = $this->templateService->substituteSubpart($subPartContent, '###CALWEEK###', $subWeekPartContent);
         }
         // Link to years overview
         $linkConf = [
@@ -210,9 +210,9 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
             foreach ($issues as $issue) {
                 $markerArrayDay['###ITEMS###'] .= $issue;
             }
-            $subPartContentList .= $this->cObj->substituteMarkerArray($subparts['singleday'], $markerArrayDay);
+            $subPartContentList .= $this->templateService->substituteMarkerArray($subparts['singleday'], $markerArrayDay);
         }
-        $this->template = $this->cObj->substituteSubpart($this->template, '###SINGLEDAY###', $subPartContentList);
+        $this->template = $this->templateService->substituteSubpart($this->template, '###SINGLEDAY###', $subPartContentList);
         if (count($allIssues) < 6) {
             $listViewActive = TRUE;
         } else {
@@ -226,8 +226,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
             '###LABEL_CALENDAR###' => $this->pi_getLL('label.view_calendar'),
             '###LABEL_LIST_VIEW###' => $this->pi_getLL('label.view_list'),
         ];
-        $this->template = $this->cObj->substituteMarkerArray($this->template, $markerArray);
-        return $this->cObj->substituteSubpart($this->template, '###CALMONTH###', $subPartContent);
+        $this->template = $this->templateService->substituteMarkerArray($this->template, $markerArray);
+        return $this->templateService->substituteSubpart($this->template, '###CALMONTH###', $subPartContent);
     }
 
     /**
@@ -251,7 +251,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
         // Load template file.
         $this->getTemplate('###TEMPLATEYEAR###');
         // Get subpart templates
-        $subparts['year'] = $this->cObj->getSubpart($this->template, '###LISTYEAR###');
+        $subparts['year'] = $this->templateService->getSubpart($this->template, '###LISTYEAR###');
         // Get the title of the anchor file
         $titleAnchor = $this->doc->getTitle($this->doc->uid);
         // Get all children of anchor. This should be the year anchor documents
@@ -283,7 +283,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
                 $yearArray = [
                     '###YEARNAME###' => $this->cObj->typoLink($year['title'], $linkConf),
                 ];
-                $subYearPartContent .= $this->cObj->substituteMarkerArray($subparts['year'], $yearArray);
+                $subYearPartContent .= $this->templateService->substituteMarkerArray($subparts['year'], $yearArray);
             }
         }
         // link to years overview (should be itself here)
@@ -298,8 +298,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin {
             '###LABEL_CHOOSE_YEAR###' => $this->pi_getLL('label.please_choose_year'),
             '###CALALLYEARS###' => $allYearsLink
         ];
-        $this->template = $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $this->template = $this->templateService->substituteMarkerArray($this->template, $markerArray);
         // Fill the week markers
-        return $this->cObj->substituteSubpart($this->template, '###LISTYEAR###', $subYearPartContent);
+        return $this->templateService->substituteSubpart($this->template, '###LISTYEAR###', $subYearPartContent);
     }
 }

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -197,9 +197,9 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
             // Don't cache the output.
             $this->setCache(FALSE);
         }
-        $entry = $this->cObj->getSubpart($this->template, '###ENTRY###');
+        $entry = $this->templateService->getSubpart($this->template, '###ENTRY###');
         foreach ($markerArray as $marker) {
-            $content .= $this->cObj->substituteMarkerArray($entry, $marker);
+            $content .= $this->templateService->substituteMarkerArray($entry, $marker);
         }
         // Hook for getting custom collection hierarchies/subentries (requested by SBB).
         foreach ($this->hookObjects as $hookObj) {
@@ -207,7 +207,7 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
                 $hookObj->showCollectionList_getCustomCollectionList($this, $this->conf['templateFile'], $content, $markerArray);
             }
         }
-        return $this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
+        return $this->templateService->substituteSubpart($this->template, '###ENTRY###', $content, TRUE);
     }
 
     /**

--- a/Classes/Plugin/ListView.php
+++ b/Classes/Plugin/ListView.php
@@ -205,7 +205,7 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin {
             $link = $this->cObj->typoLink($this->pi_getLL('addBasket', '', TRUE), $conf);
             $markerArray['###BASKETBUTTON###'] = $link;
         }
-        return $this->cObj->substituteMarkerArray($this->cObj->substituteSubpart($template['entry'], '###SUBTEMPLATE###', $subpart, TRUE), $markerArray);
+        return $this->templateService->substituteMarkerArray($this->templateService->substituteSubpart($template['entry'], '###SUBTEMPLATE###', $subpart, TRUE), $markerArray);
     }
 
     /**
@@ -374,9 +374,9 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin {
                 $link = $this->cObj->typoLink($this->pi_getLL('addBasket', '', TRUE), $conf);
                 $markerArray['###SUBBASKETBUTTON###'] = $link;
             }
-            $content .= $this->cObj->substituteMarkerArray($template['subentry'], $markerArray);
+            $content .= $this->templateService->substituteMarkerArray($template['subentry'], $markerArray);
         }
-        return $this->cObj->substituteSubpart($this->cObj->getSubpart($this->template, '###SUBTEMPLATE###'), '###SUBENTRY###', $content, TRUE);
+        return $this->templateService->substituteSubpart($this->templateService->getSubpart($this->template, '###SUBTEMPLATE###'), '###SUBENTRY###', $content, TRUE);
     }
 
     /**
@@ -483,8 +483,8 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
         // Load template file.
         $this->getTemplate();
-        $subpartArray['entry'] = $this->cObj->getSubpart($this->template, '###ENTRY###');
-        $subpartArray['subentry'] = $this->cObj->getSubpart($this->template, '###SUBENTRY###');
+        $subpartArray['entry'] = $this->templateService->getSubpart($this->template, '###ENTRY###');
+        $subpartArray['subentry'] = $this->templateService->getSubpart($this->template, '###SUBENTRY###');
         // Set some variable defaults.
         if (!empty($this->piVars['pointer']) && (($this->piVars['pointer'] * $this->conf['limit']) + 1) <= $this->list->metadata['options']['numberOfToplevelHits']) {
             $this->piVars['pointer'] = max(intval($this->piVars['pointer']), 0);
@@ -516,7 +516,7 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
         $markerArray['###PAGEBROWSER###'] = $this->getPageBrowser();
         $markerArray['###SORTING###'] = $this->getSortingForm();
-        $content = $this->cObj->substituteMarkerArray($this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE), $markerArray);
+        $content = $this->templateService->substituteMarkerArray($this->templateService->substituteSubpart($this->template, '###ENTRY###', $content, TRUE), $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -154,7 +154,7 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin {
         // Load template file.
         $this->getTemplate();
         $output = '';
-        $subpart['block'] = $this->cObj->getSubpart($this->template, '###BLOCK###');
+        $subpart['block'] = $this->templateService->getSubpart($this->template, '###BLOCK###');
         // Get list of metadata to show.
         $metaList = [];
         if ($useOriginalIiifManifestMetadata) {
@@ -214,7 +214,7 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin {
                             $markerArray['###METADATA###'] .= $this->cObj->stdWrap($field, $fieldwrap['all.']);
                         }
                     }
-                    $output .= $this->cObj->substituteMarkerArray($subpart['block'], $markerArray);
+                    $output .= $this->templateService->substituteMarkerArray($subpart['block'], $markerArray);
                 }
             }
         } else {
@@ -328,9 +328,9 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin {
                         }
                     }
                 }
-                $output .= $this->cObj->substituteMarkerArray($subpart['block'], $markerArray);
+                $output .= $this->templateService->substituteMarkerArray($subpart['block'], $markerArray);
             }
         }
-        return $this->cObj->substituteSubpart($this->template, '###BLOCK###', $output, TRUE);
+        return $this->templateService->substituteSubpart($this->template, '###BLOCK###', $output, TRUE);
     }
 }

--- a/Classes/Plugin/Navigation.php
+++ b/Classes/Plugin/Navigation.php
@@ -186,7 +186,7 @@ class Navigation extends \Kitodo\Dlf\Common\AbstractPlugin {
         $markerArray['###ROTATE_LEFT###'] = $this->pi_getLL('rotate-left', '', TRUE);
         $markerArray['###ROTATE_RIGHT###'] = $this->pi_getLL('rotate-right', '', TRUE);
         $markerArray['###ROTATE_RESET###'] = $this->pi_getLL('rotate-reset', '', TRUE);
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 

--- a/Classes/Plugin/PageGrid.php
+++ b/Classes/Plugin/PageGrid.php
@@ -68,7 +68,7 @@ class PageGrid extends \Kitodo\Dlf\Common\AbstractPlugin {
             'title' => $markerArray['###PAGINATION###']
         ];
         $markerArray['###THUMBNAIL###'] = $this->cObj->typoLink($thumbnail, $linkConf);
-        return $this->cObj->substituteMarkerArray($template, $markerArray);
+        return $this->templateService->substituteMarkerArray($template, $markerArray);
     }
 
     /**
@@ -142,7 +142,7 @@ class PageGrid extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
         // Load template file.
         $this->getTemplate();
-        $entryTemplate = $this->cObj->getSubpart($this->template, '###ENTRY###');
+        $entryTemplate = $this->templateService->getSubpart($this->template, '###ENTRY###');
         if (empty($entryTemplate)) {
             Helper::devLog('No template subpart for list entry found', DEVLOG_SEVERITY_WARNING);
             // Quit without doing anything if required variables are not set.
@@ -183,7 +183,7 @@ class PageGrid extends \Kitodo\Dlf\Common\AbstractPlugin {
         // Render page browser.
         $markerArray['###PAGEBROWSER###'] = $this->getPageBrowser();
         // Merge everything with template.
-        $content = $this->cObj->substituteMarkerArray($this->cObj->substituteSubpart($this->template, '###ENTRY###', $content, TRUE), $markerArray);
+        $content = $this->templateService->substituteMarkerArray($this->templateService->substituteSubpart($this->template, '###ENTRY###', $content, TRUE), $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -339,7 +339,7 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin {
             '###VIEWER_JS###' => $this->addViewerJS()
         ];
         $markerArray = array_merge($markerArray, $this->addInteraction(), $this->addBasketForm());
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -168,7 +168,7 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin {
                 '###EXT_SEARCH_FIELDSELECTOR###' => '<select class="tx-dlf-search-field tx-dlf-search-field-'.$i.'" name="'.$this->prefixId.'[extField]['.$i.']">'.$fieldSelectorOptions.'</select>',
                 '###EXT_SEARCH_FIELDQUERY###' => '<input class="tx-dlf-search-query tx-dlf-search-query-'.$i.'" type="text" name="'.$this->prefixId.'[extQuery]['.$i.']" />'
             ];
-            $extendedSearch .= $this->cObj->substituteMarkerArray($this->cObj->getSubpart($this->template, '###EXT_SEARCH_ENTRY###'), $markerArray);
+            $extendedSearch .= $this->templateService->substituteMarkerArray($this->templateService->getSubpart($this->template, '###EXT_SEARCH_ENTRY###'), $markerArray);
         }
         return $extendedSearch;
     }
@@ -358,7 +358,7 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin {
             // Get additional fields for extended search.
             $extendedSearch = $this->addExtendedSearch();
             // Display search form.
-            $content .= $this->cObj->substituteSubpart($this->cObj->substituteMarkerArray($this->template, $markerArray), '###EXT_SEARCH_ENTRY###', $extendedSearch);
+            $content .= $this->templateService->substituteSubpart($this->templateService->substituteMarkerArray($this->template, $markerArray), '###EXT_SEARCH_ENTRY###', $extendedSearch);
             return $this->pi_wrapInBaseClass($content);
         } else {
             // Instantiate search object.

--- a/Classes/Plugin/TableOfContents.php
+++ b/Classes/Plugin/TableOfContents.php
@@ -130,7 +130,7 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin {
         $TSconfig['special.']['userFunc'] = \Kitodo\Dlf\Plugin\TableOfContents::class.'->makeMenuArray';
         $TSconfig = Helper::mergeRecursiveWithOverrule($this->conf['menuConf.'], $TSconfig);
         $markerArray['###TOCMENU###'] = $this->cObj->cObjGetSingle('HMENU', $TSconfig);
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 

--- a/Classes/Plugin/Toolbox.php
+++ b/Classes/Plugin/Toolbox.php
@@ -46,15 +46,15 @@ class Toolbox extends \Kitodo\Dlf\Common\AbstractPlugin {
             'piVars' => $this->piVars,
         ];
         // Get template subpart for tools.
-        $subpart = $this->cObj->getSubpart($this->template, '###TOOLS###');
+        $subpart = $this->templateService->getSubpart($this->template, '###TOOLS###');
         $tools = explode(',', $this->conf['tools']);
         // Add the tools to the toolbox.
         foreach ($tools as $tool) {
             $tool = trim($tool);
             $cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
             $cObj->data = $data;
-            $content .= $this->cObj->substituteMarkerArray($subpart, ['###TOOL###' => $cObj->cObjGetSingle($GLOBALS['TSFE']->tmpl->setup['plugin.'][$tool], $GLOBALS['TSFE']->tmpl->setup['plugin.'][$tool.'.'])]);
+            $content .= $this->templateService->substituteMarkerArray($subpart, ['###TOOL###' => $cObj->cObjGetSingle($GLOBALS['TSFE']->tmpl->setup['plugin.'][$tool], $GLOBALS['TSFE']->tmpl->setup['plugin.'][$tool.'.'])]);
         }
-        return $this->pi_wrapInBaseClass($this->cObj->substituteSubpart($this->template, '###TOOLS###', $content, TRUE));
+        return $this->pi_wrapInBaseClass($this->templateService->substituteSubpart($this->template, '###TOOLS###', $content, TRUE));
     }
 }

--- a/Classes/Plugin/Tools/AnnotationTool.php
+++ b/Classes/Plugin/Tools/AnnotationTool.php
@@ -79,7 +79,7 @@ class AnnotationTool extends AbstractPlugin {
         } else {
             $markerArray['###ANNOTATION_SELECT###'] = '<span class="no-annotations">'.$this->pi_getLL('annotations-not-available', '', TRUE).'</span>';
         }
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/Tools/FulltextTool.php
+++ b/Classes/Plugin/Tools/FulltextTool.php
@@ -72,7 +72,7 @@ class FulltextTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         } else {
             $markerArray['###FULLTEXT_SELECT###'] = '<span class="no-fulltext">'.$this->pi_getLL('fulltext-not-available', '', TRUE).'</span>';
         }
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/Tools/ImageDownloadTool.php
+++ b/Classes/Plugin/Tools/ImageDownloadTool.php
@@ -69,7 +69,7 @@ class ImageDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         $markerArray['###IMAGE_LEFT###'] = $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'], $this->pi_getLL('leftPage', '')) : $this->getImage($this->piVars['page'], $this->pi_getLL('singlePage', ''));
         // Get right page download.
         $markerArray['###IMAGE_RIGHT###'] = $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'] + 1, $this->pi_getLL('rightPage', '')) : '';
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 

--- a/Classes/Plugin/Tools/ImageManipulationTool.php
+++ b/Classes/Plugin/Tools/ImageManipulationTool.php
@@ -43,7 +43,7 @@ class ImageManipulationTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         // Load template file.
         $this->getTemplate();
         $markerArray['###IMAGEMANIPULATION_SELECT###'] = '<span class="tx-dlf-tools-imagetools" id="tx-dlf-tools-imagetools" data-dic="imagemanipulation-on:'.$this->pi_getLL('imagemanipulation-on', '', TRUE).';imagemanipulation-off:'.$this->pi_getLL('imagemanipulation-off', '', TRUE).';reset:'.$this->pi_getLL('reset', '', TRUE).';saturation:'.$this->pi_getLL('saturation', '', TRUE).';hue:'.$this->pi_getLL('hue', '', TRUE).';contrast:'.$this->pi_getLL('contrast', '', TRUE).';brightness:'.$this->pi_getLL('brightness', '', TRUE).';invert:'.$this->pi_getLL('invert', '', TRUE).'" title="'.$this->pi_getLL('no-support', '', TRUE).'"></span>';
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 }

--- a/Classes/Plugin/Tools/PdfDownloadTool.php
+++ b/Classes/Plugin/Tools/PdfDownloadTool.php
@@ -70,7 +70,7 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         $markerArray['###PAGE###'] = $this->getPageLink();
         // Get work download.
         $markerArray['###WORK###'] = $this->getWorkLink();
-        $content .= $this->cObj->substituteMarkerArray($this->template, $markerArray);
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }
 


### PR DESCRIPTION
- replace `$this->cObj->getSubpart`, `$this->cObj->substituteMarkerArray` and `$this->cObj->substituteSubpart`
- make method getTemplate more generic - use extKey instead of rigid written extension key (DFG Viewer will be able also use this method in own plugins)