### PR TITLE
Fix two SQL queries

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -319,7 +319,7 @@ class Helper {
             ->select($table.'.index_name AS index_name')
             ->from($table)
             ->where(
-                $queryBuilder->expr()->eq($table.'.uid=', $uid),
+                $queryBuilder->expr()->eq($table.'.uid', $uid),
                 $where,
                 self::whereExpression($table)
             )

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -135,7 +135,7 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
         $count = $queryBuilder->count('uid')->execute()->fetchColumn(0);
         $content = '';
         if ($count == 1 && empty($this->conf['dont_show_single'])) {
-            $resArray = $allResults[0];
+            $resArray = $result->fetch();
             $this->showSingleCollection(intval($resArray['uid']));
         }
         $solr = Solr::getInstance($this->conf['solrcore']);

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -104,7 +104,7 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
 
         // Get collections.
-        $result = $queryBuilder
+        $queryBuilder
             ->select(
                 'tx_dlf_collections.index_name AS index_name',
                 'tx_dlf_collections.index_search as index_query',
@@ -129,12 +129,10 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
                 ),
                 Helper::whereExpression('tx_dlf_collections')
             )
-            ->orderBy($orderBy)
-            ->execute();
+            ->orderBy($orderBy);
 
-        $allResults = $result->fetchAll();
-
-        $count = count($allResults);
+        $result = $queryBuilder->execute();
+        $count = $queryBuilder->count('uid')->execute()->fetchColumn(0);
         $content = '';
         if ($count == 1 && empty($this->conf['dont_show_single'])) {
             $resArray = $allResults[0];


### PR DESCRIPTION
With #376 two bugs where introduced: 

- The SQL-statement to fetch the solr core is broken 
- the result of collections is always empty in the collection plugin.

This PR fixes these two errors.