### PR TITLE
Add caching of raw solr queries

### DIFF
--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -367,7 +367,7 @@ class Solr {
         $parameters['query'] = $query;
 
         // calculate cache identifier
-        $cacheIdentifier = hash('md5', print_r(array_merge($this->params, $parameters),1));
+        $cacheIdentifier = hash('md5', print_r(array_merge($this->params, $parameters), 1));
         $cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('kitodo_solr');
 
         $resultSet = [];

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -368,21 +368,22 @@ class Solr {
 
         // calculate cache identifier
         $cacheIdentifier = hash('md5', print_r(array_merge($this->params, $parameters),1));
-        $cache = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('kitodo_solr');
+        $cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('kitodo_solr');
 
+        $resultSet = [];
         if (($entry = $cache->get($cacheIdentifier)) === FALSE) {
             $selectQuery = $this->service->createSelect(array_merge($this->params, $parameters));
             $result = $this->service->select($selectQuery);
-            $resultSet = [];
             foreach ($result as $doc) {
                 $resultSet[] = $doc;
             }
-            $entry = $resultSet;
-
             // Save value in cache
-            $cache->set($cacheIdentifier, $entry);
+            $cache->set($cacheIdentifier, $resultSet);
+        } else {
+            // return cache hit
+            $resultSet = $entry;
         }
-        return $entry;
+        return $resultSet;
     }
 
     /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -64,6 +64,18 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Common/MetsDocument.php']
 // Register AJAX eID handlers.
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_search_suggest'] = \Kitodo\Dlf\Plugin\Eid\SearchSuggest::class.'::main';
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_pageview_proxy'] = \Kitodo\Dlf\Plugin\Eid\PageViewProxy::class.'::main';
+
+// add caching framework for Solr queries
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['kitodo_solr'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['kitodo_solr'] = array();
+}
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['kitodo_solr']['backend'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['kitodo_solr']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\SimpleFileBackend';
+}
+// set defaultLifeTime to 1 day (87600s)
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['kitodo_solr']['options']['defaultLifeTime'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['kitodo_solr']['options']['defaultLifeTime'] = 87600;
+}
 // Register Typoscript user function.
 if (TYPO3_MODE === 'FE') {
     /**


### PR DESCRIPTION
This adds the support of Caching of queries done via the search_raw() function, used by the collection and oaipmh-plugin.

The collection plugin fetches all information about collections and documents from Solr now. With many and huge collections this can exceed the configured timeout. As the collection plugin doesn't cache the result, each visit will resubmit the solr queries. This is an unnecessary load for the Solr which can be simple avoided by caching the results through the [TYPO3 Caching Framework](https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/ApiOverview/CachingFramework/Developer/Index.html).

It's preconfigured to use the SimpleFileBackend with an LifeTime of 1 day. It's easy to use an other Caching-Backend or to change the default lifetime. Using the Null-Backend could disable the caching.
