### PR TITLE
Fix handling of tools' templates

### DIFF
--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -66,26 +66,16 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin 
      *
      * @return void
      */
-    protected function getTemplate($part = '###TEMPLATE###', $directory = '', $tool = FALSE) {
+    protected function getTemplate($part = '###TEMPLATE###') {
         $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class);
         if (!empty($this->conf['templateFile'])) {
             // Load template file from configuration.
-            if ($tool) {
-                $templateLocation = 'EXT:'.$this->extKey.'/Resources/Private/Templates/'.Helper::getUnqualifiedClassName(get_class($this)).'.tmpl';
-                $this->template = $this->templateService->getSubpart($this->cObj->fileResource($templateLocation), $part);
-            } else {
-                $this->template = $this->templateService->getSubpart($this->cObj->fileResource($this->conf['templateFile']), $part);
-            }
+            $templateFile = $this->conf['templateFile'];
         } else {
-            if (empty($directory)) {
-                $templateLocation = 'EXT:'.$this->extKey.'/Resources/Private/Templates/' . Helper::getUnqualifiedClassName(get_class($this)) . '.tmpl';
-            } else {
-                $templateLocation = 'EXT:'.$this->extKey.'/Resources/Private/Templates/'. $directory . '/' . Helper::getUnqualifiedClassName(get_class($this)) . '.tmpl';
-            }
-
-            // Load default template file.
-            $this->template = $this->templateService->getSubpart($this->cObj->fileResource($templateLocation), $part);
+            // Load default template from extension.
+            $templateFile = 'EXT:'.$this->extKey.'/Resources/Private/Templates/' . Helper::getUnqualifiedClassName(get_class($this)) . '.tmpl';
         }
+        $this->template = $this->templateService->getSubpart($this->cObj->fileResource($templateFile), $part);
     }
 
     /**

--- a/Classes/Plugin/Tools/AnnotationTool.php
+++ b/Classes/Plugin/Tools/AnnotationTool.php
@@ -69,7 +69,7 @@ class AnnotationTool extends AbstractPlugin {
             $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
         // Load template file.
-        $this->getTemplate('###TEMPLATE###', '', TRUE);
+        $this->getTemplate();
         $annotationContainers = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['annotationContainers'];
         if ($annotationContainers != null && sizeof($annotationContainers)>0) {
             $markerArray['###ANNOTATION_SELECT###'] = '<a class="select switchoff" id="tx-dlf-tools-annotations" title="" data-dic="annotations-on:'

--- a/Classes/Plugin/Tools/FulltextTool.php
+++ b/Classes/Plugin/Tools/FulltextTool.php
@@ -65,7 +65,7 @@ class FulltextTool extends \Kitodo\Dlf\Common\AbstractPlugin {
             $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
         // Load template file.
-        $this->getTemplate('###TEMPLATE###', '', TRUE);
+        $this->getTemplate();
         $fullTextFile = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
         if (!empty($fullTextFile)) {
             $markerArray['###FULLTEXT_SELECT###'] = '<a class="select switchoff" id="tx-dlf-tools-fulltext" title="" data-dic="fulltext-on:'.$this->pi_getLL('fulltext-on', '', TRUE).';fulltext-off:'.$this->pi_getLL('fulltext-off', '', TRUE).'">&nbsp;</a>';

--- a/Classes/Plugin/Tools/ImageDownloadTool.php
+++ b/Classes/Plugin/Tools/ImageDownloadTool.php
@@ -64,7 +64,7 @@ class ImageDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
             $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
         // Load template file.
-        $this->getTemplate('###TEMPLATE###', '', TRUE);
+        $this->getTemplate();
         // Get left or single page download.
         $markerArray['###IMAGE_LEFT###'] = $this->piVars['double'] == 1 ? $this->getImage($this->piVars['page'], $this->pi_getLL('leftPage', '')) : $this->getImage($this->piVars['page'], $this->pi_getLL('singlePage', ''));
         // Get right page download.

--- a/Classes/Plugin/Tools/ImageManipulationTool.php
+++ b/Classes/Plugin/Tools/ImageManipulationTool.php
@@ -41,7 +41,7 @@ class ImageManipulationTool extends \Kitodo\Dlf\Common\AbstractPlugin {
             $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
         }
         // Load template file.
-        $this->getTemplate('###TEMPLATE###', '', TRUE);
+        $this->getTemplate();
         $markerArray['###IMAGEMANIPULATION_SELECT###'] = '<span class="tx-dlf-tools-imagetools" id="tx-dlf-tools-imagetools" data-dic="imagemanipulation-on:'.$this->pi_getLL('imagemanipulation-on', '', TRUE).';imagemanipulation-off:'.$this->pi_getLL('imagemanipulation-off', '', TRUE).';reset:'.$this->pi_getLL('reset', '', TRUE).';saturation:'.$this->pi_getLL('saturation', '', TRUE).';hue:'.$this->pi_getLL('hue', '', TRUE).';contrast:'.$this->pi_getLL('contrast', '', TRUE).';brightness:'.$this->pi_getLL('brightness', '', TRUE).';invert:'.$this->pi_getLL('invert', '', TRUE).'" title="'.$this->pi_getLL('no-support', '', TRUE).'"></span>';
         $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);

--- a/Classes/Plugin/Tools/PdfDownloadTool.php
+++ b/Classes/Plugin/Tools/PdfDownloadTool.php
@@ -65,7 +65,7 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin {
             $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
         // Load template file.
-        $this->getTemplate('###TEMPLATE###', '', TRUE);
+        $this->getTemplate();
         // Get single page downloads.
         $markerArray['###PAGE###'] = $this->getPageLink();
         // Get work download.

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -64,7 +64,7 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin {
         }
 
         // Load template file.
-        $this->getTemplate('###TEMPLATE###', '', TRUE);
+        $this->getTemplate();
 
         // Configure @action URL for form.
         $linkConf = array(

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -21,10 +21,15 @@ if (!defined('TYPO3_MODE')) {
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'dlf',
     'Configuration/TypoScript/Search/',
-    'Search Facets'
+    'Search Facets Configuration'
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'dlf',
     'Configuration/TypoScript/TableOfContents/',
-    'Table of Contents'
+    'Table of Contents Menu Configuration'
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'dlf',
+    'Configuration/TypoScript/Toolbox/',
+    'Toolbox Default Tool Templates'
 );

--- a/Configuration/TypoScript/Toolbox/setup.txt
+++ b/Configuration/TypoScript/Toolbox/setup.txt
@@ -1,0 +1,6 @@
+plugin.tx_dlf_annotationtool.templateFile = EXT:dlf/Resources/Private/Templates/AnnotationTool.tmpl
+plugin.tx_dlf_fulltexttool.templateFile = EXT:dlf/Resources/Private/Templates/FulltextTool.tmpl
+plugin.tx_dlf_imagedownloadtool.templateFile = EXT:dlf/Resources/Private/Templates/ImageDownloadTool.tmpl
+plugin.tx_dlf_imagemanipulationtool.templateFile = EXT:dlf/Resources/Private/Templates/ImageManipulationTool.tmpl
+plugin.tx_dlf_pdfdownloadtool.templateFile = EXT:dlf/Resources/Private/Templates/PdfDownloadTool.tmpl
+plugin.tx_dlf_searchindocumenttool.templateFile = EXT:dlf/Resources/Private/Templates/SearchInDocumentTool.tmpl


### PR DESCRIPTION
This removes the special handling of tools' templates in `getTemplate()`. In exchange it introduces a default configuration for tool templates.

This fixes #406 