### PR TITLE
Fix index_search field length.

### DIFF
--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -132,9 +132,9 @@ return [
             'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.index_search',
             'config' => [
-                'type' => 'input',
+                'type' => 'text',
                 'size' => 30,
-                'max' => 255,
+                'rows' => 5,
                 'eval' => 'trim',
                 'default' => '',
             ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -195,7 +195,7 @@ CREATE TABLE tx_dlf_collections (
     fe_group varchar(100) DEFAULT '' NOT NULL,
     label varchar(255) DEFAULT '' NOT NULL,
     index_name varchar(255) DEFAULT '' NOT NULL,
-    index_search varchar(255) DEFAULT '' NOT NULL,
+    index_search text NOT NULL,
     oai_name varchar(255) DEFAULT '' NOT NULL,
     description text NOT NULL,
     thumbnail text NOT NULL,


### PR DESCRIPTION
The collections index_search field might be very long to make complexe
queries e.g. for special OAI sets. This patch reverts the db
optimization for this field.