### PR TITLE
Ensure unique element ids for IIIF annotation highlighting

### DIFF
--- a/Resources/Public/Javascript/PageView/AnnotationParser.js
+++ b/Resources/Public/Javascript/PageView/AnnotationParser.js
@@ -53,7 +53,7 @@ var DlfIiifAnnotationParser = function(opt_imageObj, opt_width, opt_height, opt_
  */
 DlfIiifAnnotationParser.prototype.generateId_ = function(width, height, hpos, vpos) {
     var heigt_ = isNaN(height) ? '0' : height;
-    return '' + width + '_' + heigt_ + '_' + hpos + '_' + vpos;
+    return 'anno_' + width + '_' + heigt_ + '_' + hpos + '_' + vpos;
 };
 
 /**


### PR DESCRIPTION
For manifests with canvases where ALTO data in `seeAlso` and annotations are exactly equivalent (Wellcome manifests do that, for example: https://wellcomelibrary.org/iiif/b21203428/manifest), the span ids generated for highlighting are exactly identical which breaks the highlighting when switching between fulltext and annotation.