### PR TITLE
Enable indexing of geospatial information in GeoJSON format.

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -400,6 +400,10 @@ class Indexer {
             $solrDoc->setField('location', $doc->location);
             $solrDoc->setField('urn', $metadata['urn']);
             $solrDoc->setField('collection', $doc->metadataArray[$doc->toplevelId]['collection']);
+            $coordinates = json_decode($metadata['coordinates'][0]);
+            if (is_object($coordinates)) {
+                  $solrDoc->setField('geom', json_encode($coordinates->features[0]));
+            }
             $autocomplete = [];
             foreach ($metadata as $index_name => $data) {
                 if (!empty($data)

--- a/Configuration/ApacheSolr/configsets/dlf/conf/schema.xml
+++ b/Configuration/ApacheSolr/configsets/dlf/conf/schema.xml
@@ -22,6 +22,7 @@ limitations under the License.
         <fieldType name="int" class="solr.IntPointField" positionIncrementGap="0"/>
         <!-- Use dates of the form 1995-12-31Z23:59:49Z for this field. -->
         <fieldType name="date" class="solr.DatePointField" positionIncrementGap="0"/>
+        <fieldType name="geojson" class="solr.SpatialRecursivePrefixTreeFieldType" spatialContextFactory="Geo3D" geo="true" planetModel="WGS84" format="GeoJSON"/>
         <fieldType name="standard" class="solr.TextField" positionIncrementGap="100">
             <analyzer>
                 <tokenizer class="solr.StandardTokenizerFactory" />
@@ -137,6 +138,8 @@ limitations under the License.
         <field name="location" type="string" indexed="true" stored="true" required="true" multiValued="false" default="" />
         <!-- Associated collection(s) of the document. -->
         <field name="collection" type="string" indexed="true" stored="true" required="true" multiValued="true" default="" />
+        <!-- GeoJson data -->
+        <field name="geom" type="geojson" indexed="true" stored="true" required="false" multiValued="false"/>
 
         <!--
             The following dynamic fields define all possible field variants.

--- a/Resources/Private/Data/MetadataDefaults.php
+++ b/Resources/Private/Data/MetadataDefaults.php
@@ -386,5 +386,24 @@ $metadataDefaults = [
         'is_facet' => 0,
         'is_listed' => 0,
         'index_autocomplete' => 0,
+    ],
+    'coordinates' => [
+        'format' => [
+            [
+                'encoded' => 1,
+                'xpath' => './mods:subject/mods:cartographics/mods:coordinates',
+                'xpath_sorting' => '',
+            ],
+        ],
+        'default_value' => '',
+        'wrap' => '',
+        'index_tokenized' => 0,
+        'index_stored' => 0,
+        'index_indexed' => 0,
+        'index_boost' => 1.00,
+        'is_sortable' => 0,
+        'is_facet' => 0,
+        'is_listed' => 0,
+        'index_autocomplete' => 0,
     ]
 ];

--- a/Resources/Private/Language/NewTenant.xml
+++ b/Resources/Private/Language/NewTenant.xml
@@ -126,6 +126,7 @@
             <label index="collection">Collection(s)</label>
             <label index="owner">Owner</label>
             <label index="language">Language</label>
+            <label index="coordinates">Coordinates</label>
         </languageKey>
         <languageKey index="de" type="array">
             <label index="mlang_tabs_tab">Neuer Mandant</label>
@@ -239,6 +240,7 @@
             <label index="collection">Sammlung(en)</label>
             <label index="owner">Besitzer</label>
             <label index="language">Sprache</label>
+            <label index="coordinates">Geoinformationen</label>
         </languageKey>
     </data>
 </T3locallang>


### PR DESCRIPTION
This patch adds the feature to index GeoJSON to the Solr index and to use the [Spatial Search](https://lucene.apache.org/solr/guide/7_7/spatial-search.html) feature of Solr.

The GeoJSON is expected in MODS: `./mods:subject/mods:cartographics/mods:coordinate`

The Solr schema has to be expanded by the following field and fieldType:
```
<fieldType name="geojson" class="solr.SpatialRecursivePrefixTreeFieldType" spatialContextFactory="Geo3D" geo="true" planetModel="WGS84" format="GeoJSON"/>
<field name="geom" type="geojson" indexed="true" stored="true" required="false" multiValued="false"/>
```
That's all :-)