### PR TITLE
Several fixes on using the queryBuilder

### DIFF
--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -158,7 +158,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin 
 
             // Get UID of document with given record identifier.
             $result = $queryBuilder
-                ->select('tx_dlf_documents.uid')
+                ->select('tx_dlf_documents.uid AS uid')
                 ->from('tx_dlf_documents')
                 ->where(
                     $queryBuilder->expr()->eq('tx_dlf_documents.record_id', $queryBuilder->expr()->literal($this->piVars['recordId'])),
@@ -167,10 +167,8 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin 
                 ->setMaxResults(1)
                 ->execute();
 
-            $allResults = $result->fetchAll();
-
-            if (count($allResults) == 1) {
-                list ($this->piVars['id']) = $allResults[0];
+            if ($resArray = $result->fetch()) {
+                $this->piVars['id'] = $resArray['uid'];
                 // Set superglobal $_GET array and unset variables to avoid infinite looping.
                 $_GET[$this->prefixId]['id'] = $this->piVars['id'];
                 unset ($this->piVars['recordId'], $_GET[$this->prefixId]['recordId']);

--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -451,10 +451,8 @@ abstract class Document {
                 ->setMaxResults(1)
                 ->execute();
 
-            $allResults = $result->fetchAll();
-
-            if (count($allResults) == 1) {
-                $documentFormat = $allResults[0]['document_format'];
+            if ($resArray = $result->fetch()) {
+                $documentFormat = $resArray['document_format'];
             }
         } else {
             // Get document format from content of remote document
@@ -691,11 +689,10 @@ abstract class Document {
                 ->setMaxResults(1)
                 ->execute();
 
-            $allResults = $result->fetchAll();
-
-            if (count($allResults) == 1) {
+            if ($resArray = $result->fetch()) {
                 // Get title information.
-                list ($title, $partof) = $allResults[0];
+                $title = $resArray['title'];
+                $partof = $resArray['partof'];
                 // Search parent documents recursively for a title?
                 if ($recursive
                     && empty($title)
@@ -969,10 +966,8 @@ abstract class Document {
             ->setMaxResults(1)
             ->execute();
 
-        $allResults = $result->fetchAll();
-
-        if (count($allResults) == 1) {
-            list ($structure) = $allResults[0];
+        if ($resArray = $result->fetch()) {
+            $structure = $resArray['uid'];
         } else {
             Helper::devLog('Could not identify document/structure type "'.$queryBuilder->expr()->literal($metadata['type'][0]).'"', DEVLOG_SEVERITY_ERROR);
             return FALSE;
@@ -1053,10 +1048,8 @@ abstract class Document {
             ->setMaxResults(1)
             ->execute();
 
-        $allResults = $result->fetchAll();
-
-        if (count($allResults) == 1) {
-            list ($ownerUid) = $allResults[0];
+        if ($resArray = $result->fetch()) {
+            $ownerUid = $resArray['uid'];
         } else {
             // Insert new library.
             $libNewUid = uniqid('NEW');
@@ -1540,10 +1533,13 @@ abstract class Document {
             ->setMaxResults(1)
             ->execute();
 
-        $allResults = $result->fetchAll();
-
-        if (count($allResults) == 1) {
-            list ($this->uid, $this->pid, $this->recordId, $this->parentId, $this->thumbnail, $this->location) = $allResults[0];
+        if ($resArray = $result->fetch()) {
+            $this->uid = $resArray['uid'];
+            $this->pid = $resArray['pid'];
+            $this->recordId = $resArray['record_id'];
+            $this->uid = $resArray['uid'];
+            $this->thumbnail = $resArray['thumbnail'];
+            $this->location = $resArray['location'];
             $this->thumbnailLoaded = TRUE;
             // Load XML file if necessary...
             if ($this->getDocument() === NULL

--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -1536,7 +1536,7 @@ abstract class Document {
             $this->uid = $resArray['uid'];
             $this->pid = $resArray['pid'];
             $this->recordId = $resArray['record_id'];
-            $this->uid = $resArray['uid'];
+            $this->parentId = $resArray['partof'];
             $this->thumbnail = $resArray['thumbnail'];
             $this->location = $resArray['location'];
             $this->thumbnailLoaded = TRUE;

--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -1121,7 +1121,6 @@ abstract class Document {
                 $queryBuilder->expr()->eq('tx_dlf_metadata.pid', intval($pid)),
                 Helper::whereExpression('tx_dlf_metadata')
             )
-            ->setMaxResults(1)
             ->execute();
 
         $listed = [];

--- a/Classes/Common/DocumentTypeCheck.php
+++ b/Classes/Common/DocumentTypeCheck.php
@@ -166,7 +166,6 @@ class DocumentTypeCheck {
                 ->setMaxResults(1)
                 ->execute();
 
-            $allResults = $result->fetchAll();
             if ($resArray = $result->fetch()) {
                 $this->piVars['id'] = $resArray['uid'];
                 // Set superglobal $_GET array.

--- a/Classes/Common/DocumentTypeCheck.php
+++ b/Classes/Common/DocumentTypeCheck.php
@@ -157,7 +157,7 @@ class DocumentTypeCheck {
 
             // Get UID of document with given record identifier.
             $result = $queryBuilder
-                ->select('tx_dlf_documents.uid')
+                ->select('tx_dlf_documents.uid AS uid')
                 ->from('tx_dlf_documents')
                 ->where(
                     $queryBuilder->expr()->eq('tx_dlf_documents.record_id', $queryBuilder->expr()->literal($this->piVars['recordId'])),
@@ -167,8 +167,8 @@ class DocumentTypeCheck {
                 ->execute();
 
             $allResults = $result->fetchAll();
-            if (count($allResults) == 1) {
-                list ($this->piVars['id']) = $allResults[0];
+            if ($resArray = $result->fetch()) {
+                $this->piVars['id'] = $resArray['uid'];
                 // Set superglobal $_GET array.
                 $_GET[$this->prefixId]['id'] = $this->piVars['id'];
                 // Unset variable to avoid infinite looping.

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -155,11 +155,9 @@ class DataHandler {
                             ->setMaxResults(1)
                             ->execute();
 
-                        $allResults = $result->fetchAll();
-
-                        if (count($allResults) == 1) {
+                        if ($resArray = $result->fetch()) {
                             // Reset storing to current.
-                            list ($fieldArray['index_stored']) = $allResults[0];
+                            $fieldArray['index_stored'] = $resArray['is_listed'];
                         }
                     }
                     // Index field in index if it should be used for auto-completion.
@@ -180,11 +178,9 @@ class DataHandler {
                             ->setMaxResults(1)
                             ->execute();
 
-                        $allResults = $result->fetchAll();
-
-                        if (count($allResults) == 1) {
+                        if ($resArray = $this->fetch()) {
                             // Reset indexing to current.
-                            list ($fieldArray['index_indexed']) = $allResults[0];
+                            $fieldArray['index_indexed'] = $resArray['index_autocomplete'];
                         }
                     }
                 // Field post-processing for tables "tx_dlf_metadata" and "tx_dlf_structures".
@@ -206,11 +202,9 @@ class DataHandler {
                                 ->setMaxResults(1)
                                 ->execute();
 
-                            $allResults = $result->fetchAll();
-
-                            if (count($allResults) == 1) {
-                                // Reset index name to current.
-                                list ($fieldArray['index_name']) = $allResults[0];
+                            if ($resArray = $this->fetch()) {
+                                // Reset indexing to current.
+                                $fieldArray['index_indexed'] = $resArray['index_autocomplete'];
                             }
                         }
                         Helper::devLog('Prevented change of index_name for UID '.$id.' in table "'.$table.'"', DEVLOG_SEVERITY_NOTICE);

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -285,8 +285,12 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
             ->execute();
 
         // Fetch corresponding document UIDs from Solr.
-        $allResults = $collection->fetchAll();
-        $collectionData = $allResults[0];
+        if ($resArray = $collection->fetch()) {
+            $collectionData = $resArray;
+        } else {
+            Helper::devLog('No collection with UID '.$id.' found.', DEVLOG_SEVERITY_WARNING);
+            return;
+        }
         if ($collectionData['index_search'] != '') {
             $solr_query = '('.$collectionData['index_search'].')';
         } else {

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -554,8 +554,8 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin {
 
         $allResults = $result->fetchAll();
 
-        if (count($allResults) == 1) {
-            list ($timestamp) = $allResults[0];
+        if ($resArray = $result->fetch()) {
+            $timestamp = $resArray['tstamp'];
             $earliestDatestamp = gmdate('Y-m-d\TH:i:s\Z', $timestamp);
         } else {
             Helper::devLog('No records found with PID '.$this->conf['pages'], DEVLOG_SEVERITY_NOTICE);


### PR DESCRIPTION
There are still some few but important bugs introduced by #376.

This patch fixes the following:

* the list() function does not work with queryBuilder as it cannot work with associative arrays
* only the first metadata was indexed
* with a non-existing uid, the application stops with a SQL error in collection plugin