### PR TITLE
Add filter to make selection of collections easier.

### DIFF
--- a/Configuration/Flexforms/Collection.xml
+++ b/Configuration/Flexforms/Collection.xml
@@ -54,6 +54,7 @@
                                 <autoSizeMax>15</autoSizeMax>
                                 <maxitems>1024</maxitems>
                                 <minitems>0</minitems>
+                                <enableMultiSelectFilterTextfield>1</enableMultiSelectFilterTextfield>
                             </config>
                         </TCEforms>
                     </collections>


### PR DESCRIPTION
If working with lots of collections in the collection plugin
configuration it is really hard to find and select the proper ones. A
simple filter makes life much easier. This is situated above the
"Avaiable items" list.