### PR TITLE
Check for empty toolbox configuration.

### DIFF
--- a/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
+++ b/plugins/toolbox/tools/fulltext/class.tx_dlf_toolsFulltext.php
@@ -37,7 +37,9 @@ class tx_dlf_toolsFulltext extends tx_dlf_plugin {
         $this->init($conf);
 
         // Merge configuration with conf array of toolbox.
-        $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data['conf'])) {
+            $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        }
 
         // Load current document.
         $this->loadDocument();

--- a/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php
+++ b/plugins/toolbox/tools/imagedownload/class.tx_dlf_toolsImagedownload.php
@@ -36,7 +36,9 @@ class tx_dlf_toolsImagedownload extends tx_dlf_plugin {
         $this->init($conf);
 
         // Merge configuration with conf array of toolbox.
-        $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data['conf'])) {
+            $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        }
 
         // Load current document.
         $this->loadDocument();

--- a/plugins/toolbox/tools/imagemanipulation/class.tx_dlf_toolsImagemanipulation.php
+++ b/plugins/toolbox/tools/imagemanipulation/class.tx_dlf_toolsImagemanipulation.php
@@ -36,7 +36,9 @@ class tx_dlf_toolsImagemanipulation extends tx_dlf_plugin {
         $this->init($conf);
 
         // Merge configuration with conf array of toolbox.
-        $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data['conf'])) {
+            $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        }
 
         // Load current document.
         $this->loadDocument();

--- a/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
+++ b/plugins/toolbox/tools/pdf/class.tx_dlf_toolsPdf.php
@@ -37,7 +37,9 @@ class tx_dlf_toolsPdf extends tx_dlf_plugin {
         $this->init($conf);
 
         // Merge configuration with conf array of toolbox.
-        $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        if (!empty($this->cObj->data['conf'])) {
+            $this->conf = tx_dlf_helper::array_merge_recursive_overrule($this->cObj->data['conf'], $this->conf);
+        }
 
         // Load current document.
         $this->loadDocument();


### PR DESCRIPTION
This is a backport of Commit 9464b3907e7a469e1b11f797bfd1c1c2dfc7b902 to
Kitodo.Presentation 3.0. This makes it easier to use the tools directly
in fluid templates.
This condition is already used in `tx_dlf_toolsSearchindocument` but not in the other tools.