### PR TITLE
Expand the xpath field to old value of 1024 bytes.

### DIFF
--- a/Configuration/TCA/tx_dlf_metadataformat.php
+++ b/Configuration/TCA/tx_dlf_metadataformat.php
@@ -57,7 +57,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 30,
-                'max' => 255,
+                'max' => 1024,
                 'eval' => 'required,trim',
                 'default' => '',
             ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -123,7 +123,7 @@ CREATE TABLE tx_dlf_metadataformat (
     deleted smallint(6) DEFAULT '0' NOT NULL,
     parent_id int(11) DEFAULT '0' NOT NULL,
     encoded int(11) DEFAULT '0' NOT NULL,
-    xpath varchar(255) DEFAULT '' NOT NULL,
+    xpath varchar(1024) DEFAULT '' NOT NULL,
     xpath_sorting varchar(255) DEFAULT '' NOT NULL,
     mandatory smallint(6) DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
Used xpaths in DFG-Viewer are longer than 255 signs. In SLUB setup,
there are even xpaths with 613 signs. 1024 signs seems to be reasonable.