### PR TITLE
Always show volumes of a collection.

### DIFF
--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -379,7 +379,12 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
                     'p' => []
                 ];
             } else {
-                $subparts[$resArray['partof']][$resArray['volume_sorting']] = $resArray['uid'];
+                $subparts[$resArray['partof']][$resArray['volume_sorting']] = [
+                    'u' => $resArray['uid'],
+                    'h' => '',
+                    's' => $sorting,
+                    'p' => []
+                ];
             }
         }
         // Add volumes to the corresponding toplevel documents.
@@ -387,14 +392,9 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
             ksort($parts);
             foreach ($parts as $part) {
                 if (!empty($toplevel[$partof])) {
-                    $toplevel[$partof]['p'][] = ['u' => $part];
+                    $toplevel[$partof]['p'][] = ['u' => $part['u']];
                 } else {
-                    $toplevel[$part] = [
-                      'u' => $part,
-                      'h' => '',
-                      's' => $sorting,
-                      'p' => []
-                    ];
+                    $toplevel[$part['u']] = $part;
                 }
             }
         }

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -359,19 +359,19 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
                     ]
                 ];
             }
+            // Prepare document's metadata for sorting.
+            $sorting = unserialize($resArray['metadata_sorting']);
+            if (!empty($sorting['type']) && \TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($sorting['type'])) {
+                $sorting['type'] = Helper::getIndexNameFromUid($sorting['type'], 'tx_dlf_structures', $this->conf['pages']);
+            }
+            if (!empty($sorting['owner']) && \TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($sorting['owner'])) {
+                $sorting['owner'] = Helper::getIndexNameFromUid($sorting['owner'], 'tx_dlf_libraries', $this->conf['pages']);
+            }
+            if (!empty($sorting['collection']) && \TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($sorting['collection'])) {
+                $sorting['collection'] = Helper::getIndexNameFromUid($sorting['collection'], 'tx_dlf_collections', $this->conf['pages']);
+            }
             // Split toplevel documents from volumes.
             if ($resArray['partof'] == 0) {
-                // Prepare document's metadata for sorting.
-                $sorting = unserialize($resArray['metadata_sorting']);
-                if (!empty($sorting['type']) && \TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($sorting['type'])) {
-                    $sorting['type'] = Helper::getIndexNameFromUid($sorting['type'], 'tx_dlf_structures', $this->conf['pages']);
-                }
-                if (!empty($sorting['owner']) && \TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($sorting['owner'])) {
-                    $sorting['owner'] = Helper::getIndexNameFromUid($sorting['owner'], 'tx_dlf_libraries', $this->conf['pages']);
-                }
-                if (!empty($sorting['collection']) && \TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($sorting['collection'])) {
-                    $sorting['collection'] = Helper::getIndexNameFromUid($sorting['collection'], 'tx_dlf_collections', $this->conf['pages']);
-                }
                 $toplevel[$resArray['uid']] = [
                     'u' => $resArray['uid'],
                     'h' => '',
@@ -384,10 +384,17 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
         }
         // Add volumes to the corresponding toplevel documents.
         foreach ($subparts as $partof => $parts) {
-            if (!empty($toplevel[$partof])) {
-                ksort($parts);
-                foreach ($parts as $part) {
+            ksort($parts);
+            foreach ($parts as $part) {
+                if (!empty($toplevel[$partof])) {
                     $toplevel[$partof]['p'][] = ['u' => $part];
+                } else {
+                    $toplevel[$part] = [
+                      'u' => $part,
+                      'h' => '',
+                      's' => $sorting,
+                      'p' => []
+                    ];
                 }
             }
         }


### PR DESCRIPTION
In case volumes and parents have different collections assigned it may
happen that these volumes are not shown at all.

E.g.
Parent: "Collection-1"
Volume (child): "Collection-2"

The collection plugin is configured to show only "Collection-2". The
current code cannot find the parent as it does not belogn to "Collection
2". As result, the volume is not shown.

The proposed solution handles the found volume as "toplevel" list entry.
The parent is still not shown.