### PR TITLE
Convert eID-scripts to support PSR-7.

### DIFF
--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -54,7 +54,7 @@ class PageViewProxy
         if ($header === 0) {
             $fetchedHeaderString = GeneralUtility::getUrl($url, 2);
             if (!empty($fetchedHeaderString)) {
-                $fetchedHeader = explode("\n", );
+                $fetchedHeader = explode("\n", $fetchedHeaderString);
                 foreach ($fetchedHeader as $headerline) {
                     if (stripos($headerline, 'Last-Modified:') !== false) {
                         $lastModified = trim(substr($headerline, strpos($headerline, ':') + 1));

--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -52,11 +52,14 @@ class PageViewProxy
 
         // Fetch header data separately to get "Last-Modified" info
         if ($header === 0) {
-            $fetchedHeader = explode("\n", GeneralUtility::getUrl($url, 2));
-            foreach ($fetchedHeader as $headerline) {
-                if (stripos($headerline, 'Last-Modified:') !== false) {
-                    $lastModified = trim(substr($headerline, strpos($headerline, ':') + 1));
-                    break;
+            $fetchedHeaderString = GeneralUtility::getUrl($url, 2);
+            if (!empty($fetchedHeaderString)) {
+                $fetchedHeader = explode("\n", );
+                foreach ($fetchedHeader as $headerline) {
+                    if (stripos($headerline, 'Last-Modified:') !== false) {
+                        $lastModified = trim(substr($headerline, strpos($headerline, ':') + 1));
+                        break;
+                    }
                 }
             }
         }
@@ -64,8 +67,10 @@ class PageViewProxy
         // create response object
         /** @var Response $response */
         $response = GeneralUtility::makeInstance(Response::class);
-        $response->getBody()->write($fetchedData);
-        $response = $response->withHeader('Content-Type', finfo_buffer(finfo_open(FILEINFO_MIME), $fetchedData));
+        if ($fetchedData) {
+            $response->getBody()->write($fetchedData);
+            $response = $response->withHeader('Content-Type', finfo_buffer(finfo_open(FILEINFO_MIME), $fetchedData));
+        }
         if ($header === 0 && !empty($lastModified)) {
             $response = $response->withHeader('Last-Modified', $lastModified);
         }

--- a/Classes/Plugin/Eid/SearchInDocument.php
+++ b/Classes/Plugin/Eid/SearchInDocument.php
@@ -46,6 +46,7 @@ class SearchInDocument
         }
         $core = Helper::decrypt($encrypted, $hashed);
 
+        $output = '';
         if (!empty($core)) {
             $query = (string)$parameters['q'];
             $uid = (string)$parameters['uid'];

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -47,6 +47,7 @@ class SearchSuggest
         }
         $core = Helper::decrypt($encrypted, $hashed);
 
+        $output = '';
         if (!empty($core)) {
             $query = (string)$parameters['q'];
             $url = trim(Solr::getSolrUrl($core), '/') . '/suggest/?wt=xml&q=' . Solr::escapeQuery($query);

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -14,6 +14,10 @@ namespace Kitodo\Dlf\Plugin\Eid;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -25,29 +29,34 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @subpackage dlf
  * @access public
  */
-class SearchSuggest extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
+class SearchSuggest
 {
-    public $scriptRelPath = 'Classes/Plugin/Eid/SearchSuggest.php';
-
     /**
      * The main method of the eID script
      *
-     * @access public
-     *
-     * @return string XML response of search suggestions
+    *  @param ServerRequestInterface $request
+     * @return ResponseInterface XML response of search suggestions
      */
-    public function main()
+    public function main(ServerRequestInterface $request)
     {
-        if (
-            GeneralUtility::_GP('encrypted') != ''
-            && GeneralUtility::_GP('hashed') != ''
-        ) {
-            $core = Helper::decrypt(GeneralUtility::_GP('encrypted'), GeneralUtility::_GP('hashed'));
+        $parameters = $request->getParsedBody();
+        $encrypted = (string)$parameters['encrypted'];
+        $hashed = (string)$parameters['hashed'];
+        if (empty($encrypted) || empty($hashed)) {
+            throw new \InvalidArgumentException('No valid parameter passed!', 1580585079);
         }
+        $core = Helper::decrypt($encrypted, $hashed);
+
         if (!empty($core)) {
-            $url = trim(Solr::getSolrUrl($core), '/') . '/suggest/?wt=xml&q=' . Solr::escapeQuery(GeneralUtility::_GP('q'));
+            $query = (string)$parameters['q'];
+            $url = trim(Solr::getSolrUrl($core), '/') . '/suggest/?wt=xml&q=' . Solr::escapeQuery($query);
             $output = GeneralUtility::getUrl($url);
         }
-        echo $output;
+
+        // create response object
+        /** @var Response $response */
+        $response = GeneralUtility::makeInstance(Response::class);
+        $response->getBody()->write($output);
+        return $response;
     }
 }

--- a/Resources/Private/Templates/SearchInDocumentTool.tmpl
+++ b/Resources/Private/Templates/SearchInDocumentTool.tmpl
@@ -17,7 +17,7 @@
     <input type="hidden" name="tx_dlf[start]" value="0" />
     <input type="hidden" name="tx_dlf[id]" value="###CURRENT_DOCUMENT###" />
     <input type="hidden" name="tx_dlf[encrypted]" value="###SOLR_ENCRYPTED###" />
-    <input type="hidden" name="tx_dlf[hash]" value="###SOLR_HASH###" />
+    <input type="hidden" name="tx_dlf[hashed]" value="###SOLR_HASH###" />
   </div>
 </form>
 <div id="tx-dlf-search-in-document-loading" style="display: none;">###LABEL_LOADING###...</div>

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
                 uid: $( "input[name='tx_dlf[id]']" ).val(),
                 start: $( "input[name='tx_dlf[start]']" ).val(),
                 encrypted: $( "input[name='tx_dlf[encrypted]']" ).val(),
-                hashed: $( "input[name='tx_dlf[hash]']" ).val(),
+                hashed: $( "input[name='tx_dlf[hashed]']" ).val(),
             },
             function(data) {
               var resultItems = [];


### PR DESCRIPTION
With TYPO3 7.4 "Feature: #68186 - PSR-7 support for eID" was added. With
TYPO3 8.7 the simple old style scripts did still work. As of TYPO 9.5
these scripts fail due to missing response object.

This patch converts the eID-scripts to make it work with TYPO3 8.7 and
9.5.