### PR TITLE
Support multiple DMDID

### DIFF
--- a/Classes/Hooks/KitodoProductionHacks.php
+++ b/Classes/Hooks/KitodoProductionHacks.php
@@ -55,9 +55,13 @@ class KitodoProductionHacks
                 if (empty($id)) {
                     $id = (string) $divs[0]['DMDID'];
                 }
-                $recordIds = $xml->xpath('//mets:dmdSec[@ID="' . $id . '"]//mods:mods/mods:recordInfo/mods:recordIdentifier');
-                if (!empty($recordIds[0])) {
-                    $record_id = (string) $recordIds[0];
+                $dmdIds = explode(' ', $id);
+                foreach ($dmdIds as $dmdId) {
+                    $recordIds = $xml->xpath('//mets:dmdSec[@ID="' . $dmdId . '"]//mods:mods/mods:recordInfo/mods:recordIdentifier');
+                    if (!empty($recordIds[0])) {
+                        $record_id = (string) $recordIds[0];
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This adds support for multiple DMDIDs per logical structure separated by space. Metadata of the first corresponding dmdSec with a supported format are displayed.

This should fix #417 and slub/dfg-viewer#118 respectively.