### PR TITLE
Change target navigation of calendar plugin.

### DIFF
--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -203,7 +203,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
         // Link to current year.
         $linkConf = [
             'useCacheHash' => 1,
-            'parameter' => $this->conf['targetPid'],
+            'parameter' => $GLOBALS['TSFE']->id,
             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($this->doc->uid),
         ];
         $linkTitleData = $this->doc->getTitledata();
@@ -212,7 +212,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
         // Link to years overview.
         $linkConf = [
             'useCacheHash' => 1,
-            'parameter' => $this->conf['targetPid'],
+            'parameter' => $GLOBALS['TSFE']->id,
             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($this->doc->parentId),
         ];
         $allYearsLink = $this->cObj->typoLink($this->pi_getLL('allYears', '', true) . ' ' . $this->doc->getTitle($this->doc->parentId), $linkConf);
@@ -409,7 +409,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             foreach ($years as $year) {
                 $linkConf = [
                     'useCacheHash' => 1,
-                    'parameter' => $this->conf['targetPid'],
+                    'parameter' => $GLOBALS['TSFE']->id,
                     'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($year['uid']),
                     'title' => $titleAnchor . ': ' . $year['title']
                 ];
@@ -422,7 +422,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
         // Link to years overview (should be itself here)
         $linkConf = [
             'useCacheHash' => 1,
-            'parameter' => $this->conf['targetPid'],
+            'parameter' => $GLOBALS['TSFE']->id,
             'additionalParams' => '&' . $this->prefixId . '[id]=' . $this->doc->uid,
         ];
         $allYearsLink = $this->cObj->typoLink($this->pi_getLL('allYears', '', true) . ' ' . $this->doc->getTitle($this->doc->uid), $linkConf);

--- a/Resources/Private/Language/Calendar.xml
+++ b/Resources/Private/Language/Calendar.xml
@@ -18,7 +18,7 @@
             <label index="tt_content.pi_flexform.initialDocument">Initial document to show (e.g. of type "newspaper" or "ephemera")</label>
             <label index="tt_content.pi_flexform.sheet_general">Options</label>
             <label index="tt_content.pi_flexform.showEmptyMonths">Show months without issues in calendar?</label>
-            <label index="tt_content.pi_flexform.targetPid">Target page (with "DLF: Page View" or "DLF: Calendar View" plugin)</label>
+            <label index="tt_content.pi_flexform.targetPid">Target page (with "DLF: Page View")</label>
             <label index="tt_content.pi_flexform.templateFile">Template file</label>
             <label index="allYears">All years overview - </label>
             <label index="label.please_choose_year">Please choose a year first.</label>
@@ -29,7 +29,7 @@
             <label index="tt_content.pi_flexform.initialDocument">Anfangsdokument (z.B. vom Typ "newspaper" oder "ephemera)</label>
             <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
             <label index="tt_content.pi_flexform.showEmptyMonths">Zeige Monate ohne Ausgaben im Kalender?</label>
-            <label index="tt_content.pi_flexform.targetPid">Zielseite (mit Plugin "DLF: Seitenansicht" oder "DLF: Kalenderansicht")</label>
+            <label index="tt_content.pi_flexform.targetPid">Zielseite (mit Plugin "DLF: Seitenansicht")</label>
             <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
             <label index="allYears">Jahrgangsübersicht - </label>
             <label index="label.please_choose_year">Bitte wählen Sie zunächst einen Jahrgang aus.</label>


### PR DESCRIPTION
The calendar plugin knows the targetPid setting as almost all plugins.
Up to know there is only one targetPid so the pageview has to be on the
same uid as the calendar plugin.

With this patch, the targetPid is only used to address the pageview of
an issue. To link between anchor and year (calendar), the current uid is
used.