### PR TITLE
Enhance the calendar plugin.

### DIFF
--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -82,7 +82,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             case 'year':
                 return $this->calendar($content, $conf);
             case 'issue':
-                default:
+            default:
                 break;
         }
 

--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -63,16 +63,11 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             return $content;
         }
 
-        $metadata = $this->doc->getTitledata($this->doc->cPid);
+        $metadata = $this->doc->getTitledata();
         if (!empty($metadata['type'][0])) {
-            // Calendar plugin does not support IIIF (yet). Abort for all newspaper related types.
-            if (
-                $doc instanceof IiifManifest
-                && array_search($metadata['type'][0], ['newspaper', 'ephemera', 'year', 'issue']) !== false
-            ) {
-                return $type;
-            }
             $type = $metadata['type'][0];
+        } else {
+            return $content;
         }
 
         switch ($type) {

--- a/Configuration/Flexforms/Calendar.xml
+++ b/Configuration/Flexforms/Calendar.xml
@@ -40,6 +40,46 @@
                             </config>
                         </TCEforms>
                     </pages>
+                    <targetPid>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/Calendar.xml:tt_content.pi_flexform.targetPid</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>db</internal_type>
+                                <allowed>pages</allowed>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>0</minitems>
+                                <show_thumbs>1</show_thumbs>
+                                <wizards>
+                                    <suggest>
+                                        <type>suggest</type>
+                                    </suggest>
+                                </wizards>
+                            </config>
+                        </TCEforms>
+                    </targetPid>
+                    <initialDocument>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/Calendar.xml:tt_content.pi_flexform.initialDocument</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>db</internal_type>
+                                <allowed>tx_dlf_documents</allowed>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>0</minitems>
+                                <show_thumbs>1</show_thumbs>
+                                <wizards>
+                                    <suggest>
+                                        <type>suggest</type>
+                                    </suggest>
+                                </wizards>
+                            </config>
+                        </TCEforms>
+                    </initialDocument>
                     <showEmptyMonths>
                       <TCEforms>
                         <exclude>1</exclude>

--- a/Resources/Private/Language/Calendar.xml
+++ b/Resources/Private/Language/Calendar.xml
@@ -15,8 +15,10 @@
     </meta>
     <data type="array">
         <languageKey index="default" type="array">
+            <label index="tt_content.pi_flexform.initialDocument">Initial document to show (e.g. of type "newspaper" or "ephemera")</label>
             <label index="tt_content.pi_flexform.sheet_general">Options</label>
             <label index="tt_content.pi_flexform.showEmptyMonths">Show months without issues in calendar?</label>
+            <label index="tt_content.pi_flexform.targetPid">Target page (with "DLF: Page View" or "DLF: Calendar View" plugin)</label>
             <label index="tt_content.pi_flexform.templateFile">Template file</label>
             <label index="allYears">All years overview - </label>
             <label index="label.please_choose_year">Please choose a year first.</label>
@@ -24,8 +26,10 @@
             <label index="label.view_list">List View</label>
         </languageKey>
         <languageKey index="de" type="array">
+            <label index="tt_content.pi_flexform.initialDocument">Anfangsdokument (z.B. vom Typ "newspaper" oder "ephemera)</label>
             <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
             <label index="tt_content.pi_flexform.showEmptyMonths">Zeige Monate ohne Ausgaben im Kalender?</label>
+            <label index="tt_content.pi_flexform.targetPid">Zielseite (mit Plugin "DLF: Seitenansicht" oder "DLF: Kalenderansicht")</label>
             <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
             <label index="allYears">Jahrgangsübersicht - </label>
             <label index="label.please_choose_year">Bitte wählen Sie zunächst einen Jahrgang aus.</label>


### PR DESCRIPTION
The calendar plugin is not usable without a TypoScrip condition or a
condition inside Fluid. The main() method is without any function so
far.

This patch adds the possibility to place the plugin on a separate page
like the pageview plugin.

The main method now does the type-check. Additionally it is possible to
configure an initial document. E.g. the anchor file of a newspaper. So
you may do a page with a calendar of a special newspaper or a single
year.