### PR TITLE
Bootstrap on accessing the extension configuration in TYPO3 9.

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -637,6 +637,8 @@ class Helper
         ) {
             // Instantiate TYPO3 core engine.
             $dataHandler = GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
+            // We do not use workspaces and have to bypass restrictions in DataHandler.
+            $dataHandler->bypassWorkspaceRestrictions = true;
             // Load data and command arrays.
             $dataHandler->start($data, $cmd);
             // Process command map first if default order is reversed.

--- a/Classes/Hooks/ConfigurationForm.php
+++ b/Classes/Hooks/ConfigurationForm.php
@@ -16,6 +16,8 @@ use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Core\Bootstrap;
 
 /**
  * Hooks and helper for \TYPO3\CMS\Core\TypoScript\ConfigurationForm
@@ -93,6 +95,18 @@ class ConfigurationForm
      */
     public function checkMetadataFormats()
     {
+        // We need to do some bootstrapping manually as of TYPO3 9.
+        if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version(), '9.0.0', '>=')) {
+            // fill $GLOBALS['TCA']
+            ExtensionManagementUtility::loadBaseTca(false);
+            // get constants from dlf/ext_localconf.php
+            ExtensionManagementUtility::loadExtLocalconf(false);
+            // fill $GLOBALS['BE_USER']
+            Bootstrap::initializeBackendUser();
+            // Initializes and ensures authenticated access
+            Bootstrap::initializeBackendAuthentication();
+        }
+
         $nsDefined = [
             'MODS' => false,
             'TEIHDR' => false,
@@ -101,7 +115,6 @@ class ConfigurationForm
             'IIIF2' => false,
             'IIIF3' => false
         ];
-
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_dlf_formats');
 

--- a/Classes/Hooks/ConfigurationForm.php
+++ b/Classes/Hooks/ConfigurationForm.php
@@ -14,10 +14,10 @@ namespace Kitodo\Dlf\Hooks;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
+use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Core\Bootstrap;
 
 /**
  * Hooks and helper for \TYPO3\CMS\Core\TypoScript\ConfigurationForm
@@ -97,13 +97,13 @@ class ConfigurationForm
     {
         // We need to do some bootstrapping manually as of TYPO3 9.
         if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version(), '9.0.0', '>=')) {
-            // fill $GLOBALS['TCA']
+            // Load table configuration array into $GLOBALS['TCA'].
             ExtensionManagementUtility::loadBaseTca(false);
-            // get constants from dlf/ext_localconf.php
+            // Get extension configuration from dlf/ext_localconf.php.
             ExtensionManagementUtility::loadExtLocalconf(false);
-            // fill $GLOBALS['BE_USER']
+            // Initialize backend user into $GLOBALS['BE_USER'].
             Bootstrap::initializeBackendUser();
-            // Initializes and ensures authenticated access
+            // Initialize backend and ensure authenticated access.
             Bootstrap::initializeBackendAuthentication();
         }
 


### PR DESCRIPTION
In TYPO3 9 the following arrays are not filled on access of
checkMetadataFormats():

* $GLOBALS['TCA']
* $GLOBALS['BE_USER']
* all devlog constants defined in ext_localconf.php

We need to do some bootstrapping manually here.