### PR TITLE
Fix loop on indexing documents

### DIFF
--- a/hooks/class.tx_dlf_tcemain.php
+++ b/hooks/class.tx_dlf_tcemain.php
@@ -338,7 +338,7 @@ class tx_dlf_tcemain {
 
                                 if ($doc->ready) {
 
-                                    $doc->save($doc->pid, $core);
+                                    tx_dlf_indexing::add($doc, $core);
 
                                 } else {
 
@@ -424,7 +424,7 @@ class tx_dlf_tcemain {
 
                         if ($doc->ready) {
 
-                            $doc->save($doc->pid, $core);
+                            tx_dlf_indexing::add($doc, $core);
 
                         } else {
 


### PR DESCRIPTION
Current code ends in an endless loop on saving documents to database.

The stacktrace by xdebug is as follow:

tx_dlf_modIndexing->main( )	.../index.php:383
tx_dlf_document->save( )	.../index.php:226
tx_dlf_helper::processDB( )	.../class.tx_dlf_document.php:1777
TYPO3\CMS\Core\DataHandling\DataHandler->process_datamap( )	.../class.tx_dlf_helper.php:945
TYPO3\CMS\Core\DataHandling\DataHandler->hook_processDatamap_afterDatabaseOperations( )	.../DataHandler.php:1354
tx_dlf_tcemain->processDatamap_afterDatabaseOperations( )	.../DataHandler.php:921
tx_dlf_document->save( )	.../class.tx_dlf_tcemain.php:340
tx_dlf_helper::processDB( )	.../class.tx_dlf_document.php:1777
[..]

A fix has already been pushed to master. This is the backport of
2763d4df579c5fc721791844e253da7992fffb03