### PR TITLE
Better markup for listview pagebrowser.

### DIFF
--- a/Classes/Plugin/ListView.php
+++ b/Classes/Plugin/ListView.php
@@ -84,9 +84,9 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
         $separator = $this->pi_getLL('separator', ' - ', true);
         // Add link to previous page.
         if ($this->piVars['pointer'] > 0) {
-            $output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;', true), ['pointer' => $this->piVars['pointer'] - 1], true) . $separator;
+            $output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;', true), ['pointer' => $this->piVars['pointer'] - 1], true) . '<span class="separator">' . $separator . '</span>';
         } else {
-            $output = $this->pi_getLL('prevPage', '&lt;', true) . $separator;
+            $output = '<span>' . $this->pi_getLL('prevPage', '&lt;', true) . '</span><span class="separator">' . $separator . '</span>';
         }
         $i = 0;
         $skip = null;
@@ -94,13 +94,13 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
         while ($i < $maxPages) {
             if ($i < 3 || ($i > $this->piVars['pointer'] - 3 && $i < $this->piVars['pointer'] + 3) || $i > $maxPages - 4) {
                 if ($this->piVars['pointer'] != $i) {
-                    $output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d', true), $i + 1), ['pointer' => $i], true) . $separator;
+                    $output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d', true), $i + 1), ['pointer' => $i], true) . '<span class="separator">' . $separator . '</span>';
                 } else {
-                    $output .= sprintf($this->pi_getLL('page', '%d', true), $i + 1) . $separator;
+                    $output .= '<span class="active">' . sprintf($this->pi_getLL('page', '%d', true), $i + 1) . '</span><span class="separator">' . $separator . '</span>';
                 }
                 $skip = true;
             } elseif ($skip === true) {
-                $output .= $this->pi_getLL('skip', '...', true) . $separator;
+                $output .= '<span class="skip">' . $this->pi_getLL('skip', '...', true) . '</span><span class="separator">' . $separator . '</span>';
                 $skip = false;
             }
             $i++;
@@ -109,7 +109,7 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
         if ($this->piVars['pointer'] < $maxPages - 1) {
             $output .= $this->pi_linkTP_keepPIvars($this->pi_getLL('nextPage', '&gt;', true), ['pointer' => $this->piVars['pointer'] + 1], true);
         } else {
-            $output .= $this->pi_getLL('nextPage', '&gt;', true);
+            $output .= '<span>' .$this->pi_getLL('nextPage', '&gt;', true) . '</span>';
         }
         return $output;
     }

--- a/Classes/Plugin/ListView.php
+++ b/Classes/Plugin/ListView.php
@@ -81,12 +81,12 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
             return '';
         }
         // Get separator.
-        $separator = $this->pi_getLL('separator', ' - ', true);
+        $separator = '<span class="separator">' . $this->pi_getLL('separator', ' - ', true) . '</span>';
         // Add link to previous page.
         if ($this->piVars['pointer'] > 0) {
-            $output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;', true), ['pointer' => $this->piVars['pointer'] - 1], true) . '<span class="separator">' . $separator . '</span>';
+            $output = $this->pi_linkTP_keepPIvars($this->pi_getLL('prevPage', '&lt;', true), ['pointer' => $this->piVars['pointer'] - 1], true) . $separator;
         } else {
-            $output = '<span>' . $this->pi_getLL('prevPage', '&lt;', true) . '</span><span class="separator">' . $separator . '</span>';
+            $output = '<span>' . $this->pi_getLL('prevPage', '&lt;', true) . '</span>' . $separator;
         }
         $i = 0;
         $skip = null;
@@ -94,13 +94,13 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
         while ($i < $maxPages) {
             if ($i < 3 || ($i > $this->piVars['pointer'] - 3 && $i < $this->piVars['pointer'] + 3) || $i > $maxPages - 4) {
                 if ($this->piVars['pointer'] != $i) {
-                    $output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d', true), $i + 1), ['pointer' => $i], true) . '<span class="separator">' . $separator . '</span>';
+                    $output .= $this->pi_linkTP_keepPIvars(sprintf($this->pi_getLL('page', '%d', true), $i + 1), ['pointer' => $i], true) . $separator;
                 } else {
-                    $output .= '<span class="active">' . sprintf($this->pi_getLL('page', '%d', true), $i + 1) . '</span><span class="separator">' . $separator . '</span>';
+                    $output .= '<span class="active">' . sprintf($this->pi_getLL('page', '%d', true), $i + 1) . '</span>' . $separator;
                 }
                 $skip = true;
             } elseif ($skip === true) {
-                $output .= '<span class="skip">' . $this->pi_getLL('skip', '...', true) . '</span><span class="separator">' . $separator . '</span>';
+                $output .= '<span class="skip">' . $this->pi_getLL('skip', '...', true) . '</span>' . $separator;
                 $skip = false;
             }
             $i++;
@@ -109,7 +109,7 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
         if ($this->piVars['pointer'] < $maxPages - 1) {
             $output .= $this->pi_linkTP_keepPIvars($this->pi_getLL('nextPage', '&gt;', true), ['pointer' => $this->piVars['pointer'] + 1], true);
         } else {
-            $output .= '<span>' .$this->pi_getLL('nextPage', '&gt;', true) . '</span>';
+            $output .= '<span>' . $this->pi_getLL('nextPage', '&gt;', true) . '</span>';
         }
         return $output;
     }


### PR DESCRIPTION
The current markup of the pagebrowser is as follows:

```
<p class="tx-dlf-pagebrowser">
        &lt; - 1 -
        <a href="/listenansicht?tx_dlf%5Bpointer%5D=1&amp;cHash=eb8b8cfb2f0a3ceff42e4736914db972">2</a>
         -
        <a href="/listenansicht?tx_dlf%5Bpointer%5D=2&amp;cHash=65978b125c84a3989a08d99ca605d932">3</a>
         - ... -
        <a href="/listenansicht?tx_dlf%5Bpointer%5D=307&amp;cHash=fb0b9ec99993a5c2396053d1720bd902">308</a>
         -
        <a href="/listenansicht?tx_dlf%5Bpointer%5D=308&amp;cHash=cb9b71da010da38114ecc62c6c546e94">309</a>
         -
        <a href="/listenansicht?tx_dlf%5Bpointer%5D=309&amp;cHash=cad88079150728e410b34fd4a7558b5e">310</a>
         -
        <a href="/listenansicht?tx_dlf%5Bpointer%5D=1&amp;cHash=eb8b8cfb2f0a3ceff42e4736914db972">&gt;</a>
</p>
```
This is hard to design as the separators, skip, active and previous
"buttons" cannot be styled by CSS.

The current patch changes the markup to the following:

```
<p class="tx-dlf-pagebrowser">
	<span>&lt;</span>
	<span class="separator"> - </span>
	<span class="active">1</span>
	<span class="separator"> - </span>
	<a href="/listenansicht?tx_dlf%5Bpointer%5D=1&amp;cHash=eb8b8cfb2f0a3ceff42e4736914db972">2</a>
	<span class="separator"> - </span>
	<a href="/listenansicht?tx_dlf%5Bpointer%5D=2&amp;cHash=65978b125c84a3989a08d99ca605d932">3</a>
	<span class="separator"> - </span>
	<span class="skip">...</span>
	<span class="separator"> - </span>
	<a href="/listenansicht?tx_dlf%5Bpointer%5D=307&amp;cHash=fb0b9ec99993a5c2396053d1720bd902">308</a>
	<span class="separator"> - </span>
	<a href="/listenansicht?tx_dlf%5Bpointer%5D=308&amp;cHash=cb9b71da010da38114ecc62c6c546e94">309</a>
	<span class="separator"> - </span>
	<a href="/listenansicht?tx_dlf%5Bpointer%5D=309&amp;cHash=cad88079150728e410b34fd4a7558b5e">310</a>
	<span class="separator"> - </span>
	<a href="/listenansicht?tx_dlf%5Bpointer%5D=1&amp;cHash=eb8b8cfb2f0a3ceff42e4736914db972">&gt;</a>
</p>
```
Now, all text may be styled separately. The `<span class="separator">`
could be hidden if the other links and spans are styled as buttons.