### PR TITLE
Fix calendar view of newspaper and ephemera

### DIFF
--- a/Configuration/TCA/tx_dlf_documents.php
+++ b/Configuration/TCA/tx_dlf_documents.php
@@ -305,6 +305,26 @@ return array (
                 'maxitems' => 1,
             ),
         ),
+        'mets_label' => array (
+            'exclude' => 1,
+            'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_documents.mets_label',
+            'config' => array (
+                'type' => 'input',
+                'size' => 30,
+                'max' => 255,
+                'eval' => 'trim',
+            ),
+        ),
+        'mets_orderlabel' => array (
+            'exclude' => 1,
+            'label' => 'LLL:EXT:dlf/locallang.xml:tx_dlf_documents.mets_orderlabel',
+            'config' => array (
+                'type' => 'input',
+                'size' => 30,
+                'max' => 255,
+                'eval' => 'trim',
+            ),
+        ),
         'solrcore' => array (
             'config' => array (
                 'type' => 'passthrough',
@@ -331,7 +351,7 @@ return array (
     ),
     'palettes' => array (
         '1' => array ('showitem' => 'title_sorting', 'canNotCollapse' => 1),
-        '2' => array ('showitem' => 'partof, thumbnail, --linebreak--, volume, volume_sorting', 'canNotCollapse' => 1),
+        '2' => array ('showitem' => 'partof, thumbnail, --linebreak--, volume, volume_sorting, --linebreak--, mets_label, mets_orderlabel', 'canNotCollapse' => 1),
         '3' => array ('showitem' => 'starttime, endtime', 'canNotCollapse' => 1),
     )
 );

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -952,19 +952,19 @@ final class tx_dlf_document {
      *
      * @access	public
      *
-     * @param	array	$titledata: the tiledata array
+     * @param	array	$tiledata: the tiledata array
      *
      */
-    protected function setTitledataFromMets(&$metadata) {
-        if ( empty($metadata['year'][0]) ) {
+    protected function setTitledataFromMets(&$tiledata) {
+        if ( empty($tiledata['year'][0]) ) {
             $divs = $this->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]//mets:div[@ADMID]'); // search first admid section
             if (!empty($divs)) {
                 $details = $this->getLogicalStructureInfo($divs[0]);
                 if ( $details['type'] == 'year' ) {
                     // eg (mets v2.3.1): TYPE=“year“ ORDERLABEL=”1983/1984” LABEL=“Spielzeit 1983/1984“
-                    $metadata['year'][0] = $metadata['volume'][0] = $metadata['volume_sorting'][0] = $details['orderlabel'];
+                    $tiledata['year'][0] = $tiledata['volume'][0] = $tiledata['volume_sorting'][0] = $details['orderlabel'];
                     if ( !empty( $details['label'] ) ) {
-                         $metadata['volume'][0] = $details['label'];
+                         $tiledata['volume'][0] = $details['label'];
                     }
                 }
             }

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -354,12 +354,8 @@ final class tx_dlf_document {
     public function addMetadataFromMets(&$metadata, $id) {
         $details = $this->getLogicalStructure($id);
         if (!empty($details)) {
-            if (empty($metadata['volume_sorting'][0])) {
-                $metadata['volume_sorting'][0] = !empty($details['orderlabel']) ? $details['orderlabel'] : $details['label'];
-            }
-            if (empty($metadata['volume'][0])) {
-                $metadata['volume'][0] = !empty($details['label']) ? $details['label'] : $details['orderlabel'];
-            }
+            $metadata['mets_label'][0] = $details['label'];
+            $metadata['mets_orderlabel'][0] = $details['orderlabel'];
             // Set publication date to @ORDERLABEL only for calendar.
             if ($details['type'] == 'year' && empty($metadata['year'][0])) {
                 $metadata['year'][0] = $details['orderlabel'];
@@ -608,6 +604,8 @@ final class tx_dlf_document {
 
         $details['dmdId'] = (isset($attributes['DMDID']) ? $attributes['DMDID'] : '');
 
+        $details['order'] = (isset($attributes['ORDER']) ? $attributes['ORDER'] : '');
+
         $details['label'] = (isset($attributes['LABEL']) ? $attributes['LABEL'] : '');
 
         $details['orderlabel'] = (isset($attributes['ORDERLABEL']) ? $attributes['ORDERLABEL'] : '');
@@ -778,6 +776,8 @@ final class tx_dlf_document {
             'volume_sorting' => array (),
             'collection' => array (),
             'owner' => array (),
+            'mets_label' => array (),
+            'mets_orderlabel' => array (),
         );
 
         // Get the logical structure node's DMDID.
@@ -1791,6 +1791,8 @@ final class tx_dlf_document {
             'volume_sorting' => $metadata['volume_sorting'][0],
             'collections' => $metadata['collection'],
             'owner' => $metadata['owner'][0],
+            'mets_label' => $metadata['mets_label'][0],
+            'mets_orderlabel' => $metadata['mets_orderlabel'][0],
             'solrcore' => $core,
             'status' => 0,
         );
@@ -2147,6 +2149,8 @@ final class tx_dlf_document {
 
                 $this->physicalStructureInfo[$physSeq[0]]['dmdId'] = (isset($physNode[0]['DMDID']) ? (string) $physNode[0]['DMDID'] : '');
 
+                $this->physicalStructureInfo[$physSeq[0]]['order'] = (isset($physNode[0]['ORDER']) ? (string) $physNode[0]['ORDER'] : '');
+
                 $this->physicalStructureInfo[$physSeq[0]]['label'] = (isset($physNode[0]['LABEL']) ? (string) $physNode[0]['LABEL'] : '');
 
                 $this->physicalStructureInfo[$physSeq[0]]['orderlabel'] = (isset($physNode[0]['ORDERLABEL']) ? (string) $physNode[0]['ORDERLABEL'] : '');
@@ -2175,6 +2179,8 @@ final class tx_dlf_document {
                     $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['id'] = (string) $elementNode['ID'];
 
                     $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['dmdId'] = (isset($elementNode['DMDID']) ? (string) $elementNode['DMDID'] : '');
+
+                    $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['order'] = (isset($elementNode['ORDER']) ? (string) $elementNode['ORDER'] : '');
 
                     $this->physicalStructureInfo[$elements[(int) $elementNode['ORDER']]]['label'] = (isset($elementNode['LABEL']) ? (string) $elementNode['LABEL'] : '');
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -962,7 +962,7 @@ final class tx_dlf_document {
                 $details = $this->getLogicalStructureInfo($divs[0]);
                 if ( $details['type'] == 'year' ) {
                     // eg (mets v2.3.1): TYPE=“year“ ORDERLABEL=”1983/1984” LABEL=“Spielzeit 1983/1984“
-                    $tiledata['year'][0] = $tiledata['volume'][0] = $tiledata['volume_sorting'][0] = $details['orderlabel'];
+                    $tiledata['year'][0] = $tiledata['title'][0] = $tiledata['volume'][0] = $tiledata['volume_sorting'][0] = $details['orderlabel'];
                     if ( !empty( $details['label'] ) ) {
                          $tiledata['volume'][0] = $details['label'];
                     }
@@ -1203,6 +1203,7 @@ final class tx_dlf_document {
         $titledata = $this->getMetadata($this->_getToplevelId(), $cPid);
 
         $this->setTitledataFromMets($titledata);
+
         // Set record identifier for METS file if not present.
         if (is_array($titledata) && array_key_exists('record_id', $titledata)) {
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -948,6 +948,30 @@ final class tx_dlf_document {
     }
 
     /**
+     * This sets the titledata based from mets in year files.
+     *
+     * @access	public
+     *
+     * @param	array	$titledata: the tiledata array
+     *
+     */
+    protected function setTitledataFromMets(&$metadata) {
+        if ( empty($metadata['year'][0]) ) {
+            $divs = $this->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]//mets:div[@ADMID]'); // search first admid section
+            if (!empty($divs)) {
+                $details = $this->getLogicalStructureInfo($divs[0]);
+                if ( $details['type'] == 'year' ) {
+                    // eg (mets v2.3.1): TYPE=“year“ ORDERLABEL=”1983/1984” LABEL=“Spielzeit 1983/1984“
+                    $metadata['year'][0] = $metadata['volume'][0] = $metadata['volume_sorting'][0] = $details['orderlabel'];
+                    if ( !empty( $details['label'] ) ) {
+                         $metadata['volume'][0] = $details['label'];
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * This returns the first corresponding physical page number of a given logical page label
      *
      * @access	public
@@ -1178,6 +1202,7 @@ final class tx_dlf_document {
 
         $titledata = $this->getMetadata($this->_getToplevelId(), $cPid);
 
+        $this->setTitledataFromMets($titledata);
         // Set record identifier for METS file if not present.
         if (is_array($titledata) && array_key_exists('record_id', $titledata)) {
 

--- a/common/class.tx_dlf_document.php
+++ b/common/class.tx_dlf_document.php
@@ -352,7 +352,7 @@ final class tx_dlf_document {
      * @return  void
      */
     public function addMetadataFromMets(&$metadata, $id) {
-        $details = $this->getLogicalStructureInfo($id);
+        $details = $this->getLogicalStructure($id);
         if (!empty($details)) {
             if (empty($metadata['volume_sorting'][0])) {
                 $metadata['volume_sorting'][0] = !empty($details['orderlabel']) ? $details['orderlabel'] : $details['label'];

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -33,6 +33,8 @@ CREATE TABLE tx_dlf_documents (
     volume_sorting varchar(255) DEFAULT '' NOT NULL,
     collections int(11) DEFAULT '0' NOT NULL,
     owner int(11) DEFAULT '0' NOT NULL,
+    mets_label varchar(255) DEFAULT '' NOT NULL,
+    mets_orderlabel varchar(255) DEFAULT '' NOT NULL,
     solrcore int(11) DEFAULT '0' NOT NULL,
     status smallint(6) unsigned DEFAULT '0' NOT NULL,
 

--- a/locallang.xml
+++ b/locallang.xml
@@ -47,6 +47,8 @@
 			<label index="tx_dlf_documents.volume_sorting">Number of Volume (Sorting)</label>
 			<label index="tx_dlf_documents.collections">Collections</label>
 			<label index="tx_dlf_documents.owner">Owner</label>
+			<label index="tx_dlf_documents.mets_label">METS @LABEL</label>
+			<label index="tx_dlf_documents.mets_orderlabel">METS @ORDERLABEL</label>
 			<label index="tx_dlf_documents.status">Status</label>
 			<label index="tx_dlf_documents.status.default">default</label>
 			<label index="tx_dlf_documents.tab1">Titledata</label>
@@ -145,7 +147,7 @@
 			<label index="tx_dlf_toolbox.toolsFulltext">Fulltext</label>
 			<label index="tx_dlf_toolbox.toolsImagemanipulation">Image Manipulation</label>
 			<label index="tx_dlf_toolbox.toolsImagedownload">Image Download</label>
-      <label index="tx_dlf_toolbox.toolsSearchindocument">Search in Document</label>
+            <label index="tx_dlf_toolbox.toolsSearchindocument">Search in Document</label>
 			<label index="tt_content.dlf_audioplayer">DLF: Audio Player</label>
 			<label index="tt_content.dlf_basket">DLF: Basket</label>
 			<label index="tt_content.dlf_collection">DLF: Collection</label>
@@ -261,6 +263,8 @@
 			<label index="tx_dlf_documents.volume_sorting">Bandnummer (Sortierung)</label>
 			<label index="tx_dlf_documents.collections">Sammlungen</label>
 			<label index="tx_dlf_documents.owner">Besitzer</label>
+			<label index="tx_dlf_documents.mets_label">METS @LABEL</label>
+			<label index="tx_dlf_documents.mets_orderlabel">METS @ORDERLABEL</label>
 			<label index="tx_dlf_documents.status">Status</label>
 			<label index="tx_dlf_documents.status.default">Standard</label>
 			<label index="tx_dlf_documents.tab1">Titeldaten</label>
@@ -359,7 +363,7 @@
 			<label index="tx_dlf_toolbox.toolsFulltext">Volltext</label>
 			<label index="tx_dlf_toolbox.toolsImagemanipulation">Bildbearbeitung</label>
 			<label index="tx_dlf_toolbox.toolsImagedownload">Bild-Download</label>
-      <label index="tx_dlf_toolbox.toolsSearchindocument">Suche im Dokument</label>
+            <label index="tx_dlf_toolbox.toolsSearchindocument">Suche im Dokument</label>
 			<label index="tt_content.dlf_audioplayer">DLF: Audioplayer</label>
 			<label index="tt_content.dlf_basket">DLF: Warenkorb</label>
 			<label index="tt_content.dlf_collection">DLF: Kollektion</label>

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -80,7 +80,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         // Get all children of year anchor.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_documents.uid AS uid, tx_dlf_documents.volume AS volume, tx_dlf_documents.title AS title, tx_dlf_documents.year AS year',
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.volume AS volume, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.title AS title, tx_dlf_documents.year AS year',
             'tx_dlf_documents',
             '(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('issue', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -411,7 +411,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         // Process results.
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             $years[] = array (
-                'title' => !empty($resArray['label']) ? $resArray['label'] : $resArray['orderlabel'],
+                'title' => !empty($resArray['label']) ? $resArray['label'] : !empty($resArray['orderlabel']) ? $resArray['orderlabel'] : $resArray['title'],
                 'uid' => $resArray['uid']
             );
         }

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -80,7 +80,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         // Get all children of year anchor.
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_documents.uid AS uid, tx_dlf_documents.volume AS volume, tx_dlf_documents.volume_sorting AS volume_sorting, tx_dlf_documents.title AS title, tx_dlf_documents.year AS year',
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.volume AS volume, tx_dlf_documents.title AS title, tx_dlf_documents.year AS year',
             'tx_dlf_documents',
             '(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('issue', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',
@@ -93,7 +93,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
             $issues[] = array (
                 'uid' => $resArray['uid'],
-                'title' => !empty($resArray['title']) ? $resArray['title'] : !empty($resArray['volume']) ? $resArray['volume'] : (strftime('%x', strtotime($resArray['volume_sorting']))),
+                'title' => !empty($resArray['title']) ? $resArray['title'] : strtotime($resArray['volume']) !== FALSE ? strftime('%x', strtotime($resArray['volume'])) : $resArray['volume'],
                 'year' => $resArray['year']
             );
 

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -395,7 +395,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
             'tx_dlf_documents',
             '(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('year', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',
-            'volume_sorting ASC',
+            'tx_dlf_documents.volume_sorting ASC',
             ''
         );
 

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -102,7 +102,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
             $issues[] = array (
                 'uid' => $resArray['uid'],
-                'title' => $title,
+                'title' => !empty($title) ? $title : $resArray['year'],
                 'year' => $resArray['year']
             );
 

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -402,7 +402,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         // Process results.
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             $years[ $resArray['volume'] ] = array (
-                'title' => $resArray['volume'],
+                'title' => !empty($resArray['volume']) ? $resArray['volume'] : $resArray['volume_sorting'],
                 'uid' => $resArray['uid']
             );
         }

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -145,7 +145,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         );
 
         $titleData = $this->doc->getTitledata();
-        $title = empty($titleData['mets_orderlabel'][0]) ? $titleData['mets_orderlabel'][0] : $titleData['mets_label'][0];
+        $title = !empty($titleData['mets_orderlabel'][0]) ? $titleData['mets_orderlabel'][0] : $titleData['mets_label'][0];
 
         $yearLink = $this->cObj->typoLink($title, $linkConf);
 
@@ -411,7 +411,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         // Process results.
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             $years[] = array (
-                'title' => !empty($resArray['label']) ? $resArray['label'] : !empty($resArray['orderlabel']) ? $resArray['orderlabel'] : $resArray['title'],
+                'title' => !empty($resArray['label']) ? $resArray['label'] : (!empty($resArray['orderlabel']) ? $resArray['orderlabel'] : $resArray['title']),
                 'uid' => $resArray['uid']
             );
         }

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -193,9 +193,6 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         $subparts['singleday'] = $this->cObj->getSubpart($subparts['list'], '###SINGLEDAY###');
 
-        // Build calendar for given year.
-        // $year = date('Y', strtotime($issues[0]['year']));
-
         for ($i = 0; $i <= 11; $i++) {
 
             $markerArray = array (
@@ -442,16 +439,16 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
     }
     
     function setVolumeFromMets(&$resArray) {
-            if ( empty($resArray['volume']) ) {
-                $yearDoc = & tx_dlf_document::getInstance($resArray['uid'], $pid);
-                if ( $yearDoc->ready==true ) {
-                    $metadata = $yearDoc->getTitledata();
-                    if ( !empty($metadata['volume'][0]) ) {
-                        $resArray['volume'] = $metadata['volume'][0];
-                        return true;
-                    }
+        if ( empty($resArray['volume']) ) {
+            $yearDoc = & tx_dlf_document::getInstance($resArray['uid'], $pid);
+            if ( $yearDoc->ready==true ) {
+                $metadata = $yearDoc->getTitledata();
+                if ( !empty($metadata['volume'][0]) ) {
+                    $resArray['volume'] = $metadata['volume'][0];
+                    return true;
                 }
             }
+        }
     }
 
 }

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -145,7 +145,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         );
 
         $titleData = $this->doc->getTitledata();
-        $title = empty($titleData['title'][0]) ? $titleData['volume'][0] : $titleData['title'][0];
+        $title = empty($titleData['mets_orderlabel'][0]) ? $titleData['mets_orderlabel'][0] : $titleData['mets_label'][0];
 
         $yearLink = $this->cObj->typoLink($title, $linkConf);
 

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -25,6 +25,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
     public $scriptRelPath = 'plugins/newspaper/class.tx_dlf_newspaper.php';
     
     private $allIssues = array ();
+    private $calendarRenderStart = false;
 
     /**
      * The main method of the PlugIn
@@ -244,6 +245,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
                         $currentMonth = date('n', $currentDayTime);
 
                         if (is_array($calendarIssues[$currentMonth])) {
+                            $this->calendarRenderStart = true;
 
                             foreach ($calendarIssues[$currentMonth] as $id => $day) {
 
@@ -322,11 +324,14 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
             }
 
-            // Fill the month markers.
-            $subPartContent .= $this->cObj->substituteMarkerArray($subparts['month'], $markerArray);
+            // render calender only if a issue in this month is present
+            if (  $this->calendarRenderStart === true ) {
+                // Fill the month markers.
+                $subPartContent .= $this->cObj->substituteMarkerArray($subparts['month'], $markerArray);
 
-            // Fill the week markers with the week entries.
-            $subPartContent = $this->cObj->substituteSubpart($subPartContent, '###CALWEEK###', $subWeekPartContent);
+                // Fill the week markers with the week entries.
+                $subPartContent = $this->cObj->substituteSubpart($subPartContent, '###CALWEEK###', $subWeekPartContent);
+            }
         }
         return $subPartContent;
     }

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -25,7 +25,6 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
     public $scriptRelPath = 'plugins/newspaper/class.tx_dlf_newspaper.php';
 
     private $allIssues = array ();
-    private $calendarRenderStart = false;
 
     /**
      * The main method of the PlugIn
@@ -141,7 +140,6 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         $yearLink = $this->cObj->typoLink($title, $linkConf);
 
-
         // Get subpart templates.
         $subparts['list'] = $this->cObj->getSubpart($this->template, '###ISSUELIST###');
         $subparts['singleday'] = $this->cObj->getSubpart($subparts['list'], '###SINGLEDAY###');
@@ -165,7 +163,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         $this->template = $this->cObj->substituteSubpart($this->template, '###SINGLEDAY###', $subPartContentList);
 
-        if (count($allIssues) < 6) {
+        if (count($this->allIssues) < 6) {
 
             $listViewActive = TRUE;
 
@@ -402,7 +400,6 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         );
 
         // Process results.
-        $arraySort = false;
         while ($resArray = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($result)) {
             $years[ $resArray['volume'] ] = array (
                 'title' => $resArray['volume'],

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -391,7 +391,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         // get all children of anchor. this should be the year anchor documents
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_documents.uid AS uid, tx_dlf_documents.volume AS volume',
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.volume AS volume, tx_dlf_documents.volume_sorting AS volume_sorting',
             'tx_dlf_documents',
             '(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('year', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -93,7 +93,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
             $issues[] = array (
                 'uid' => $resArray['uid'],
-                'title' => $resArray['title'] ? $resArray['title'] : (strftime('%x', strtotime($resArray['volume']))),
+                'title' => !empty($resArray['title']) ? $resArray['title'] : !empty($resArray['volume']) ? $resArray['volume'] : (strftime('%x', strtotime($resArray['volume_sorting']))),
                 'year' => $resArray['year']
             );
 

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -111,7 +111,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
         $lastMonth = 12;
         foreach ($calendarIssuesByYear as $year => $calendarIssues) {
             // show calendar from first issue in case of seasons
-            if (empty($conf['showEmptyMonths'])) {
+            if (empty($this->conf['showEmptyMonths'])) {
                 $firstMonth = key($calendarIssues);
                 end($calendarIssues);
                 $lastMonth = key($calendarIssues);

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -404,7 +404,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
             'tx_dlf_documents',
             '(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('year', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',
-            'tx_dlf_documents.mets_orderlabel ASC',
+            'tx_dlf_documents.mets_orderlabel, tx_dlf_documents.title_sorting ASC',
             ''
         );
 

--- a/plugins/newspaper/class.tx_dlf_newspaper.php
+++ b/plugins/newspaper/class.tx_dlf_newspaper.php
@@ -400,7 +400,7 @@ class tx_dlf_newspaper extends tx_dlf_plugin {
 
         // get all children of anchor. this should be the year anchor documents
         $result = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-            'tx_dlf_documents.uid AS uid, tx_dlf_documents.mets_label AS label, tx_dlf_documents.mets_orderlabel AS orderlabel',
+            'tx_dlf_documents.uid AS uid, tx_dlf_documents.mets_label AS label, tx_dlf_documents.mets_orderlabel AS orderlabel, tx_dlf_documents.title AS title',
             'tx_dlf_documents',
             '(tx_dlf_documents.structure='.tx_dlf_helper::getIdFromIndexName('year', 'tx_dlf_structures', $this->doc->pid).' AND tx_dlf_documents.partof='.intval($this->doc->uid).')'.tx_dlf_helper::whereClause('tx_dlf_documents'),
             '',

--- a/plugins/newspaper/flexform.xml
+++ b/plugins/newspaper/flexform.xml
@@ -46,7 +46,7 @@
                         <label>LLL:EXT:dlf/plugins/newspaper/locallang.xml:tt_content.pi_flexform.showEmptyMonths</label>
                         <config>
                           <type>check</type>
-                          <default>0</default>
+                          <default>1</default>
                         </config>
                       </TCEforms>
                     </showEmptyMonths>

--- a/plugins/newspaper/flexform.xml
+++ b/plugins/newspaper/flexform.xml
@@ -40,6 +40,16 @@
                             </config>
                         </TCEforms>
                     </pages>
+                    <showEmptyMonths>
+                      <TCEforms>
+                        <exclude>1</exclude>
+                        <label>LLL:EXT:dlf/plugins/newspaper/locallang.xml:tt_content.pi_flexform.showEmptyMonths</label>
+                        <config>
+                          <type>check</type>
+                          <default>0</default>
+                        </config>
+                      </TCEforms>
+                    </showEmptyMonths>
                     <templateFile>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/plugins/newspaper/locallang.xml
+++ b/plugins/newspaper/locallang.xml
@@ -17,6 +17,7 @@
         <languageKey index="default" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Options</label>
             <label index="tt_content.pi_flexform.templateFile">Template file</label>
+            <label index="tt_content.pi_flexform.showEmptyMonths">Show empty months in calendar.</label>
             <label index="allYears">All years overview - </label>
             <label index="label.please_choose_year">Please choose a year first.</label>
             <label index="label.view_calendar">Calendar</label>
@@ -25,6 +26,7 @@
         <languageKey index="de" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
             <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
+            <label index="tt_content.pi_flexform.showEmptyMonths">Zeige leere Monate in Kalender.</label>
             <label index="allYears">Jahrgangsübersicht - </label>
             <label index="label.please_choose_year">Bitte wählen Sie zunächst einen Jahrgang aus.</label>
             <label index="label.view_calendar">Kalender</label>

--- a/plugins/newspaper/locallang.xml
+++ b/plugins/newspaper/locallang.xml
@@ -17,7 +17,7 @@
         <languageKey index="default" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Options</label>
             <label index="tt_content.pi_flexform.templateFile">Template file</label>
-            <label index="tt_content.pi_flexform.showEmptyMonths">Show empty months in calendar.</label>
+            <label index="tt_content.pi_flexform.showEmptyMonths">Show months without issues in calendar?</label>
             <label index="allYears">All years overview - </label>
             <label index="label.please_choose_year">Please choose a year first.</label>
             <label index="label.view_calendar">Calendar</label>
@@ -26,7 +26,7 @@
         <languageKey index="de" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
             <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
-            <label index="tt_content.pi_flexform.showEmptyMonths">Zeige leere Monate in Kalender.</label>
+            <label index="tt_content.pi_flexform.showEmptyMonths">Zeige Monate ohne Ausgaben im Kalender?</label>
             <label index="allYears">Jahrgangsübersicht - </label>
             <label index="label.please_choose_year">Bitte wählen Sie zunächst einen Jahrgang aus.</label>
             <label index="label.view_calendar">Kalender</label>

--- a/plugins/newspaper/template.tmpl
+++ b/plugins/newspaper/template.tmpl
@@ -23,6 +23,7 @@
     </div>
     <div class="calendar-view">
         <!-- ###CALMONTH### begin -->
+        ###CALYEAR###
         <table class="month">
             <caption>###MONTHNAME###</caption>
             <tr>


### PR DESCRIPTION
This is a possible solution to fix the newspaper plugin. 

With the changed METS-structure of the [application profile v2.3.1](http://www.dfg-viewer.de/fileadmin/groups/dfgviewer/METS_application_profile_2.3.1.pdf) the are several bugs in the view
* The year overview does not show the year but the title of the workview page
* The toc plugin does not show the years but the structure label
* In case of seasons, all issues of different years are mapped to the first year

The provided solution fixes indexing volume, volume_sorting, year and title in case of year and anchor files.

Additionally the calendar plugin is fixed to show seasons from the first to the last issue. E.g. from August 1879 to July 1880.