### PR TITLE
Check for type of instance to avoid loading unnecessary JavaScript.

### DIFF
--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -81,8 +81,10 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin {
         $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AltoParser.js');
         $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/ImageManipulationControl.js');
         $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/FulltextControl.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationParser.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationControl.js');
+        if ($this->doc instanceof IiifManifest) {
+            $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationParser.js');
+            $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/AnnotationControl.js');
+        }
         $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey).'Resources/Public/Javascript/PageView/PageView.js');
         // Add viewer configuration.
         $viewerConfiguration = '


### PR DESCRIPTION
This uses the same condition as in getAnnotationContainers(). 
This is of course only a workaround for the problem of #410. The IIIF-manifest would still not work in MSIE 11.