### PR TITLE
Fix JavaScript error introduced with PR #487.

### DIFF
--- a/Resources/Public/Javascript/PageView/OL3.js
+++ b/Resources/Public/Javascript/PageView/OL3.js
@@ -100,7 +100,7 @@ ol.Map.prototype.rotate = function(rotation) {
         'duration':200
     }));
     view.rotate(rotate, center);
-    if (this.ov_view !== null) {
+    if (this.ov_view !== null && this.ov_view !== undefined) {
         this.ov_view.rotate(rotate);
     }
 };
@@ -110,7 +110,7 @@ ol.Map.prototype.rotate = function(rotation) {
  */
 ol.Map.prototype.rotateLeft = function() {
     this.rotate(-5);
-    if (this.ov_view !== null) {
+    if (this.ov_view !== null && this.ov_view !== undefined) {
         this.ov_view.rotate(-5);
     }
 };
@@ -120,7 +120,8 @@ ol.Map.prototype.rotateLeft = function() {
  */
 ol.Map.prototype.rotateRight = function() {
     this.rotate(5);
-    if (this.ov_view !== null) {
+    if (this.ov_view !== null && this.ov_view !== undefined) {
+        alert('no');
         this.ov_view.rotate(5);
     }
 };
@@ -130,7 +131,7 @@ ol.Map.prototype.rotateRight = function() {
  */
 ol.Map.prototype.resetRotation = function() {
     this.getView().rotate(0, this.getView().getCenter());
-    if (this.ov_view !== null) {
+    if (this.ov_view !== null && this.ov_view !== undefined) {
         this.ov_view.rotate(0);
     }
 };

--- a/Resources/Public/Javascript/PageView/OL3.js
+++ b/Resources/Public/Javascript/PageView/OL3.js
@@ -121,7 +121,6 @@ ol.Map.prototype.rotateLeft = function() {
 ol.Map.prototype.rotateRight = function() {
     this.rotate(5);
     if (this.ov_view !== null && this.ov_view !== undefined) {
-        alert('no');
         this.ov_view.rotate(5);
     }
 };


### PR DESCRIPTION
Using the rotate buttons, a JavaScript error is shown in the webconsole:

``Uncaught TypeError: Cannot read property 'rotate' of undefined``

This is due to the change of the condition in OL3.js:

Old:
```
if (this.ov_view != null) {
	this.ov_view.rotate(0);
}
```

New in PR #487:
```
if (this.ov_view !== null) {
	this.ov_view.rotate(0);
}
```

This patch:
```
if (this.ov_view !== null && this.ov_view !== undefined) {
	this.ov_view.rotate(0);
}
```

The problem is, that `this.ov_view` is always `undefined` NOT `null`. So
the change with PR #487 causes the entry into the if condition.

I suspect that the above condition will never work. But I have no idea
how the "magnifier" feature works and didn't get it working.