### PR TITLE
Fix the searchInDocument tool on initial page.

### DIFF
--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -60,6 +60,22 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
+        } else {
+            if (!empty($this->piVars['logicalPage'])) {
+                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
+                // The logical page parameter should not appear again
+                unset($this->piVars['logicalPage']);
+            }
+            // Set default values if not set.
+            // $this->piVars['page'] may be integer or string (physical structure @ID)
+            if (
+                (int) $this->piVars['page'] > 0
+                || empty($this->piVars['page'])
+            ) {
+                $this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
+            } else {
+                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
+            }
         }
 
         // Quit if no fulltext file is present


### PR DESCRIPTION
If calling a document, the parameter tx_dlf[page] may be empty. In this
case usually page 1 is taken. This is the default behaviour of all
plugins. In searchInDocument this part is missing and the search is
disabled on the initial page.