### PR TITLE
Fix docTypeCheck for non-indexed documents

### DIFF
--- a/Classes/Hooks/UserFunc.php
+++ b/Classes/Hooks/UserFunc.php
@@ -64,9 +64,11 @@ class UserFunc
      *
      * @access public
      *
+     * @param int $cPid The PID for the metadata definitions
+     *
      * @return string The type of the current document or 'undefined'
      */
-    public function getDocumentType()
+    public function getDocumentType(int $cPid)
     {
         $type = 'undefined';
         // Load document with current plugin parameters.
@@ -74,7 +76,7 @@ class UserFunc
         if ($doc === null) {
             return $type;
         }
-        $metadata = $doc->getTitledata();
+        $metadata = $doc->getTitledata($cPid);
         if (!empty($metadata['type'][0])) {
             // Calendar plugin does not support IIIF (yet). Abort for all newspaper related types.
             if (

--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -89,7 +89,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             )
             ->from('tx_dlf_documents')
             ->where(
-                $queryBuilder->expr()->eq('tx_dlf_documents.structure', Helper::getUidFromIndexName('issue', 'tx_dlf_structures', $this->doc->pid)),
+                $queryBuilder->expr()->eq('tx_dlf_documents.structure', Helper::getUidFromIndexName('issue', 'tx_dlf_structures', $this->doc->cPid)),
                 $queryBuilder->expr()->eq('tx_dlf_documents.partof', intval($this->doc->uid)),
                 Helper::whereExpression('tx_dlf_documents')
             )
@@ -357,7 +357,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             )
             ->from('tx_dlf_documents')
             ->where(
-                $queryBuilder->expr()->eq('tx_dlf_documents.structure', Helper::getUidFromIndexName('year', 'tx_dlf_structures', $this->doc->pid)),
+                $queryBuilder->expr()->eq('tx_dlf_documents.structure', Helper::getUidFromIndexName('year', 'tx_dlf_structures', $this->doc->cPid)),
                 $queryBuilder->expr()->eq('tx_dlf_documents.partof', intval($this->doc->uid)),
                 Helper::whereExpression('tx_dlf_documents')
             )

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -229,12 +229,14 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
         // Get fulltext link.
         if (!empty($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$this->conf['fileGrpFulltext']])) {
             $fulltext['url'] = $this->doc->getFileLocation($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$this->conf['fileGrpFulltext']]);
-            // Configure @action URL for form.
-            $linkConf = [
-                'parameter' => $GLOBALS['TSFE']->id,
-                'additionalParams' => '&eID=tx_dlf_pageview_proxy&url=' . urlencode($fulltext['url']),
-            ];
-            $fulltext['url'] = $this->cObj->typoLink_URL($linkConf);
+            if ($this->conf['useInternalProxy']) {
+                // Configure @action URL for form.
+                $linkConf = [
+                    'parameter' => $GLOBALS['TSFE']->id,
+                    'additionalParams' => '&eID=tx_dlf_pageview_proxy&url=' . urlencode($fulltext['url']),
+                ];
+                $fulltext['url'] = $this->cObj->typoLink_URL($linkConf);
+            }
             $fulltext['mimetype'] = $this->doc->getFileMimeType($this->doc->physicalStructureInfo[$this->doc->physicalStructure[$page]]['files'][$this->conf['fileGrpFulltext']]);
         } else {
             Helper::devLog('File not found in fileGrp "' . $this->conf['fileGrpFulltext'] . '"', DEVLOG_SEVERITY_WARNING);
@@ -243,13 +245,13 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
     }
 
     /**
-     * Get all AnnotationPages / AnnotationLists that contain text Annotations with "painting" motivation
+     * Get all AnnotationPages / AnnotationLists that contain text Annotations with motivation "painting"
      *
      * @access protected
      *
-     * @param int    $page: the current page's number
-     * @return array     An array containing the IRIs of the AnnotationLists / AnnotationPages as well as
-     *                   some information about the canvas.
+     * @param int $page: Page number
+     * @return array An array containing the IRIs of the AnnotationLists / AnnotationPages as well as
+     *               some information about the canvas.
      */
     protected function getAnnotationContainers($page)
     {
@@ -272,12 +274,12 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
                         if (($textAnnotations = $annotationContainer->getTextAnnotations(Motivation::PAINTING)) != null) {
                             foreach ($textAnnotations as $annotation) {
                                 if (
-                                    $annotation->getBody()->getFormat() == "text/plain"
+                                    $annotation->getBody()->getFormat() == 'text/plain'
                                     && $annotation->getBody()->getChars() != null
                                 ) {
                                     $annotationListData = [];
-                                    $annotationListData["uri"] = $annotationContainer->getId();
-                                    $annotationListData["label"] = $annotationContainer->getLabelForDisplay();
+                                    $annotationListData['uri'] = $annotationContainer->getId();
+                                    $annotationListData['label'] = $annotationContainer->getLabelForDisplay();
                                     $annotationContainers[] = $annotationListData;
                                     break;
                                 }
@@ -285,12 +287,12 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
                         }
                     }
                     $result = [
-                        "canvas" => [
-                            "id" => $canvas->getId(),
-                            "width" => $canvas->getWidth(),
-                            "height" => $canvas->getHeight(),
+                        'canvas' => [
+                            'id' => $canvas->getId(),
+                            'width' => $canvas->getWidth(),
+                            'height' => $canvas->getHeight(),
                         ],
-                        "annotationContainers" => $annotationContainers
+                        'annotationContainers' => $annotationContainers
                     ];
                     return $result;
                 }

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -95,7 +95,7 @@
             <label index="tx_dlf_metadata.tab3">Access</label>
             <label index="tx_dlf_metadataformat">Metadata Format</label>
             <label index="tx_dlf_metadataformat.encoded">Encoding</label>
-            <label index="tx_dlf_metadataformat.xpath">XPath (relative to //dmdSec/mdWrap/xmlData/root and with namespace) or JSONPath (relative to resource JSON object</label>
+            <label index="tx_dlf_metadataformat.xpath">XPath (relative to //dmdSec/mdWrap/xmlData/root and with namespace) or JSONPath (relative to resource JSON object)</label>
             <label index="tx_dlf_metadataformat.xpath_sorting">XPath / JSONPath for sorting (optional)</label>
             <label index="tx_dlf_metadataformat.mandatory">Mandatory field?</label>
             <label index="tx_dlf_metadataformat.tab1">General</label>
@@ -276,7 +276,7 @@
             <label index="tx_dlf_metadata.tab3">Zugriff</label>
             <label index="tx_dlf_metadataformat">Metadatenformat</label>
             <label index="tx_dlf_metadataformat.encoded">Datenformat</label>
-            <label index="tx_dlf_metadataformat.xpath">XPath (relativ zu //dmdSec/mdWrap/xmlData/root und mit Namensraum) oder JSONPath (relativ zum Ressourcen-JSON-Objekt</label>
+            <label index="tx_dlf_metadataformat.xpath">XPath (relativ zu //dmdSec/mdWrap/xmlData/root und mit Namensraum) oder JSONPath (relativ zum JSON-Objekt der Ressource)</label>
             <label index="tx_dlf_metadataformat.xpath_sorting">XPath / JSONPath für Sortierfeld (optional)</label>
             <label index="tx_dlf_metadataformat.mandatory">Pflichtfeld?</label>
             <label index="tx_dlf_metadataformat.tab1">Allgemein</label>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -82,17 +82,18 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
 if (\TYPO3_MODE === 'FE') {
     /**
      * docTypeCheck user function to use in Typoscript
-     * @example [userFunc = user_dlf_docTypeCheck($type)]
+     * @example [userFunc = user_dlf_docTypeCheck($type, $pid)]
      *
      * @access public
      *
-     * @param string $type: document type string to test for
+     * @param string $type The document type string to test for
+     * @param int $pid The PID for the metadata definitions
      *
      * @return bool true if document type matches, false if not
      */
-    function user_dlf_docTypeCheck($type)
+    function user_dlf_docTypeCheck(string $type, int $pid): bool
     {
         $hook = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Kitodo\Dlf\Hooks\UserFunc::class);
-        return ($hook->getDocumentType() === $type);
+        return ($hook->getDocumentType($pid) === $type);
     }
 }


### PR DESCRIPTION
The new docTypeCheck doesn't work for non-indexed documents (i. e. the DFG Viewer), because those documents don't bring their own PID for the metadata configuration. So we have to set a PID explicitly when calling the user function from Typoscript:
`[userFunc = user_dlf_docTypeCheck($type, $pid)]`