### PR TITLE
Fix indexing METS files with linked URIs.

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -573,7 +573,15 @@ class Indexer
                     !empty($data)
                     && substr($index_name, -8) !== '_sorting'
                 ) {
+
                     if (in_array($index_name, self::$fields['facets'])) {
+                        // Remove appended "valueURI" from authors' names for indexing.
+                        if ($index_name == 'author') {
+                            foreach ($data as $i => $author) {
+                                $splitName = explode(chr(31), $author);
+                                $data[$i] = $splitName[0];
+                            }
+                        }
                         // Add facets to index.
                         $solrDoc->setField($index_name . '_faceting', $data);
                     }


### PR DESCRIPTION
Introduced with #401 it is possible for author metadata fields to link
to the given valueURI attribute.

Unfortunately this feature is not complete in case you are using the
author field for facets. The Solr query breaks due to the not allowed
character 31. We have to split the string in Indexer::processPhysical()
as well.

We should fix this issue in 2.x, too.