### PR TITLE
check if array exists to avoid PHP warning

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -380,12 +380,14 @@ class Indexer
         $errors = 0;
         // Get metadata for logical unit.
         $metadata = $doc->metadataArray[$logicalUnit['id']];
-        // Remove appended "valueURI" from authors' names for indexing.
-        foreach ($metadata['author'] as $i => $author) {
-            $splitName = explode(chr(31), $author);
-            $metadata['author'][$i] = $splitName[0];
-        }
         if (!empty($metadata)) {
+            // Remove appended "valueURI" from authors' names for indexing.
+            if (is_array($metadata['author'])) {
+                foreach ($metadata['author'] as $i => $author) {
+                    $splitName = explode(chr(31), $author);
+                    $metadata['author'][$i] = $splitName[0];
+                }
+            }
             // Create new Solr document.
             $updateQuery = self::$solr->service->createUpdate();
             $solrDoc = $updateQuery->createDocument();


### PR DESCRIPTION
This avoids the following Solr exception if metadata[authors] is not set:

> Kitodo\Dlf\Common\Indexer::add([Kitodo\Dlf\Common\MetsDocument], 1)] Apache Solr threw exception: "PHP Warning: Invalid argument supplied for foreach() in /app/web/typo3conf/ext/dlf/Classes/Common/Indexer.php line 384"

Due to this exeption, this document is not indexed by Solr at all.