### PR TITLE
Show flashmessages on updating kitodo records in the backend.

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -678,9 +678,6 @@ class Helper
     {
         $flashMessageService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Messaging\FlashMessageService::class);
         $flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier($queue);
-        // \TYPO3\CMS\Core\Messaging\FlashMessage::getMessageAsMarkup() uses htmlspecialchars()
-        // on all messages, but we have messages with HTML tags. Therefore we copy the official
-        // implementation and remove the htmlspecialchars() call on the message body.
         $content = '';
         $flashMessages = $flashMessageQueue->getAllMessagesAndFlush();
         $content = GeneralUtility::makeInstance(\Kitodo\Dlf\Common\KitodoFlashmessageRenderer::class)

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -683,31 +683,8 @@ class Helper
         // implementation and remove the htmlspecialchars() call on the message body.
         $content = '';
         $flashMessages = $flashMessageQueue->getAllMessagesAndFlush();
-        if (!empty($flashMessages)) {
-            $content .= '<div class="typo3-messages">';
-            foreach ($flashMessages as $flashMessage) {
-                $messageTitle = $flashMessage->getTitle();
-                $markup = [];
-                $markup[] = '<div class="alert ' . htmlspecialchars($flashMessage->getClass()) . '">';
-                $markup[] = '    <div class="media">';
-                $markup[] = '        <div class="media-left">';
-                $markup[] = '            <span class="fa-stack fa-lg">';
-                $markup[] = '                <i class="fa fa-circle fa-stack-2x"></i>';
-                $markup[] = '                <i class="fa fa-' . htmlspecialchars($flashMessage->getIconName()) . ' fa-stack-1x"></i>';
-                $markup[] = '            </span>';
-                $markup[] = '        </div>';
-                $markup[] = '        <div class="media-body">';
-                if (!empty($messageTitle)) {
-                    $markup[] = '            <h4 class="alert-title">' . htmlspecialchars($messageTitle) . '</h4>';
-                }
-                $markup[] = '            <p class="alert-message">' . $flashMessage->getMessage() . '</p>'; // Removed htmlspecialchars() here.
-                $markup[] = '        </div>';
-                $markup[] = '    </div>';
-                $markup[] = '</div>';
-                $content .= implode('', $markup);
-            }
-            $content .= '</div>';
-        }
+        $content = GeneralUtility::makeInstance(\Kitodo\Dlf\Common\KitodoFlashmessageRenderer::class)
+            ->render($flashMessages);
         return $content;
     }
 

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -679,7 +679,7 @@ class Helper
         $flashMessageService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Messaging\FlashMessageService::class);
         $flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier($queue);
         $flashMessages = $flashMessageQueue->getAllMessagesAndFlush();
-        $content = GeneralUtility::makeInstance(\Kitodo\Dlf\Common\KitodoFlashmessageRenderer::class)
+        $content = GeneralUtility::makeInstance(\Kitodo\Dlf\Common\KitodoFlashMessageRenderer::class)
             ->render($flashMessages);
         return $content;
     }

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -678,7 +678,6 @@ class Helper
     {
         $flashMessageService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Messaging\FlashMessageService::class);
         $flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier($queue);
-        $content = '';
         $flashMessages = $flashMessageQueue->getAllMessagesAndFlush();
         $content = GeneralUtility::makeInstance(\Kitodo\Dlf\Common\KitodoFlashmessageRenderer::class)
             ->render($flashMessages);

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -155,14 +155,16 @@ class Indexer
                             htmlspecialchars(sprintf(Helper::getMessage('flash.documentIndexed'), $resArray['title'], $doc->uid)),
                             Helper::getMessage('flash.done', true),
                             \TYPO3\CMS\Core\Messaging\FlashMessage::OK,
-                            true
+                            true,
+                            'core.template.flashMessages'
                         );
                     } else {
                         Helper::addMessage(
                             htmlspecialchars(sprintf(Helper::getMessage('flash.documentNotIndexed'), $resArray['title'], $doc->uid)),
                             Helper::getMessage('flash.error', true),
                             \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
-                            true
+                            true,
+                            'core.template.flashMessages'
                         );
                     }
                 }
@@ -173,7 +175,8 @@ class Indexer
                         Helper::getMessage('flash.solrException', true) . '<br />' . htmlspecialchars($e->getMessage()),
                         Helper::getMessage('flash.error', true),
                         \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
-                        true
+                        true,
+                        'core.template.flashMessages'
                     );
                 }
                 Helper::devLog('Apache Solr threw exception: "' . $e->getMessage() . '"', DEVLOG_SEVERITY_ERROR);
@@ -185,7 +188,8 @@ class Indexer
                     Helper::getMessage('flash.solrNoConnection', true),
                     Helper::getMessage('flash.warning', true),
                     \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING,
-                    true
+                    true,
+                    'core.template.flashMessages'
                 );
             }
             Helper::devLog('Could not connect to Apache Solr server', DEVLOG_SEVERITY_ERROR);
@@ -233,7 +237,8 @@ class Indexer
                             Helper::getMessage('flash.solrException', true) . '<br />' . htmlspecialchars($e->getMessage()),
                             Helper::getMessage('flash.error', true),
                             \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
-                            true
+                            true,
+                            'core.template.flashMessages'
                         );
                     }
                     Helper::devLog('Apache Solr threw exception: "' . $e->getMessage() . '"', DEVLOG_SEVERITY_ERROR);
@@ -245,7 +250,8 @@ class Indexer
                         Helper::getMessage('flash.solrNoConnection', true),
                         Helper::getMessage('flash.error', true),
                         \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
-                        true
+                        true,
+                        'core.template.flashMessages'
                     );
                 }
                 Helper::devLog('Could not connect to Apache Solr server', DEVLOG_SEVERITY_ERROR);
@@ -256,7 +262,8 @@ class Indexer
                     htmlspecialchars(sprintf(Helper::getMessage('flash.documentDeleted'), $title, $uid)),
                     Helper::getMessage('flash.done', true),
                     \TYPO3\CMS\Core\Messaging\FlashMessage::OK,
-                    true
+                    true,
+                    'core.template.flashMessages'
                 );
             }
             return 0;
@@ -463,7 +470,8 @@ class Indexer
                         Helper::getMessage('flash.solrException', true) . '<br />' . htmlspecialchars($e->getMessage()),
                         Helper::getMessage('flash.error', true),
                         \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
-                        true
+                        true,
+                        'core.template.flashMessages'
                     );
                 }
                 return 1;
@@ -603,7 +611,8 @@ class Indexer
                         Helper::getMessage('flash.solrException', true) . '<br />' . htmlspecialchars($e->getMessage()),
                         Helper::getMessage('flash.error', true),
                         \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR,
-                        true
+                        true,
+                        'core.template.flashMessages'
                     );
                 }
                 return 1;

--- a/Classes/Common/KitodoFlashMessageRenderer.php
+++ b/Classes/Common/KitodoFlashMessageRenderer.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
  * The created output contains all classes which are required for
  * the TYPO3 backend. Any kind of message contains also a nice icon.
  */
-class KitodoFlashmessageRenderer implements \TYPO3\CMS\Core\Messaging\Renderer\FlashMessageRendererInterface
+class KitodoFlashMessageRenderer implements \TYPO3\CMS\Core\Messaging\Renderer\FlashMessageRendererInterface
 {
     /**
      * @var string The message severity class names

--- a/Classes/Common/KitodoFlashmessageRenderer.php
+++ b/Classes/Common/KitodoFlashmessageRenderer.php
@@ -88,6 +88,9 @@ class KitodoFlashmessageRenderer implements \TYPO3\CMS\Core\Messaging\Renderer\F
      */
     protected function getMessageAsMarkup(array $flashMessages): string
     {
+        // \TYPO3\CMS\Core\Messaging\FlashMessage::getMessageAsMarkup() uses htmlspecialchars()
+        // on all messages, but we have messages with HTML tags. Therefore we copy the official
+        // implementation and remove the htmlspecialchars() call on the message body.
         $markup = [];
         $markup[] = '<div class="typo3-messages">';
         foreach ($flashMessages as $flashMessage) {

--- a/Classes/Common/KitodoFlashmessageRenderer.php
+++ b/Classes/Common/KitodoFlashmessageRenderer.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common;
+
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+
+/**
+ * A class representing a bootstrap flash messages.
+ * This class renders flash messages as markup, based on the
+ * bootstrap HTML/CSS framework. It is used in backend context.
+ * The created output contains all classes which are required for
+ * the TYPO3 backend. Any kind of message contains also a nice icon.
+ */
+class KitodoFlashmessageRenderer implements \TYPO3\CMS\Core\Messaging\Renderer\FlashMessageRendererInterface
+{
+    /**
+     * @var string The message severity class names
+     */
+    protected static $classes = [
+        FlashMessage::NOTICE => 'notice',
+        FlashMessage::INFO => 'info',
+        FlashMessage::OK => 'success',
+        FlashMessage::WARNING => 'warning',
+        FlashMessage::ERROR => 'danger'
+    ];
+
+    /**
+     * @var string The message severity icon names
+     */
+    protected static $icons = [
+        FlashMessage::NOTICE => 'lightbulb-o',
+        FlashMessage::INFO => 'info',
+        FlashMessage::OK => 'check',
+        FlashMessage::WARNING => 'exclamation',
+        FlashMessage::ERROR => 'times'
+    ];
+
+    /**
+     * Render method
+     *
+     * @param FlashMessage[] $flashMessages
+     * @return string Representation of the flash message
+     */
+    public function render(array $flashMessages): string
+    {
+        return $this->getMessageAsMarkup($flashMessages);
+    }
+
+    /**
+     * Gets the message severity class name
+     *
+     * @param FlashMessage $flashMessage
+     *
+     * @return string The message severity class name
+     */
+    protected function getClass(FlashMessage $flashMessage): string
+    {
+        return 'alert-' . self::$classes[$flashMessage->getSeverity()];
+    }
+
+    /**
+     * Gets the message severity icon name
+     *
+     * @param FlashMessage $flashMessage
+     *
+     * @return string The message severity icon name
+     */
+    protected function getIconName(FlashMessage $flashMessage): string
+    {
+        return self::$icons[$flashMessage->getSeverity()];
+    }
+
+    /**
+     * Gets the message rendered as clean and secure markup
+     *
+     * @param FlashMessage[] $flashMessages
+     * @return string
+     */
+    protected function getMessageAsMarkup(array $flashMessages): string
+    {
+        $markup = [];
+        $markup[] = '<div class="typo3-messages">';
+        foreach ($flashMessages as $flashMessage) {
+            $messageTitle = $flashMessage->getTitle();
+            $markup[] = '<div class="alert ' . htmlspecialchars($this->getClass($flashMessage)) . '">';
+            $markup[] = '  <div class="media">';
+            $markup[] = '    <div class="media-left">';
+            $markup[] = '      <span class="fa-stack fa-lg">';
+            $markup[] = '        <i class="fa fa-circle fa-stack-2x"></i>';
+            $markup[] = '        <i class="fa fa-' . htmlspecialchars($this->getIconName($flashMessage)) . ' fa-stack-1x"></i>';
+            $markup[] = '      </span>';
+            $markup[] = '    </div>';
+            $markup[] = '    <div class="media-body">';
+            if ($messageTitle !== '') {
+                $markup[] = '      <h4 class="alert-title">' . htmlspecialchars($messageTitle) . '</h4>';
+            }
+            $markup[] = '      <p class="alert-message">' . $flashMessage->getMessage() . '</p>';
+            $markup[] = '    </div>';
+            $markup[] = '  </div>';
+            $markup[] = '</div>';
+        }
+        $markup[] = '</div>';
+        return implode('', $markup);
+    }
+}


### PR DESCRIPTION
This patch introduce an own flashMessageRenderer to be able to show flash messages with hrefs again. This feature is only a maintenance task. See [official documentation about flash messages](https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/ApiOverview/FlashMessages/Index.html).

The other part of this patch fixes #457. Flash messages are shown again on updating kitodo records like tx_dlf_documents. Unfortunately in this case, the default renderer is used with the message queue core.template.flashMessages.

If you find a better way, please let me know :-)

