### PR TITLE
Proposal: Link to PURL in listview and calendar plugin.

### DIFF
--- a/Classes/Common/DocumentList.php
+++ b/Classes/Common/DocumentList.php
@@ -174,6 +174,7 @@ class DocumentList implements \ArrayAccess, \Countable, \Iterator, \TYPO3\CMS\Co
                 $result = $queryBuilder
                     ->select(
                         'tx_dlf_documents.uid AS uid',
+                        'tx_dlf_documents.purl AS purl',
                         'tx_dlf_documents.thumbnail AS thumbnail',
                         'tx_dlf_documents.metadata AS metadata'
                     )
@@ -216,6 +217,7 @@ class DocumentList implements \ArrayAccess, \Countable, \Iterator, \TYPO3\CMS\Co
                     // Add metadata to list element.
                     if ($resArray['uid'] == $record['uid']) {
                         $record['thumbnail'] = $resArray['thumbnail'];
+                        $record['purl'] = $resArray['purl'];
                         $record['metadata'] = $metadata;
                     } elseif (($key = array_search(['u' => $resArray['uid']], $record['subparts'], true)) !== false) {
                         $record['subparts'][$key] = [
@@ -234,7 +236,7 @@ class DocumentList implements \ArrayAccess, \Countable, \Iterator, \TYPO3\CMS\Co
                 if ($this->solrConnect()) {
                     $params = [];
                     // Restrict the fields to the required ones
-                    $params['fields'] = 'uid,id,toplevel,thumbnail,page';
+                    $params['fields'] = 'uid,id,toplevel,thumbnail,page,purl';
                     foreach ($this->solrConfig as $solr_name) {
                         $params['fields'] .= ',' . $solr_name;
                     }
@@ -286,6 +288,7 @@ class DocumentList implements \ArrayAccess, \Countable, \Iterator, \TYPO3\CMS\Co
                         // Add metadata to list elements.
                         if ($resArray->toplevel) {
                             $record['thumbnail'] = $resArray->thumbnail;
+                            $record['purl'] = $resArray->purl;
                             $record['metadata'] = $metadata;
                         } else {
                             $highlightedDoc = !empty($highlighting) ? $highlighting->getResult($resArray->id) : null;

--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -115,6 +115,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             ->select(
                 'tx_dlf_documents.uid AS uid',
                 'tx_dlf_documents.title AS title',
+                'tx_dlf_documents.purl AS purl',
                 'tx_dlf_documents.year AS year',
                 'tx_dlf_documents.mets_label AS label',
                 'tx_dlf_documents.mets_orderlabel AS orderlabel'
@@ -144,7 +145,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             $issues[] = [
                 'uid' => $resArray['uid'],
                 'title' => $title,
-                'year' => $resArray['year']
+                'year' => $resArray['year'],
+                'purl' => $resArray['purl'],
             ];
         }
         //  We need an array of issues with year => month => day number as key.
@@ -297,7 +299,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
                                         $dayLinkLabel = empty($issue['title']) ? strftime('%x', $currentDayTime) : $issue['title'];
                                         $linkConf = [
                                             'useCacheHash' => 1,
-                                            'parameter' => $this->conf['targetPid'],
+                                            'parameter' => $this->conf['linkToPurl'] ? $issue['purl'] : $this->conf['targetPid'],
                                             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($issue['uid']),
                                             'ATagParams' => ' class="title"',
                                         ];
@@ -384,6 +386,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             ->select(
                 'tx_dlf_documents.uid AS uid',
                 'tx_dlf_documents.title AS title',
+                'tx_dlf_documents.purl AS purl',
                 'tx_dlf_documents.mets_label AS label',
                 'tx_dlf_documents.mets_orderlabel AS orderlabel'
             )

--- a/Classes/Plugin/ListView.php
+++ b/Classes/Plugin/ListView.php
@@ -163,7 +163,8 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
                         }
                         $conf = [
                             'useCacheHash' => 1,
-                            'parameter' => $this->conf['targetPid'],
+                            'parameter' => $this->conf['linkToPurl'] ? ($this->list[$number]['purl'] . '/' . $this->list[$number]['page']) : $this->conf['targetPid'],
+                            // additionalParams is only active with internal links
                             'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
                         ];
                         $value = $this->cObj->typoLink(htmlspecialchars($value), $conf);
@@ -324,18 +325,27 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
                             $value = $noTitle;
                         }
                         $imgAlt = htmlspecialchars($value);
-                        $additionalParams = [
-                            'id' => $subpart['uid'],
-                            'page' => $subpart['page'],
-                            'highlight_word' => $highlight_word
-                        ];
+                        if (!empty($this->conf['linkToPurl'])) {
+                            $additionalParams = [
+                                'highlight_word' => $highlight_word
+                            ];
+                        } else {
+                            $additionalParams = [
+                                'id' => $subpart['uid'],
+                                'page' => $subpart['page'],
+                                'highlight_word' => $highlight_word
+                            ];
+                        }
                         if (!empty($this->piVars['logicalPage'])) {
                             $additionalParams['logicalPage'] = $this->piVars['logicalPage'];
                         }
                         $conf = [
                             // we don't want cHash in case of search parameters
                             'useCacheHash' => empty($this->list->metadata['searchString']) ? 1 : 0,
-                            'parameter' => $this->conf['targetPid'],
+                            'parameter' => $this->conf['linkToPurl']
+                                ? ($this->list[$number]['purl'] . '/' . $subpart['page'] . '?' . \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false))
+                                : $this->conf['targetPid'],
+                            // additionalParams is only active with internal links
                             'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
                         ];
                         $value = $this->cObj->typoLink(htmlspecialchars($value), $conf);

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -19,8 +19,41 @@ Plugin Reference
 Kitodo Plugin Reference
 =======================
 
-Common Settings
+Global Settings
 ---------------
+
+Settings can be done done on muliple places. The order is the following:
+
+ Flexforms > TS-Templates > Extension Configuration > ext_localconf.php
+
+Properties
+^^^^^^^^^^
+:typoscript:`plugin.tx_dlf.`
+
+.. t3-field-list-table::
+ :header-rows: 1
+
+ - :Property:
+       Property
+   :Data Type:
+       Data type
+   :Default:
+        Default
+
+ - :Property:
+       linkToPurl
+   :Data Type:
+       :ref:`t3tsref:data-type-boolean`
+   :Default:
+        0
+
+linkToPurl
+""""""""""
+Link to PURL in suitable plugins (listview, calendar) instead directly to a local page with the page view plugin.
+
+
+Common Properties
+-----------------
 pages
 ^^^^^
 Startingpoint of this plugin. This is the Kitodo.Presentation data folder.
@@ -190,11 +223,27 @@ Calendar
    :Default:
 
  - :Property:
+       targetPid
+   :Data Type:
+       :ref:`t3tsref:data-type-page-id`
+   :Default:
+
+ - :Property:
+       initialDocument
+   :Data Type:
+       :ref:`t3tsref:data-type-db`
+   :Default:
+
+ - :Property:
        templateFile_
    :Data Type:
        :ref:`t3tsref:data-type-resource`
    :Default:
        Calendar.tmpl
+
+initialDocument
+"""""""""""""""
+UID of a newspaper or ephemera document to show the calendar initially (type=newspaper|ephemera|year).
 
 
 Collection


### PR DESCRIPTION
This is a new feature which makes it possible to use the PURL to link
documents out of the search, listview and calendar plugins.

To enable this feature, you can use the TypoScript setting
  `plugin.tx_dlf.linkToPurl = 1`

Serveral questions appear during implementation:

* Should we add the setting to the extension configuration (globaly),
  too?
* Which plugins make it sense to add this feature? I could imagine the
  feed plugin, maybe the OAI-plugin?
* The highlight_word parameter will be appended to the PURL. Otherwise
  it get's lost from listview -> pageview. Is this a clean way? The we
  must enable the resolver to allow additional parameters like this.