### PR TITLE
refactores $GLOBALS['TYPO3_DB'] to QueryBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 .vscode
 nbproject/
 Documentation-GENERATED-temp/
+vendor/
+public/
+composer.lock

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -40,17 +40,21 @@ class ext_update
      *
      * @return bool Should the update option be shown?
      */
-    public function access()
+    public function access(): bool
     {
         if (count($this->getMetadataConfig())) {
             return true;
-        } elseif ($this->oldIndexRelatedTableNames()) {
+        }
+        if ($this->oldIndexRelatedTableNames()) {
             return true;
-        } elseif ($this->solariumSolrUpdateRequired()) {
+        }
+        if ($this->solariumSolrUpdateRequired()) {
             return true;
-        } elseif (count($this->oldFormatClasses())) {
+        }
+        if (count($this->oldFormatClasses())) {
             return true;
-        } elseif ($this->hasNoFormatForDocument()) {
+        }
+        if ($this->hasNoFormatForDocument()) {
             return true;
         }
         return false;
@@ -63,7 +67,7 @@ class ext_update
      *
      * @return string The content that is displayed on the website
      */
-    public function main()
+    public function main(): string
     {
         // Load localization file.
         $GLOBALS['LANG']->includeLLFile('EXT:dlf/Resources/Private/Language/FlashMessages.xml');
@@ -86,7 +90,7 @@ class ext_update
         }
         return $this->content;
     }
-    
+
     /**
      * Get all outdated metadata configuration records
      *
@@ -94,7 +98,7 @@ class ext_update
      *
      * @return array Array of UIDs of outdated records
      */
-    protected function getMetadataConfig()
+    protected function getMetadataConfig(): array
     {
         $uids = [];
         // check if tx_dlf_metadata.xpath exists anyhow
@@ -107,15 +111,14 @@ class ext_update
 
         $rows = $result->fetchAll();
 
-        if((count($rows) === 0) || !in_array('xpath', array_keys($rows[0]))) {
+        if((count($rows) === 0) || !array_key_exists('xpath', $rows[0])) {
             return $uids;
-        } else {
-            foreach($rows as $row) {
-                if($row['format'] === 0 && $row['xpath']) {
-                    $uids[] = intval($row['uid']);
-                }
+        }
+        foreach($rows as $row) {
+            if($row['format'] === 0 && $row['xpath']) {
+                $uids[] = (int)$row['uid'];
             }
-        };
+        }
         return $uids;
     }
 
@@ -126,7 +129,7 @@ class ext_update
      *
      * @return bool
      */
-    protected function solariumSolrUpdateRequired()
+    protected function solariumSolrUpdateRequired(): bool
     {
         // Get all Solr cores that were not deleted.
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_solrcores');
@@ -152,7 +155,7 @@ class ext_update
      *
      * @return array containing old format classes
      */
-    protected function oldFormatClasses()
+    protected function oldFormatClasses(): array
     {
         $oldRecords = [];
         // Get all records with outdated configuration.
@@ -178,7 +181,7 @@ class ext_update
      *
      * @return bool true if old index related columns exist
      */
-    protected function oldIndexRelatedTableNames()
+    protected function oldIndexRelatedTableNames(): bool
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('INFORMATION_SCHEMA.COLUMNS');
 
@@ -189,11 +192,11 @@ class ext_update
             ->execute();
         while($resArray = $result->fetch()) {
             if (
-                $resArray['column_name'] == 'tokenized'
-                || $resArray['column_name'] == 'stored'
-                || $resArray['column_name'] == 'indexed'
-                || $resArray['column_name'] == 'boost'
-                || $resArray['column_name'] == 'autocomplete'
+                $resArray['column_name'] === 'tokenized'
+                || $resArray['column_name'] === 'stored'
+                || $resArray['column_name'] === 'indexed'
+                || $resArray['column_name'] === 'boost'
+                || $resArray['column_name'] === 'autocomplete'
             ) {
                 return true;
             }
@@ -208,7 +211,7 @@ class ext_update
      * @param bool $checkStructureOnly
      * @return bool
      */
-    protected function hasNoFormatForDocument($checkStructureOnly = false)
+    protected function hasNoFormatForDocument($checkStructureOnly = false): bool
     {
         // Check if column "document_format" exists.
         $database = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'];
@@ -221,7 +224,7 @@ class ext_update
             ->where('TABLE_NAME="tx_dlf_documents" AND TABLE_SCHEMA="' . $database . '" AND COLUMN_NAME="document_format"')
             ->execute();
         while ($resArray = $result->fetch()) {
-            if ($resArray['COLUMN_NAME'] == 'document_format') {
+            if ($resArray['COLUMN_NAME'] === 'document_format') {
                 if ($checkStructureOnly) {
                     return false;
                 }
@@ -249,7 +252,7 @@ class ext_update
      *
      * @return void
      */
-    protected function renameIndexRelatedColumns()
+    protected function renameIndexRelatedColumns(): void
     {
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_metadata');
@@ -286,7 +289,7 @@ class ext_update
      *
      * @return void
      */
-    protected function updateFormatClasses()
+    protected function updateFormatClasses(): void
     {
         $oldRecords = $this->oldFormatClasses();
         $newValues = [
@@ -320,7 +323,7 @@ class ext_update
      *
      * @return void
      */
-    protected function updateMetadataConfig()
+    protected function updateMetadataConfig(): void
     {
         $metadataUids = $this->getMetadataConfig();
         if (!empty($metadataUids)) {
@@ -387,7 +390,7 @@ class ext_update
      *
      * @return void
      */
-    protected function doSolariumSolrUpdate()
+    protected function doSolariumSolrUpdate(): void
     {
         // Get all Solr cores that were not deleted.
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_solrcores');
@@ -427,7 +430,7 @@ class ext_update
                     $status = $response->xpath('//lst[@name="responseHeader"]/int[@name="status"]');
                     if (
                         $status !== false
-                        && $status[0] == 0
+                        && $status[0] === 0
                     ) {
                         continue;
                     }
@@ -449,7 +452,12 @@ class ext_update
         $this->content .= Helper::renderFlashMessages();
     }
 
-    protected function updateDocumentAddFormat()
+    /**
+     * Add format type to outdated tx_dlf_documents rows
+     *
+     * @return void
+     */
+    protected function updateDocumentAddFormat(): void
     {
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_documents');

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -138,7 +138,7 @@ class ext_update
             ->from('tx_dlf_solrcores')
             ->execute();
 
-        while($resArray = $result->fetch()) {
+        while ($resArray = $result->fetch()) {
             // Instantiate search object.
             $solr = Solr::getInstance($resArray['index_name']);
             if (!$solr->ready) {

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -167,7 +167,7 @@ class ext_update
             ->where(
                 $queryBuilder->expr()->isNotNull('tx_dlf_formats.class'),
                 $queryBuilder->expr()->neq('tx_dlf_formats.class', $queryBuilder->createNamedParameter('')),
-                $queryBuilder->expr()->notLike('tx_dlf_formats.class', $queryBuilder->createNamedParameter('%\\\\%'))
+                $queryBuilder->expr()->like('tx_dlf_formats.class', $queryBuilder->createNamedParameter('%tx_dlf_%'))
             )
             ->execute();
         while ($resArray = $result->fetch()) {

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -111,11 +111,11 @@ class ext_update
 
         $rows = $result->fetchAll();
 
-        if((count($rows) === 0) || !array_key_exists('xpath', $rows[0])) {
+        if ((count($rows) === 0) || !array_key_exists('xpath', $rows[0])) {
             return $uids;
         }
-        foreach($rows as $row) {
-            if($row['format'] === 0 && $row['xpath']) {
+        foreach ($rows as $row) {
+            if ($row['format'] === 0 && $row['xpath']) {
                 $uids[] = (int)$row['uid'];
             }
         }
@@ -193,7 +193,7 @@ class ext_update
             ->from('INFORMATION_SCHEMA.COLUMNS')
             ->where('TABLE_NAME = "tx_dlf_metadata"')
             ->execute();
-        while($resArray = $result->fetch()) {
+        while ($resArray = $result->fetch()) {
             if (
                 $resArray['column_name'] === 'tokenized'
                 || $resArray['column_name'] === 'stored'
@@ -335,7 +335,7 @@ class ext_update
             // Get all old metadata configuration records.
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_metadata');
             $result = $queryBuilder
-                ->select('tx_dlf_metadata.uid AS uid', 'tx_dlf_metadata.pid AS pid','tx_dlf_metadata.cruser_id AS cruser_id', 'tx_dlf_metadata.encoded AS encoded', 'tx_dlf_metadata.xpath AS xpath', 'tx_dlf_metadata.xpath_sorting AS xpath_sorting')
+                ->select('tx_dlf_metadata.uid AS uid', 'tx_dlf_metadata.pid AS pid', 'tx_dlf_metadata.cruser_id AS cruser_id', 'tx_dlf_metadata.encoded AS encoded', 'tx_dlf_metadata.xpath AS xpath', 'tx_dlf_metadata.xpath_sorting AS xpath_sorting')
                 ->from('tx_dlf_metadata')
                 ->where(
                     $queryBuilder->expr()->in(

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -164,9 +164,12 @@ class ext_update
         $result = $queryBuilder
             ->select('tx_dlf_formats.uid AS uid', 'tx_dlf_formats.type AS type')
             ->from('tx_dlf_formats')
-            ->where('tx_dlf_formats.class IS NOT NULL AND tx_dlf_formats.class != "" AND tx_dlf_formats.class NOT LIKE "%\\\\\\\\%"')
+            ->where(
+                $queryBuilder->expr()->isNotNull('tx_dlf_formats.class'),
+                $queryBuilder->expr()->neq('tx_dlf_formats.class', $queryBuilder->createNamedParameter('')),
+                $queryBuilder->expr()->notLike('tx_dlf_formats.class', $queryBuilder->createNamedParameter('%\\\\%'))
+            )
             ->execute();
-
         while ($resArray = $result->fetch()) {
             $oldRecords[$resArray['uid']] = $resArray['type'];
         }
@@ -300,7 +303,7 @@ class ext_update
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_formats');
 
         foreach ($oldRecords as $uid => $type) {
-            $result = $queryBuilder
+            $queryBuilder
                 ->update('tx_dlf_formats')
                 ->where(
                     $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid))
@@ -468,7 +471,7 @@ class ext_update
                 $queryBuilder->expr()->orX(
                     $queryBuilder->expr()->eq('document_format', $queryBuilder->createNamedParameter(null)),
                     $queryBuilder->expr()->eq('document_format', $queryBuilder->createNamedParameter(''))
-                ),
+                )
             )
             ->set('document_format', 'METS')
             ->execute();

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "docs": "https://docs.typo3.org/typo3cms/extensions/dlf/"
   },
   "require": {
-    "php": "^7.2",
+    "php": "^7.3",
     "ext-curl": "*",
     "ext-dom": "*",
     "ext-json": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Kitodo.Presentation',
     'description' => 'Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.',
-    'version' => '3.0.1',
+    'version' => '3.1.0',
     'category' => 'misc',
     'constraints' => [
         'depends' => [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,12 +13,12 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Kitodo.Presentation',
     'description' => 'Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.',
-    'version' => '3.0.0',
+    'version' => '3.0.1',
     'category' => 'misc',
     'constraints' => [
         'depends' => [
             'php' => '7.0.0-',
-            'typo3' => '8.7.0-8.7.99'
+            'typo3' => '8.7.0-9.5.99'
         ],
         'conflicts' => [],
         'suggests' => []


### PR DESCRIPTION
This pull request refactores $GLOBALS['TYPO3_DB'] to QueryBuilder functionality for TYPO3 9LTS compatibility.
* all methods are refactored for QueryBuilder usage
* Helper::whereClause() removed (check for hidden and deleted is default restriction configuration in querybuilder)
* general code cleanup