### PR TITLE
Do not re-use QueryBuilder for different queries.

### DIFF
--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -251,9 +251,10 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
      * @return void
      */
     protected function showSingleCollection($id) {
+        /** @var ConnectionPool $connectionPool */
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
         /** @var QueryBuilder $queryBuilder */
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tx_dlf_collections');
+        $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_dlf_collections');
 
         $additionalWhere = '';
         // Should user-defined collections be shown?
@@ -312,6 +313,8 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin {
             }
         }
         $documentSet = array_unique($documentSet);
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_dlf_documents');
         // Fetch document info for UIDs in $documentSet from DB
         $documents = $queryBuilder
             ->select(


### PR DESCRIPTION
Following the [TYPO3 documentation](https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/ApiOverview/Database/QueryBuilder/Index.html), the QueryBuilder should not be re-used.

> The QueryBuilder holds internal state and should not be re-used for different queries: Use one query builder per query. Get a fresh one by calling $connection->createQueryBuilder() if the same table is affected, or use $connectionPool->getQueryBuilderForTable() for a query on to a different table.