### PR TITLE
Fill orderlabel for sub-entries in TableOfContents plugin.

### DIFF
--- a/Classes/Plugin/TableOfContents.php
+++ b/Classes/Plugin/TableOfContents.php
@@ -226,6 +226,7 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
                     'tx_dlf_documents.uid AS uid',
                     'tx_dlf_documents.title AS title',
                     'tx_dlf_documents.volume AS volume',
+                    'tx_dlf_documents.mets_label AS mets_label',
                     'tx_dlf_documents.mets_orderlabel AS mets_orderlabel',
                     'tx_dlf_structures_join.index_name AS type'
                 )
@@ -255,7 +256,7 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
                 $menuArray[0]['_SUB_MENU'] = [];
                 foreach ($allResults as $resArray) {
                     $entry = [
-                        'label' => $resArray['title'],
+                        'label' => !empty($resArray['mets_label']) ? $resArray['mets_label'] : $resArray['title'],
                         'type' => $resArray['type'],
                         'volume' => $resArray['volume'],
                         'orderlabel' => $resArray['mets_orderlabel'],

--- a/Classes/Plugin/TableOfContents.php
+++ b/Classes/Plugin/TableOfContents.php
@@ -226,6 +226,7 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
                     'tx_dlf_documents.uid AS uid',
                     'tx_dlf_documents.title AS title',
                     'tx_dlf_documents.volume AS volume',
+                    'tx_dlf_documents.mets_orderlabel AS mets_orderlabel',
                     'tx_dlf_structures_join.index_name AS type'
                 )
                 ->innerJoin(
@@ -243,7 +244,8 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
                     $queryBuilder->expr()->eq('tx_dlf_structures_join.pid', intval($this->doc->pid)),
                     $excludeOtherWhere
                 )
-                ->orderBy('tx_dlf_documents.volume_sorting')
+                ->addOrderBy('tx_dlf_documents.volume_sorting')
+                ->addOrderBy('tx_dlf_documents.mets_orderlabel')
                 ->execute();
 
             $allResults = $result->fetchAll();
@@ -256,6 +258,7 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
                         'label' => $resArray['title'],
                         'type' => $resArray['type'],
                         'volume' => $resArray['volume'],
+                        'orderlabel' => $resArray['mets_orderlabel'],
                         'pagination' => '',
                         'targetUid' => $resArray['uid']
                     ];


### PR DESCRIPTION
With newspaper/ephemera year files the fields title, year, volume,
volume_sorting are not filled. The TableOfContents plugin only shows the
structure type ("Year") on the anchor level.

The label we want to see is the mets_orderlabel in this case. But this
field is not queried in the plugin.

Filling the internal "orderlabel" field in the menuArray fixes this
issue. The "orderlabel" will be filled into the "title" field in
getMenuEntry().

Another issue is fixed in this patch: The ordering of the menu entries.
The sorting does not work if volume is not filled. In this case the
sorting by mets_orderlabel must be used.