### PR TITLE
Fix Image Manipuation Tool (again).

### DIFF
--- a/Resources/Public/Javascript/PageView/ImageManipulationControl.js
+++ b/Resources/Public/Javascript/PageView/ImageManipulationControl.js
@@ -71,7 +71,7 @@ dlfViewerImageManipulationControl = function(options) {
      * @type {Element}
      * @private
      */
-    this.toolContainerEl_ = dlfUtils.exists(options.toolContainer) ? options.toolContainer: $('.tx-dlf-Toolbox')[0];
+    this.toolContainerEl_ = dlfUtils.exists(options.toolContainer) ? options.toolContainer: $('.tx-dlf-toolbox')[0];
 
     //
     // Append open/close behavior to toolbox


### PR DESCRIPTION
The regulator of the imagemanipulation tools are shown within the `<div class="tx-dlf-toolbox">`. During development of Kitodo.Presentation 3.0 the plugin CSS classes changed to use the uppercase class name first.

With commit a196b60f3d765420fc10e9d6c163f65f41b9f700 this has been changed and lowercase is used again.

In commit b41db8b4b4ee5745b5ddb480544e3a8ab102e080 the CSS class of the imagemanipulation tool JavaScript selector has been modified. This is changed back in this commit.