### PR TITLE
Facet collection configuration fix

### DIFF
--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -609,7 +609,7 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin
             ->execute();
 
         while ($collection = $result->fetch()) {
-            $facetCollectionArray[] = $collection[0];
+            $facetCollectionArray[] = $collection['index_name'];
         }
 
         // Process results.


### PR DESCRIPTION
This part controls the output of the collection facet.
With $collection[0] the facetCollectionArray only gets filled with NULL instead of the collection name. The PR should fix it.