### PR TITLE
Use PageRenderer to add JavaScript and CSS file to page header/footer.

### DIFF
--- a/Classes/Plugin/AudioPlayer.php
+++ b/Classes/Plugin/AudioPlayer.php
@@ -41,11 +41,24 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin {
         $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
         // Add AudioPlayer library.
         $pageRenderer->addCssFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/blue.monday/css/jplayer.blue.monday.min.css');
+        $pageRenderer->addCssInlineBlock('kitodo-audioplayer-configuration', '#tx-dlf-audio { width: 100px; height: 100px; }');
         $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/jquery.jplayer.min.js');
         $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/AudioPlayer/AudioPlayer.js');
         // Add AudioPlayer configuration.
-        $pageRenderer->addJscInlineBlock('kitodo-audioplayer-configuration', '#tx-dlf-audio { width: 100px; height: 100px; }');
-        $pageRenderer->addJsFooterInlineCode('kitodo-audioplayer-configuration', $viewerConfiguration);
+        $audioplayerConfiguration = '
+                $(document).ready(function() {
+                    AudioPlayer = new dlfAudioPlayer({
+                        audio: {
+                            mimeType: "'.$this->audio['mimetype'].'",
+                            title: "'.$this->audio['label'].'",
+                            url:  "'.$this->audio['url'].'"
+                        },
+                        parentElId: "tx-dlf-audio",
+                        swfPath: "'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/jquery.jplayer.swf"
+                    });
+                });
+        ';
+        $pageRenderer->addJsFooterInlineCode('kitodo-audioplayer-configuration', $audioplayerConfiguration);
     }
 
     /**

--- a/Classes/Plugin/AudioPlayer.php
+++ b/Classes/Plugin/AudioPlayer.php
@@ -35,30 +35,17 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin {
      *
      * @access protected
      *
-     * @return string Player script tags ready for output
+     * @return void
      */
     protected function addPlayerJS() {
-        $output = [];
-        $output[] = '<link type="text/css" rel="stylesheet" href="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/blue.monday/css/jplayer.blue.monday.min.css">';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/jquery.jplayer.min.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/AudioPlayer/AudioPlayer.js"></script>';
-        // Add player configuration.
-        $output[] = '
-            <style>#tx-dlf-audio { width: 100px; height: 100px; }</style>
-            <script id="tx-dlf-audioplayer-initViewer" type="text/javascript">
-                $(document).ready(function() {
-                    AudioPlayer = new dlfAudioPlayer({
-                        audio: {
-                            mimeType: "'.$this->audio['mimetype'].'",
-                            title: "'.$this->audio['label'].'",
-                            url:  "'.$this->audio['url'].'"
-                        },
-                        parentElId: "tx-dlf-audio",
-                        swfPath: "'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/jquery.jplayer.swf"
-                    });
-                });
-            </script>';
-        return implode("\n", $output);
+        $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+        // Add AudioPlayer library.
+        $pageRenderer->addCssFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/blue.monday/css/jplayer.blue.monday.min.css');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/jPlayer/jquery.jplayer.min.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/AudioPlayer/AudioPlayer.js');
+        // Add AudioPlayer configuration.
+        $pageRenderer->addJscInlineBlock('kitodo-audioplayer-configuration', '#tx-dlf-audio { width: 100px; height: 100px; }');
+        $pageRenderer->addJsFooterInlineCode('kitodo-audioplayer-configuration', $viewerConfiguration);
     }
 
     /**
@@ -102,10 +89,8 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
         // Load template file.
         $this->getTemplate();
-        // Fill in the template markers.
-        $markerArray = [
-            '###PLAYER_JS###' => $this->addPlayerJS()
-        ];
+        // Fill in the template markers (currently: none).
+        $markerArray = [];
         $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -64,42 +64,42 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin {
      *
      * @access protected
      *
-     * @return string Viewer script tags ready for output
+     * @return void
      */
     protected function addViewerJS() {
-        $output = [];
+
+        $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
         // Add OpenLayers library.
-        $output[] = '<link type="text/css" rel="stylesheet" href="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/OpenLayers/ol3.css">';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/OpenLayers/glif.min.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/OpenLayers/ol3-dlf.js"></script>';
+        $pageRenderer->addCssFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/OpenLayers/ol3.css');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/OpenLayers/glif.min.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/OpenLayers/ol3-dlf.js');
         // Add viewer library.
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/Utility.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/OL3.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/OL3Styles.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/OL3Sources.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AltoParser.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/ImageManipulationControl.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/FulltextControl.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationParser.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationControl.js"></script>';
-        $output[] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/PageView.js"></script>';
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/Utility.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/OL3.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/OL3Styles.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/OL3Sources.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AltoParser.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/ImageManipulationControl.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/FulltextControl.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationParser.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationControl.js');
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/PageView.js');
         // Add viewer configuration.
-        $output[] = '
-            <script id="tx-dlf-pageview-initViewer" type="text/javascript">
-                $(document).ready(function() {
-                    if (dlfUtils.exists(dlfViewer)) {
-                        tx_dlf_viewer = new dlfViewer({
-                            controls: ["'.implode('", "', $this->controls).'"],
-                            div: "'.$this->conf['elementId'].'",
-                            images: '.json_encode($this->images).',
-                            fulltexts: '.json_encode($this->fulltexts).',
-                            annotationContainers: '.json_encode($this->annotationContainers).',
-                            useInternalProxy: '.($this->conf['useInternalProxy'] ? 1 : 0).'
-                        });
-                    }
-                });
-            </script>';
-        return implode("\n", $output);
+        $viewerConfiguration = '
+            $(document).ready(function() {
+                if (dlfUtils.exists(dlfViewer)) {
+                    tx_dlf_viewer = new dlfViewer({
+                        controls: ["'.implode('", "', $this->controls).'"],
+                        div: "'.$this->conf['elementId'].'",
+                        images: '.json_encode($this->images).',
+                        fulltexts: '.json_encode($this->fulltexts).',
+                        annotationContainers: '.json_encode($this->annotationContainers).',
+                        useInternalProxy: '.($this->conf['useInternalProxy'] ? 1 : 0).'
+                    });
+                }
+            });
+            ';
+        $pageRenderer->addJsFooterInlineCode('kitodo-pageview-configuration', $viewerConfiguration);
     }
 
     /**
@@ -335,10 +335,8 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin {
         // Get the controls for the map.
         $this->controls = explode(',', $this->conf['features']);
         // Fill in the template markers.
-        $markerArray = [
-            '###VIEWER_JS###' => $this->addViewerJS()
-        ];
-        $markerArray = array_merge($markerArray, $this->addInteraction(), $this->addBasketForm());
+        $this->addViewerJS();
+        $markerArray = array_merge($this->addInteraction(), $this->addBasketForm());
         $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -58,7 +58,8 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin {
             ->execute();
 
         if ($result->rowCount() == 1) {
-            $GLOBALS['TSFE']->additionalHeaderData[$this->prefixId.'_search_suggest'] = '<script type="text/javascript" src="'.\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/Search/Suggester.js"></script>';
+            $pageRenderer = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+            $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/Search/Suggester.js');
         } else {
             Helper::devLog('No metadata fields configured for search suggestions', DEVLOG_SEVERITY_WARNING);
         }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,3 +1,11 @@
+config {
+  # concatenate all JavaScript files by default
+  concatenateJs = 1
+  # concatenate all CSS files by default
+  concatenateCss = 1
+}
+
+
 page {
   includeJSLibs {
     jQuery = EXT:dlf/Resources/Public/Javascript/jQuery/jquery-2.2.4.min.js

--- a/Resources/Private/Templates/AudioPlayer.tmpl
+++ b/Resources/Private/Templates/AudioPlayer.tmpl
@@ -9,5 +9,4 @@
 -->
 <!-- ###TEMPLATE### -->
 <div id="tx-dlf-audio" class="tx-dlf-audio"></div>
-###PLAYER_JS###
 <!-- ###TEMPLATE### -->

--- a/Resources/Private/Templates/PageView.tmpl
+++ b/Resources/Private/Templates/PageView.tmpl
@@ -17,5 +17,4 @@
 <div class="tx-dlf-navigation-editRemove">###EDITREMOVE###</div>
 <div class="tx-dlf-navigation-magnifier">###MAGNIFIER###</div>
 <div class="tx-dlf-interaction-addbasket">###BASKETBUTTON###</div>
-###VIEWER_JS###
 <!-- ###TEMPLATE### -->


### PR DESCRIPTION
This patch uses the PageRenderer class to add JavaScript and Css to header and footer of the page.

In addition, the TypoScript config concatenates the JS and CSS files to one each. This has the advantage to have less HTTP requests and to avoid blocking single JavaScript files by adblocker.