### PR TITLE
Fix 450: Show all MODS metadata

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -465,12 +465,12 @@ final class MetsDocument extends Document
             // First all metadata with configured xpath.
             $result = $queryBuilder
                 ->select(
-                  'tx_dlf_metadata.index_name AS index_name',
-                  'tx_dlf_metadataformat_joins.xpath AS xpath',
-                  'tx_dlf_metadataformat_joins.xpath_sorting AS xpath_sorting',
-                  'tx_dlf_metadata.is_sortable AS is_sortable',
-                  'tx_dlf_metadata.default_value AS default_value',
-                  'tx_dlf_metadata.format AS format'
+                    'tx_dlf_metadata.index_name AS index_name',
+                    'tx_dlf_metadataformat_joins.xpath AS xpath',
+                    'tx_dlf_metadataformat_joins.xpath_sorting AS xpath_sorting',
+                    'tx_dlf_metadata.is_sortable AS is_sortable',
+                    'tx_dlf_metadata.default_value AS default_value',
+                    'tx_dlf_metadata.format AS format'
                 )
                 ->from('tx_dlf_metadata')
                 ->innerJoin(
@@ -512,10 +512,10 @@ final class MetsDocument extends Document
 
                 $result2 = $queryBuilder
                     ->select(
-                      'tx_dlf_metadata.index_name AS index_name',
-                      'tx_dlf_metadata.is_sortable AS is_sortable',
-                      'tx_dlf_metadata.default_value AS default_value',
-                      'tx_dlf_metadata.format AS format'
+                        'tx_dlf_metadata.index_name AS index_name',
+                        'tx_dlf_metadata.is_sortable AS is_sortable',
+                        'tx_dlf_metadata.default_value AS default_value',
+                        'tx_dlf_metadata.format AS format'
                     )
                     ->from('tx_dlf_metadata')
                     ->where(

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -483,18 +483,16 @@ final class MetsDocument extends Document
                     'tx_dlf_metadataformat_joins',
                     'tx_dlf_formats',
                     'tx_dlf_formats_joins',
-                    $queryBuilder->expr()->andX(
-                        $queryBuilder->expr()->eq(
-                            'tx_dlf_formats_joins.uid',
-                            'tx_dlf_metadataformat_joins.encoded'
-                        )
+                    $queryBuilder->expr()->eq(
+                        'tx_dlf_formats_joins.uid',
+                        'tx_dlf_metadataformat_joins.encoded'
                     )
                 )
                 ->where(
                     $queryBuilder->expr()->eq('tx_dlf_metadata.pid', intval($cPid)),
                     $queryBuilder->expr()->eq('tx_dlf_metadata.l18n_parent', 0),
                     $queryBuilder->expr()->eq('tx_dlf_metadataformat_joins.pid', intval($cPid)),
-                    $queryBuilder->expr()->eq('tx_dlf_formats_join.type', $queryBuilder->createNamedParameter($this->dmdSec[$dmdId]['type']))
+                    $queryBuilder->expr()->eq('tx_dlf_formats_joins.type', $queryBuilder->createNamedParameter($this->dmdSec[$dmdId]['type']))
                 )
                 ->execute();
             // Get all metadata without a format, but with a default value next.
@@ -516,7 +514,7 @@ final class MetsDocument extends Document
                     $queryBuilder->expr()->eq('tx_dlf_metadata.pid', intval($cPid)),
                     $queryBuilder->expr()->eq('tx_dlf_metadata.l18n_parent', 0),
                     $queryBuilder->expr()->eq('tx_dlf_metadata.format', 0),
-                    $queryBuilder->expr()->neq('tx_dlf_metadata.defaul_value', $queryBuilder->createNamedParameter(''))
+                    $queryBuilder->expr()->neq('tx_dlf_metadata.default_value', $queryBuilder->createNamedParameter(''))
                 )
                 ->execute();
             // Merge both result sets.

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -534,7 +534,7 @@ final class MetsDocument extends Document
             $domXPath = new \DOMXPath($domNode->ownerDocument);
             $this->registerNamespaces($domXPath);
             // OK, now make the XPath queries.
-            foreach ($allResults AS $resArray) {
+            foreach ($allResults as $resArray) {
 
                 // Set metadata field's value(s).
                 if (

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -246,8 +246,7 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                         ),
                         $queryBuilder->expr()->eq('tx_dlf_metadata.l18n_parent', 0)
                     ),
-                    $queryBuilder->expr()->eq('tx_dlf_metadata.pid', intval($this->conf['pages'])),
-                    Helper::whereExpression('tx_dlf_metadata')
+                    $queryBuilder->expr()->eq('tx_dlf_metadata.pid', intval($this->conf['pages']))
                 )
                 ->orderBy('tx_dlf_metadata.sorting')
                 ->execute();
@@ -275,8 +274,7 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                 ->select('tx_dlf_collections.index_name AS index_name')
                 ->from('tx_dlf_collections')
                 ->where(
-                    $queryBuilder->expr()->eq('tx_dlf_collections.pid', intval($this->conf['pages'])),
-                    Helper::whereExpression('tx_dlf_collections')
+                    $queryBuilder->expr()->eq('tx_dlf_collections.pid', intval($this->conf['pages']))
                 )
                 ->execute();
 
@@ -300,67 +298,70 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                 }
                 // Process each metadate.
                 foreach ($metaList as $index_name => $metaConf) {
-                    if (!empty($metadata[$index_name])) {
-                        $parsedValue = '';
-                        $fieldwrap = $this->parseTS($metaConf['wrap']);
-                        do {
-                            $value = @array_shift($metadata[$index_name]);
-                            if ($index_name == 'title') {
-                                // Get title of parent document if needed.
-                                if (empty($value) && $this->conf['getTitle'] && $this->doc->parentId) {
-                                    $superiorTitle = Document::getTitle($this->doc->parentId, true);
-                                    if (!empty($superiorTitle)) {
-                                        $value = '[' . $superiorTitle . ']';
-                                    }
+                    $parsedValue = '';
+                    $fieldwrap = $this->parseTS($metaConf['wrap']);
+                    if ($index_name == 'authors') {
+                        $cho = 1;
+                    }
+                    do {
+                        $value = @array_shift($metadata[$index_name]);
+                        if ($index_name == 'title') {
+                            // Get title of parent document if needed.
+                            if (empty($value) && $this->conf['getTitle'] && $this->doc->parentId) {
+                                $superiorTitle = Document::getTitle($this->doc->parentId, true);
+                                if (!empty($superiorTitle)) {
+                                    $value = '[' . $superiorTitle . ']';
                                 }
-                                if (!empty($value)) {
-                                    $value = htmlspecialchars($value);
-                                    // Link title to pageview.
-                                    if ($this->conf['linkTitle'] && $metadata['_id']) {
-                                        $details = $this->doc->getLogicalStructure($metadata['_id']);
-                                        $value = $this->pi_linkTP($value, [$this->prefixId => ['id' => $this->doc->uid, 'page' => (!empty($details['points']) ? intval($details['points']) : 1)]], true, $this->conf['targetPid']);
-                                    }
-                                }
-                            } elseif ($index_name == 'owner' && !empty($value)) {
-                                // Translate name of holding library.
-                                $value = htmlspecialchars(Helper::translate($value, 'tx_dlf_libraries', $this->conf['pages']));
-                            } elseif ($index_name == 'type' && !empty($value)) {
-                                // Translate document type.
-                                $value = htmlspecialchars(Helper::translate($value, 'tx_dlf_structures', $this->conf['pages']));
-                            } elseif ($index_name == 'collection' && !empty($value)) {
-                                // Check if collections isn't hidden.
-                                if (in_array($value, $collList)) {
-                                    // Translate collection.
-                                    $value = htmlspecialchars(Helper::translate($value, 'tx_dlf_collections', $this->conf['pages']));
-                                } else {
-                                    $value = '';
-                                }
-                            } elseif ($index_name == 'language' && !empty($value)) {
-                                // Translate ISO 639 language code.
-                                $value = htmlspecialchars(Helper::getLanguageName($value));
-                            } elseif (!empty($value)) {
-                                // Sanitize value for output.
-                                $value = htmlspecialchars($value);
                             }
-
                             if (!empty($value)) {
-                                // Hook for getting a customized value (requested by SBB).
-                                foreach ($this->hookObjects as $hookObj) {
-                                    if (method_exists($hookObj, 'printMetadata_customizeMetadata')) {
-                                        $hookObj->printMetadata_customizeMetadata($value);
-                                    }
+                                $value = htmlspecialchars($value);
+                                // Link title to pageview.
+                                if ($this->conf['linkTitle'] && $metadata['_id']) {
+                                    $details = $this->doc->getLogicalStructure($metadata['_id']);
+                                    $value = $this->pi_linkTP($value, [$this->prefixId => ['id' => $this->doc->uid, 'page' => (!empty($details['points']) ? intval($details['points']) : 1)]], true, $this->conf['targetPid']);
                                 }
-                                $value = $this->cObj->stdWrap($value, $fieldwrap['value.']);
-
-                                $parsedValue .= $value;
                             }
-                        } while (count($metadata[$index_name]));
-
-                        if (!empty($parsedValue)) {
-                            $field = $this->cObj->stdWrap(htmlspecialchars($metaConf['label']), $fieldwrap['key.']);
-                            $field .= $parsedValue;
-                            $markerArray['###METADATA###'] .= $this->cObj->stdWrap($field, $fieldwrap['all.']);
+                        } elseif ($index_name == 'owner' && !empty($value)) {
+                            // Translate name of holding library.
+                            $value = htmlspecialchars(Helper::translate($value, 'tx_dlf_libraries', $this->conf['pages']));
+                        } elseif ($index_name == 'type' && !empty($value)) {
+                            // Translate document type.
+                            $value = htmlspecialchars(Helper::translate($value, 'tx_dlf_structures', $this->conf['pages']));
+                        } elseif ($index_name == 'collection' && !empty($value)) {
+                            // Check if collections isn't hidden.
+                            if (in_array($value, $collList)) {
+                                // Translate collection.
+                                $value = htmlspecialchars(Helper::translate($value, 'tx_dlf_collections', $this->conf['pages']));
+                            } else {
+                                $value = '';
+                            }
+                        } elseif ($index_name == 'language' && !empty($value)) {
+                            // Translate ISO 639 language code.
+                            $value = htmlspecialchars(Helper::getLanguageName($value));
+                        } elseif (!empty($value)) {
+                            // Sanitize value for output.
+                            $value = htmlspecialchars($value);
                         }
+
+                        // Hook for getting a customized value (requested by SBB).
+                        foreach ($this->hookObjects as $hookObj) {
+                            if (method_exists($hookObj, 'printMetadata_customizeMetadata')) {
+                                $hookObj->printMetadata_customizeMetadata($value);
+                            }
+                        }
+
+                        // $value might be empty for aggregation metadata fields including other "hidden" fields.
+                        $value = $this->cObj->stdWrap($value, $fieldwrap['value.']);
+
+                        if (!empty($value)) {
+                            $parsedValue .= $value;
+                        }
+                    } while (is_array($metadata[$index_name]) && count($metadata[$index_name]) > 0);
+
+                    if (!empty($parsedValue)) {
+                        $field = $this->cObj->stdWrap(htmlspecialchars($metaConf['label']), $fieldwrap['key.']);
+                        $field .= $parsedValue;
+                        $markerArray['###METADATA###'] .= $this->cObj->stdWrap($field, $fieldwrap['all.']);
                     }
                 }
                 $output .= $this->templateService->substituteMarkerArray($subpart['block'], $markerArray);

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -300,9 +300,6 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                 foreach ($metaList as $index_name => $metaConf) {
                     $parsedValue = '';
                     $fieldwrap = $this->parseTS($metaConf['wrap']);
-                    if ($index_name == 'authors') {
-                        $cho = 1;
-                    }
                     do {
                         $value = @array_shift($metadata[$index_name]);
                         if ($index_name == 'title') {

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -162,6 +162,8 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
         $this->getTemplate();
         $output = '';
         $subpart['block'] = $this->templateService->getSubpart($this->template, '###BLOCK###');
+        // Save original data array.
+        $cObjData = $this->cObj->data;
         // Get list of metadata to show.
         $metaList = [];
         if ($useOriginalIiifManifestMetadata) {
@@ -178,8 +180,6 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
             $iiifLink['value.']['setContentToCurrent'] = 1;
             $iiifLink['value.']['typolink.']['parameter.']['current'] = 1;
             $iiifLink['value.']['wrap'] = '<dd>|</dd>';
-            // Save original data array.
-            $cObjData = $this->cObj->data;
             foreach ($metadataArray as $metadata) {
                 foreach ($metadata as $key => $group) {
                     $markerArray['###METADATA###'] = '<span class="tx-dlf-metadata-group">' . $this->pi_getLL($key) . '</span>';
@@ -229,7 +229,6 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
         } else {
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable('tx_dlf_metadata');
-
             $result = $queryBuilder
                 ->select(
                     'tx_dlf_metadata.index_name AS index_name',
@@ -250,7 +249,6 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                 )
                 ->orderBy('tx_dlf_metadata.sorting')
                 ->execute();
-
             while ($resArray = $result->fetch()) {
                 if (is_array($resArray) && $resArray['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL) {
                     $resArray = $GLOBALS['TSFE']->sys_page->getRecordOverlay('tx_dlf_metadata', $resArray, $GLOBALS['TSFE']->sys_language_content, $GLOBALS['TSFE']->sys_language_contentOL);
@@ -264,11 +262,9 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                     }
                 }
             }
-
+            // Get list of collections to show.
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable('tx_dlf_collections');
-
-            // Get list of collections to show.
             $collList = [];
             $result = $queryBuilder
                 ->select('tx_dlf_collections.index_name AS index_name')
@@ -277,12 +273,9 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                     $queryBuilder->expr()->eq('tx_dlf_collections.pid', intval($this->conf['pages']))
                 )
                 ->execute();
-
             while ($resArray = $result->fetch()) {
                 $collList[] = $resArray['index_name'];
             }
-            // Save original data array.
-            $cObjData = $this->cObj->data;
             // Parse the metadata arrays.
             foreach ($metadataArray as $metadata) {
                 $markerArray['###METADATA###'] = '';
@@ -339,17 +332,14 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
                             // Sanitize value for output.
                             $value = htmlspecialchars($value);
                         }
-
                         // Hook for getting a customized value (requested by SBB).
                         foreach ($this->hookObjects as $hookObj) {
                             if (method_exists($hookObj, 'printMetadata_customizeMetadata')) {
                                 $hookObj->printMetadata_customizeMetadata($value);
                             }
                         }
-
                         // $value might be empty for aggregation metadata fields including other "hidden" fields.
                         $value = $this->cObj->stdWrap($value, $fieldwrap['value.']);
-
                         if (!empty($value)) {
                             $parsedValue .= $value;
                         }


### PR DESCRIPTION
This pull request fixes the issue #450. 

Additionally it fixes a broken SQL query in MetsDocuments. The current query is the following:

<pre>
SELECT tx_dlf_metadata.index_name AS index_name, tx_dlf_metadataformat.xpath AS xpath, tx_dlf_metadataformat.xpath_sorting AS xpath_sorting, tx_dlf_metadata.is_sortable AS is_sortable, tx_dlf_metadata.default_value AS default_value, tx_dlf_metadata.format AS format 
FROM tx_dlf_metadata, tx_dlf_metadataformat, tx_dlf_formats 
WHERE 
  tx_dlf_metadata.pid=133 
  AND tx_dlf_metadataformat.pid=133 
  AND (
    (
      tx_dlf_metadata.uid=tx_dlf_metadataformat.parent_id 
      AND tx_dlf_metadataformat.encoded=tx_dlf_formats.uid 
      AND tx_dlf_formats.type='MODS'
    ) 
    OR tx_dlf_metadata.format=0
  ) 
  AND `tx_dlf_metadata`.`deleted` = 0 
  AND `tx_dlf_metadataformat`.`deleted` = 0 
  AND `tx_dlf_formats`.`deleted` = 0 
  ;
</pre>

This results in 222876 records (!) on using 336 metadata records (default language) and 302 metadataformats. Nevertheless, the code is working due to if conditions on iterating all the 200k records.

As we have to move to QueryBuilder anyway, I've done this. This is more code but hopefully less error-prone.
The resulting SQL in the same examle is

<pre>
SELECT tx_dlf_metadata.index_name AS index_name, tx_dlf_metadataformat_joins`.`xpath` AS `xpath`, `tx_dlf_metadataformat_joins`.`xpath_sorting` AS `xpath_sorting`, `tx_dlf_metadata`.`is_sortable` AS `is_sortable`, `tx_dlf_metadata`.`default_value` AS `default_value`, `tx_dlf_metadata`.`format` AS `format` 
FROM `tx_dlf_metadata` 
  INNER JOIN `tx_dlf_metadataformat` `tx_dlf_metadataformat_joins` ON `tx_dlf_metadataformat_joins`.`parent_id` = tx_dlf_metadata.uid 
  INNER JOIN `tx_dlf_formats` `tx_dlf_formats_joins` ON `tx_dlf_formats_joins`.`uid` = tx_dlf_metadataformat_joins.encoded 
WHERE 
  (`tx_dlf_metadata`.`pid` = 133) 
  AND (`tx_dlf_metadata`.`l18n_parent` = 0) 
  AND (`tx_dlf_metadataformat_joins`.`pid` = 133) 
  AND (
    (`tx_dlf_metadata`.`deleted` = 0) 
    AND (`tx_dlf_metadataformat_joins`.`deleted` = 0) 
    AND (`tx_dlf_formats_joins`.`deleted` = 0)
  ) 
ORDER BY `tx_dlf_metadata`.`sorting` ASC
</pre>

The result are 336 rows which is equal to the available 336 metadata records.

**Please note**: The function Helper::whereExpression() is NOT necessary here as the TYPO3 QueryBuilder already does this job our you. (see documentation about the [RestrictionBuilder](https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/ApiOverview/Database/RestrictionBuilder/Index.html)). You would do it twice on using this function. Maybe the whole function is unecessary.