### PR TITLE
Add a new tool "search in document".

### DIFF
--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -110,7 +110,7 @@ class Solr {
         $helper = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Solarium\Core\Query\Helper::class);
         // Escape query phrase or term.
         if (preg_match('/^".*"$/', $query)) {
-            return '"'.$helper->escapePhrase(trim($query, '"')).'"';
+            return $helper->escapePhrase(trim($query, '"'));
         } else {
             return $helper->escapeTerm($query);
         }

--- a/Classes/Plugin/Eid/SearchInDocument.php
+++ b/Classes/Plugin/Eid/SearchInDocument.php
@@ -1,0 +1,52 @@
+<?php
+namespace Kitodo\Dlf\Plugin\Eid;
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use Kitodo\Dlf\Common\Helper;
+use Kitodo\Dlf\Common\Solr;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * eID search in document for plugin 'Search' of the 'dlf' extension
+ *
+ * @author Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class SearchInDocument extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
+    public $scriptRelPath = 'Classes/Plugin/Eid/SearchInDocument.php';
+
+    /**
+     * The main method of the eID script
+     *
+     * @access public
+     *
+     * @param string $content: The PlugIn content
+     * @param array $conf: The PlugIn configuration
+     *
+     * @return string JSON response of search suggestions
+     */
+    public function main($content = '', $conf = []) {
+        if (GeneralUtility::_GP('encrypted') != ''
+            && GeneralUtility::_GP('hashed') != '') {
+            $core = Helper::decrypt(GeneralUtility::_GP('encrypted'), GeneralUtility::_GP('hashed'));
+        }
+        if (!empty($core)) {
+            $url = trim(Solr::getSolrUrl($core), '/').'/select?wt=json&q=fulltext:('.Solr::escapeQuery(GeneralUtility::_GP('q')).')%20AND%20uid:'.GeneralUtility::_GP('uid')
+              .'&hl=on&hl.fl=fulltext&fl=uid,id,page&hl.method=fastVector'
+              .'&start='.GeneralUtility::_GP('start').'&rows=20';
+            $output = GeneralUtility::getUrl($url);
+        }
+        echo $output;
+    }
+}

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -1,0 +1,117 @@
+<?php
+namespace Kitodo\Dlf\Plugin\Tools;
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use Kitodo\Dlf\Common\Helper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * SearchInDocument tool for the plugin 'Toolbox' of the 'dlf' extension
+ *
+ * @author Sebastian Meyer <sebastian.meyer@slub-dresden.de>
+ * @author Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin {
+    public $scriptRelPath = 'Classes/Plugin/Tools/SearchInDocumentTool.php';
+
+    /**
+     * The main method of the PlugIn
+     *
+     * @access public
+     *
+     * @param string $content: The PlugIn content
+     * @param array $conf: The PlugIn configuration
+     *
+     * @return string The content that is displayed on the website
+     */
+    public function main($content, $conf) {
+
+        $this->init($conf);
+
+        // Merge configuration with conf array of toolbox.
+        if (!empty($this->cObj->data['conf'])) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
+
+        $this->addSearchInDocumentJS();
+
+        // Load current document.
+        $this->loadDocument();
+        if ($this->doc === NULL
+            || $this->doc->numPages < 1
+            || empty($this->conf['fileGrpFulltext'])
+            || empty($this->conf['solrcore'])) {
+            // Quit without doing anything if required variables are not set.
+            return $content;
+        }
+        // Load template file.
+        $this->getTemplate();
+
+        // Configure @action URL for form.
+        $linkConf = array(
+            'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => 1
+        );
+
+        $encryptedSolr = $this->getEncryptedCoreName();
+        // Fill markers.
+        $markerArray = array(
+            '###ACTION_URL###' => $this->cObj->typoLink_URL($linkConf),
+            '###LABEL_QUERY###' => $this->pi_getLL('label.query'),
+            '###LABEL_DELETE_SEARCH###' => $this->pi_getLL('label.delete_search'),
+            '###LABEL_LOADING###' => $this->pi_getLL('label.loading'),
+            '###LABEL_SUBMIT###' => $this->pi_getLL('label.submit'),
+            '###LABEL_SEARCH_IN_DOCUMENT###' => $this->pi_getLL('label.searchInDocument'),
+            '###LABEL_NEXT###' => $this->pi_getLL('label.next'),
+            '###LABEL_PREVIOUS###' => $this->pi_getLL('label.previous'),
+            '###LABEL_PAGE###' => $this->pi_getLL('label.logicalPage'),
+            '###CURRENT_DOCUMENT###' => $this->doc->uid,
+            '###SOLR_ENCRYPTED###' => isset($encryptedSolr['encrypted']) ? $encryptedSolr['encrypted'] : '',
+            '###SOLR_HASH###' => isset($encryptedSolr['hash']) ? $encryptedSolr['hash'] : '',
+        );
+
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
+        return $this->pi_wrapInBaseClass($content);
+    }
+
+    /**
+     * Adds the JS files necessary for search in document
+     *
+     * @access protected
+     *
+     * @return void
+     */
+    protected function addSearchInDocumentJS() {
+        $pageRenderer = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/Search/SearchInDocument.js');
+    }
+
+    /**
+     * Get the encrypted Solr core name
+     *
+     * @access protected
+     *
+     * @return array with encrypted core name and hash
+     */
+    protected function getEncryptedCoreName() {
+        // Get core name.
+        $name = Helper::getIndexNameFromUid($this->conf['solrcore'], 'tx_dlf_solrcores');
+        // Encrypt core name.
+        if (!empty($name)) {
+            $name = Helper::encrypt($name);
+        }
+        return $name;
+    }
+}

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -56,6 +56,14 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin {
             // Quit without doing anything if required variables are not set.
             return $content;
         }
+
+        // Quit if no fulltext file is present
+        $fullTextFile = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
+        if (empty($fullTextFile)) {
+           return $content;
+        }
+
+
         // Load template file.
         $this->getTemplate();
 

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -60,9 +60,8 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         // Quit if no fulltext file is present
         $fullTextFile = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
         if (empty($fullTextFile)) {
-           return $content;
+            return $content;
         }
-
 
         // Load template file.
         $this->getTemplate();

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -64,7 +64,7 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
 
         // Load template file.
-        $this->getTemplate();
+        $this->getTemplate('###TEMPLATE###', '', TRUE);
 
         // Configure @action URL for form.
         $linkConf = array(

--- a/Configuration/Flexforms/Toolbox.xml
+++ b/Configuration/Flexforms/Toolbox.xml
@@ -55,6 +55,20 @@
                             </config>
                         </TCEforms>
                     </tools>
+                    <solrcore>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/Search.xml:tt_content.pi_flexform.solrcore</label>
+                            <config>
+                                <type>select</type>
+                                <items type="array"></items>
+                                <itemsProcFunc>Kitodo\Dlf\Hooks\FormEngine->itemsProcFunc_solrList</itemsProcFunc>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>0</minitems>
+                            </config>
+                        </TCEforms>
+                    </solrcore>
                     <fileGrpsImageDownload>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -960,6 +960,13 @@ Toolbox
        * tx_dlf_imagedownloadtool
        * tx_dlf_imagemanipulationtool
        * tx_dlf_pdfdownloadtool
+       * tx_dlf_searchindocumenttool
+
+ - :Property:
+       solrcore
+   :Data Type:
+       :ref:`t3tsref:data-type-integer`
+   :Default:
 
  - :Property:
        fileGrpsImageDownload

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -149,6 +149,7 @@
             <label index="tx_dlf_toolbox.imagedownloadtool">Image Download</label>
             <label index="tx_dlf_toolbox.imagemanipulationtool">Image Manipulation</label>
             <label index="tx_dlf_toolbox.pdfdownloadtool">PDF Download</label>
+            <label index="tx_dlf_toolbox.searchindocumenttool">Search in Document</label>
             <label index="tt_content.dlf_audioplayer">DLF: Audio Player</label>
             <label index="tt_content.dlf_basket">DLF: Basket</label>
             <label index="tt_content.dlf_calendar">DLF: Calendar</label>
@@ -322,6 +323,7 @@
             <label index="tx_dlf_toolbox.imagedownloadtool">Bild-Download</label>
             <label index="tx_dlf_toolbox.imagemanipulationtool">Bildbearbeitung</label>
             <label index="tx_dlf_toolbox.pdfdownloadtool">PDF-Download</label>
+            <label index="tx_dlf_toolbox.searchindocumenttool">Suche im Dokument</label>
             <label index="tt_content.dlf_audioplayer">DLF: Audioplayer</label>
             <label index="tt_content.dlf_basket">DLF: Warenkorb</label>
             <label index="tt_content.dlf_calendar">DLF: Kalender</label>

--- a/Resources/Private/Language/SearchInDocumentTool.xml
+++ b/Resources/Private/Language/SearchInDocumentTool.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+<T3locallang>
+    <meta type="array">
+        <type>module</type>
+        <description>Language labels for plugin SearchInDocumentTool</description>
+    </meta>
+    <data type="array">
+        <languageKey index="default" type="array">
+            <label index="label.query">Search for:</label>
+            <label index="label.submit">Search</label>
+            <label index="label.logicalPage">Page</label>
+            <label index="label.searchInDocument">Search in document</label>
+            <label index="label.delete_search">Delete Search</label>
+            <label index="label.next">next</label>
+            <label index="label.previous">previous</label>
+            <label index="search">Search</label>
+        </languageKey>
+        <languageKey index="de" type="array">
+            <label index="label.query">Suchen nach:</label>
+            <label index="label.submit">Suchen</label>
+            <label index="label.logicalPage">Seite</label>
+            <label index="label.searchInDocument">Im Dokument suchen</label>
+            <label index="label.delete_search">Suche löschen</label>
+            <label index="label.next">weiter</label>
+            <label index="label.previous">zurück</label>
+            <label index="search">Suche</label>
+        </languageKey>
+    </data>
+</T3locallang>

--- a/Resources/Private/Templates/SearchInDocumentTool.tmpl
+++ b/Resources/Private/Templates/SearchInDocumentTool.tmpl
@@ -1,0 +1,31 @@
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+<!-- ###TEMPLATE### -->
+<form class="tx-dlf-search-form" id="tx-dlf-search-in-document-form" action="###ACTION_URL###" method="post" enctype="multipart/form-data">
+  <div>
+    <label for="tx-dlf-search-query">###LABEL_QUERY###</label>
+    <!-- Never change the @id of this input field! Otherwise search won't work! -->
+    <input type="text" id="tx-dlf-search-in-document-query" placeholder="###LABEL_SEARCH_IN_DOCUMENT###" name="tx_dlf[query]"></input>
+    <input type="submit" value="###LABEL_SUBMIT###" onclick="resetStart();"/>
+    <input type="hidden" name="tx_dlf[start]" value="0" />
+    <input type="hidden" name="tx_dlf[id]" value="###CURRENT_DOCUMENT###" />
+    <input type="hidden" name="tx_dlf[encrypted]" value="###SOLR_ENCRYPTED###" />
+    <input type="hidden" name="tx_dlf[hash]" value="###SOLR_HASH###" />
+  </div>
+</form>
+<div id="tx-dlf-search-in-document-loading" style="display: none;">###LABEL_LOADING###...</div>
+<div id="tx-dlf-search-in-document-clearing">###LABEL_DELETE_SEARCH###...</div>
+<div id="tx-dlf-search-in-document-results"></div>
+<div id="tx-dlf-search-in-document-labels" style="display:none;">
+    <span id="tx-dlf-search-in-document-label-next">###LABEL_NEXT###</span>
+    <span id="tx-dlf-search-in-document-label-previous">###LABEL_PREVIOUS###</span>
+    <span id="tx-dlf-search-in-document-label-page">###LABEL_PAGE###</span>
+</div>
+<!-- ###TEMPLATE### -->

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -1,0 +1,129 @@
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+ /**
+  * This function increases the start parameter of the search form and submits
+  * the form.
+  *
+  * @param rows
+  * @returns void
+  */
+function nextResultPage(rows) {
+    var currentstart = $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val();
+    var newstart = parseInt(currentstart) + rows;
+    $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val(newstart);
+    $('#tx-dlf-search-in-document-form').submit();
+};
+
+/**
+ * This function decreases the start parameter of the search form and submits
+ * the form.
+ *
+ * @param rows
+ * @returns void
+ */
+function previousResultPage(rows) {
+    var currentstart = $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val();
+    currentstart = parseInt(currentstart);
+    var newstart = (currentstart > rows) ? (currentstart - rows) : 0;
+    $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val(newstart);
+    $('#tx-dlf-search-in-document-form').submit();
+};
+
+/**
+ * This function resets the start parameter on new queries.
+ *
+ * @returns void
+ */
+function resetStart() {
+    $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val(0);
+    $('#tx-dlf-search-in-document-form').submit();
+};
+
+$(document).ready(function() {
+    $("#tx-dlf-search-in-document-form").submit(function( event ) {
+      console.log(event);
+        // Stop form from submitting normally
+        event.preventDefault();
+        $('#tx-dlf-search-in-document-loading').show();
+        $('#tx-dlf-search-in-document-clearing').hide();
+        $('#tx-dlf-search-in-document-button-next').hide();
+        $('#tx-dlf-search-in-document-button-previous').hide();
+        // Send the data using post
+        $.post(
+            "/",
+            {
+                eID: "tx_dlf_search_in_document",
+                q: $( "input[name='tx_dlf[query]']" ).val(),
+                uid: $( "input[name='tx_dlf[id]']" ).val(),
+                start: $( "input[name='tx_dlf[start]']" ).val(),
+                encrypted: $( "input[name='tx_dlf[encrypted]']" ).val(),
+                hashed: $( "input[name='tx_dlf[hash]']" ).val(),
+            },
+            function(data) {
+              var resultItems = [];
+              var resultList = '<div class="results-active-indicator"></div><ul>';
+              if (data.error) {
+                  resultList += '<li>' + data.error + '</li>';
+              } else {
+                  for (var i=0; i < data.response.docs.length; i++) {
+
+                      var link_current = $(location).attr('href');
+                      var link_base = link_current.substring(0, link_current.indexOf('?'));
+                      var link_params = link_current.substring(link_base.length + 1, link_current.length);
+                      var link_id = link_params.match(/id=(\d)*/g);
+
+                      if (link_id) {
+                        link_params = link_id + '&';
+                      } else {
+                        link_params = '&';
+                      }
+
+                      var searchHit = data.highlighting[data.response.docs[i].id].fulltext.toString();
+                      searchHit = searchHit.substring(searchHit.indexOf('<em>')+4,searchHit.indexOf('</em>'));
+
+                      var newlink = link_base + '?' + (link_params
+                      + 'tx_dlf[id]=' + data.response.docs[i].uid
+                      + '&tx_dlf[highlight_word]=' + encodeURIComponent(searchHit)
+                      + '&tx_dlf[page]=' + (data.response.docs[i].page));
+
+                      if (data.highlighting[data.response.docs[i].id].fulltext) {
+                          resultItems[data.response.docs[i].page] = '<span class="structure">' + $('#tx-dlf-search-in-document-label-page').text() + ' ' + data.response.docs[i].page + '</span><br /><span ="textsnippet"><a href=\"' + newlink + '\">' + data.highlighting[data.response.docs[i].id].fulltext + '</a></span>';
+                      }
+                  }
+                  // sort by page as this cannot be done with current solr schema
+                  resultItems.sort(function(a, b){return a-b});
+                  resultItems.forEach(function(item, index){
+                      resultList += '<li>' + item + '</li>';
+                  });
+              }
+              resultList += '</ul>';
+              if (parseInt(data.response.start) > 0) {
+                  resultList += '<input type="button" id="tx-dlf-search-in-document-button-previous" class="button-previous" onclick="previousResultPage(' + data.responseHeader.params.rows + ');" value="' + $('#tx-dlf-search-in-document-label-previous').text() + '" />';
+              }
+              if (parseInt(data.response.numFound) > (parseInt(data.response.start) + parseInt(data.responseHeader.params.rows))) {
+                  resultList += '<input type="button" id="tx-dlf-search-in-document-button-next" class="button-next" onclick="nextResultPage(' + data.responseHeader.params.rows + ');" value="' + $('#tx-dlf-search-in-document-label-next').text() + '" />';
+              }
+              $('#tx-dlf-search-in-document-results').html(resultList);
+            },
+            "json"
+        )
+        .done(function( data ) {
+            $('#tx-dfgviewer-sru-results-loading').hide();
+            $('#tx-dfgviewer-sru-results-clearing').show();
+        });
+    });
+      // clearing button
+    $('#tx-dlf-search-in-document-clearing').click(function() {
+        $('#tx-dlf-search-in-document-results ul').remove();
+        $('.results-active-indicator').remove();
+        $('#tx-dlf-search-in-document-query').val('');
+    });
+});

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -57,12 +57,15 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['too
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_imagemanipulationtool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.imagemanipulationtool';
 \Kitodo\Dlf\Hooks\ExtensionManagementUtility::addPItoST43($_EXTKEY, \Kitodo\Dlf\Plugin\Tools\PdfDownloadTool::class, '_pdfdownloadtool', '', TRUE);
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_pdfdownloadtool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.pdfdownloadtool';
+\Kitodo\Dlf\Hooks\ExtensionManagementUtility::addPItoST43($_EXTKEY, \Kitodo\Dlf\Plugin\Tools\SearchInDocumentTool::class, '_searchindocumenttool', '', TRUE);
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY).'_searchindocumenttool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.searchindocumenttool';
 // Register hooks.
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \Kitodo\Dlf\Hooks\DataHandler::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = \Kitodo\Dlf\Hooks\DataHandler::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Common/MetsDocument.php']['hookClass'][] = \Kitodo\Dlf\Hooks\KitodoProductionHacks::class;
 // Register AJAX eID handlers.
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_suggest'] = \Kitodo\Dlf\Plugin\Eid\SearchSuggest::class.'::main';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_in_document'] = \Kitodo\Dlf\Plugin\Eid\SearchInDocument::class.'::main';
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_pageview_proxy'] = \Kitodo\Dlf\Plugin\Eid\PageViewProxy::class.'::main';
 // Register Typoscript user function.
 if (TYPO3_MODE === 'FE') {


### PR DESCRIPTION
This adds a input field to the toolbox in case a fulltext file is
present. The search is executed only in this document. 20 results are
listed and you may page through all results in pages with 20 items.

The search is inspired by the SRU search in DFG-Viewer.

Please note: there is no design provided for this feature (as usual in
Kitodo.Presentation).