### PR TITLE
Fix class name on new format records.

### DIFF
--- a/Classes/Hooks/ConfigurationForm.php
+++ b/Classes/Hooks/ConfigurationForm.php
@@ -129,7 +129,7 @@ class ConfigurationForm {
                 'type' => 'MODS',
                 'root' => 'mods',
                 'namespace' => 'http://www.loc.gov/mods/v3',
-                'class' => 'Kitodo\\\\Dlf\\\\Format\\\\Mods'
+                'class' => 'Kitodo\\Dlf\\Format\\Mods'
             ];
         }
         // Add TEIHDR namespace.
@@ -139,7 +139,7 @@ class ConfigurationForm {
                 'type' => 'TEIHDR',
                 'root' => 'teiHeader',
                 'namespace' => 'http://www.tei-c.org/ns/1.0',
-                'class' => 'Kitodo\\\\Dlf\\\\Format\\\\TeiHeader'
+                'class' => 'Kitodo\\Dlf\\Format\\TeiHeader'
             ];
         }
         // Add ALTO namespace.
@@ -149,7 +149,7 @@ class ConfigurationForm {
                 'type' => 'ALTO',
                 'root' => 'alto',
                 'namespace' => 'http://www.loc.gov/standards/alto/ns-v2#',
-                'class' => 'Kitodo\\\\Dlf\\\\Format\\\\Alto'
+                'class' => 'Kitodo\\Dlf\\Format\\Alto'
             ];
         }
         // Add IIIF Metadata API 1 context


### PR DESCRIPTION
The default formats are created automatically in tx_dlf_formats on
opening the extension configuration. In this case the class field is set
with double backslashes which is wrong.

The update-script is not affected. The four (!) backslashes updates an
existing old class name correctly.

This fixes #372.