### PR TITLE
Resize to options field of the tx_dlf_tokens table.

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -244,7 +244,7 @@ CREATE TABLE tx_dlf_tokens (
     uid int(11) NOT NULL auto_increment,
     tstamp int(11) DEFAULT '0' NOT NULL,
     token varchar(255) DEFAULT '' NOT NULL,
-    options text NOT NULL,
+    options mediumtext NOT NULL,
     ident varchar(30) DEFAULT '' NOT NULL,
 
     PRIMARY KEY (uid),


### PR DESCRIPTION
The options field keeps the serialized array of found UIDs of an OAI
set. With 6-digit UIDs it is only possible to have about 6500 objects in
an OAI set. In this case the serialized array is cutted an the OAI
plugin will fail with an exception.

Before commit 443aaff2cbb79870ae3f1ebecd3f7460f81e2812 this field was
textlong which might be really too long. This patch changes the field to
mediumtext wich should be able to keep about 1.6 million objects.