### PR TITLE
Fix arguments on calling addMessage().

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -592,7 +592,6 @@ class Indexer
             } catch (\Exception $e) {
                 if (!(\TYPO3_REQUESTTYPE & \TYPO3_REQUESTTYPE_CLI)) {
                     Helper::addMessage(
-                        \TYPO3\CMS\Core\Messaging\FlashMessage::class,
                         Helper::getMessage('flash.solrException', true) . '<br />' . htmlspecialchars($e->getMessage()),
                         Helper::getMessage('flash.error', true),
                         \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,


### PR DESCRIPTION
If Solr errors occure on saving tx_dlf_documents the backend dies with
the following error:

<pre>
Argument 1 passed to TYPO3\CMS\Core\Messaging\AbstractMessage::setSeverity() 
must be of the type integer, string given, called in 
/app/vendor/typo3/cms/typo3/sysext/core/Classes/Messaging/FlashMessage.php on line 68
</pre>

This is related to #457 but no fix of the problem mentioned there.