### PR TITLE
Backport: Sort collection's entries by title initially #443

### DIFF
--- a/plugins/collection/class.tx_dlf_collection.php
+++ b/plugins/collection/class.tx_dlf_collection.php
@@ -529,6 +529,8 @@ class tx_dlf_collection extends tx_dlf_plugin {
 
         $list->metadata = $listMetadata;
 
+        $list->sort('title');
+
         $list->save();
 
         // Clean output buffer.


### PR DESCRIPTION
This fixes #442 in Branch 2.x