### PR TITLE
$GLOBALS['TYPO3_DB'] in OaiPmh.php

### DIFF
--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -480,11 +480,18 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             $where .
             'AND ' . Helper::whereExpression('tx_dlf_collections');
 
-        $statement = $connection->prepare($sql);
-        $statement->bindValue(1, $this->piVars['identifier']);
-        $statement->bindValue(2, (int)$this->conf['pages']);
-        $statement->bindValue(3, (int)$this->conf['pages']);
-        $statement->execute();
+        $values = [
+            $this->piVars['identifier'],
+            $this->conf['pages'],
+            $this->conf['pages']
+        ];
+        $types = [
+            Connection::PARAM_STR,
+            Connection::PARAM_INT,
+            Connection::PARAM_INT
+        ];
+        // Create a prepared statement for the passed SQL query, bind the given params with their binding types and execute the query
+        $statement = $connection->executeQuery($sql, $values, $types);
 
         $resArray = $statement->fetch();
 
@@ -978,8 +985,6 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         ];
         // Create a prepared statement for the passed SQL query, bind the given params with their binding types and execute the query
         $documents = $connection->executeQuery($sql, $values, $types);
-
-        $documents->execute();
 
         $output = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $verb);
         while ($resArray = $documents->fetch()) {

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -464,7 +464,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         }
         $where = '';
         if (!$this->conf['show_userdefined']) {
-            $where .= ' AND tx_dlf_collections.fe_cruser_id=0';
+            $where .= 'AND tx_dlf_collections.fe_cruser_id=0 ';
         }
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_dlf_documents');
@@ -473,13 +473,12 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= ' . $GLOBALS['EXEC_TIME'] . ') AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > ' . $GLOBALS['EXEC_TIME'] . '))) ' .
-            'AND tx_dlf_documents.record_id = ? ' .
+            'WHERE tx_dlf_documents.record_id = ? ' .
             'AND tx_dlf_documents.pid = ? ' .
             'AND tx_dlf_collections.pid = ? ' .
-            'AND tx_dlf_relations.ident="docs_colls"' .
+            'AND tx_dlf_relations.ident="docs_colls" ' .
             $where .
-            Helper::whereClause('tx_dlf_collections', [$this->piVars['identifier']]);
+            'AND ' . Helper::whereExpression('tx_dlf_collections', [$this->piVars['identifier']]);
 
         $statement = $connection->prepare($sql);
         $statement->bindValue(1, $this->piVars['identifier']);
@@ -955,12 +954,11 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= ' . $GLOBALS['EXEC_TIME'] . ') AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > ' . $GLOBALS['EXEC_TIME'] . '))) ' .
-            'AND tx_dlf_documents.uid IN ( ? ) ' .
+            'WHERE tx_dlf_documents.uid IN ( ? ) ' .
             'AND tx_dlf_documents.pid = ? ' .
             'AND tx_dlf_collections.pid = ? ' .
             'AND tx_dlf_relations.ident="docs_colls" ' .
-            Helper::whereClause('tx_dlf_collections') .
+            'AND ' . Helper::whereExpression('tx_dlf_collections') .
             ' LIMIT ?';
 
         $documents = $connection->prepare($sql);

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -469,17 +469,17 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_dlf_documents');
 
-        $sql =  'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS `collections` ' .
-                'FROM `tx_dlf_documents` ' .
-                'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
-                'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-                'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= 1586953440) AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > 1586953440))) ' .
-                'AND tx_dlf_documents.record_id = ? ' .
-                'AND tx_dlf_documents.pid = ? ' .
-                'AND tx_dlf_collections.pid = ? ' .
-                'AND tx_dlf_relations.ident="docs_colls"' .
-                $where .
-                Helper::whereClause('tx_dlf_collections', [ $this->piVars['identifier'] ]);
+        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS `collections` ' .
+            'FROM `tx_dlf_documents` ' .
+            'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
+            'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
+            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= 1586953440) AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > 1586953440))) ' .
+            'AND tx_dlf_documents.record_id = ? ' .
+            'AND tx_dlf_documents.pid = ? ' .
+            'AND tx_dlf_collections.pid = ? ' .
+            'AND tx_dlf_relations.ident="docs_colls"' .
+            $where .
+            Helper::whereClause('tx_dlf_collections', [$this->piVars['identifier']]);
 
         $statement = $connection->prepare($sql);
         $statement->bindValue(1, $this->piVars['identifier']);
@@ -951,7 +951,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_dlf_documents');
 
-        $sql =  'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS `collections` ' .
+        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS `collections` ' .
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -80,7 +80,6 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
     protected function deleteExpiredTokens()
     {
         // Delete expired resumption tokens.
-
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_tokens');
 
         $result = $queryBuilder

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -473,7 +473,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= 1586953440) AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > 1586953440))) ' .
+            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= ' . $GLOBALS['EXEC_TIME'] . ') AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > ' . $GLOBALS['EXEC_TIME'] . '))) ' .
             'AND tx_dlf_documents.record_id = ? ' .
             'AND tx_dlf_documents.pid = ? ' .
             'AND tx_dlf_collections.pid = ? ' .
@@ -955,7 +955,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= 1586953440) AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > 1586953440))) ' .
+            'WHERE (((`tx_dlf_documents`.`deleted` = 0) AND (`tx_dlf_collections`.`deleted` = 0)) AND ((`tx_dlf_documents`.`hidden` = 0) AND (`tx_dlf_collections`.`hidden` = 0)) AND (`tx_dlf_documents`.`starttime` <= ' . $GLOBALS['EXEC_TIME'] . ') AND ((`tx_dlf_documents`.`endtime` = 0) OR (`tx_dlf_documents`.`endtime` > ' . $GLOBALS['EXEC_TIME'] . '))) ' .
             'AND tx_dlf_documents.uid IN ( ? ) ' .
             'AND tx_dlf_documents.pid = ? ' .
             'AND tx_dlf_collections.pid = ? ' .

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -979,7 +979,6 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         // Create a prepared statement for the passed SQL query, bind the given params with their binding types and execute the query
         $documents = $connection->executeQuery($sql, $values, $types);
 
-        $documents->execute();
 
         $output = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $verb);
         while ($resArray = $documents->fetch()) {

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -979,7 +979,6 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         // Create a prepared statement for the passed SQL query, bind the given params with their binding types and execute the query
         $documents = $connection->executeQuery($sql, $values, $types);
 
-
         $output = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', $verb);
         while ($resArray = $documents->fetch()) {
             // Add header node.

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -15,9 +15,9 @@ namespace Kitodo\Dlf\Plugin;
 use Kitodo\Dlf\Common\DocumentList;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Database\Connection;
 
 /**
  * Plugin 'OAI-PMH Interface' for the 'dlf' extension

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -479,7 +479,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
                 'AND tx_dlf_collections.pid = ? ' .
                 'AND tx_dlf_relations.ident="docs_colls"' .
                 $where .
-                Helper::whereClause('tx_dlf_collections' , [ $this->piVars['identifier'] ]);
+                Helper::whereClause('tx_dlf_collections', [ $this->piVars['identifier'] ]);
 
         $statement = $connection->prepare($sql);
         $statement->bindValue(1, $this->piVars['identifier']);

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -467,16 +467,16 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_dlf_documents');
 
-        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS `collections` ' .
+        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.`oai_name` ORDER BY `tx_dlf_collections`.`oai_name` SEPARATOR " ") AS `collections` ' .
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE tx_dlf_documents.record_id = ? ' .
-            'AND tx_dlf_documents.pid = ? ' .
-            'AND tx_dlf_collections.pid = ? ' .
-            'AND tx_dlf_relations.ident="docs_colls" ' .
+            'WHERE `tx_dlf_documents`.`record_id` = ? ' .
+            'AND `tx_dlf_documents`.`pid` = ? ' .
+            'AND `tx_dlf_collections`.`pid` = ? ' .
+            'AND `tx_dlf_relations`.`ident`="docs_colls" ' .
             $where .
-            'AND ' . Helper::whereExpression('tx_dlf_collections', [$this->piVars['identifier']]);
+            'AND ' . Helper::whereExpression('tx_dlf_collections');
 
         $statement = $connection->prepare($sql);
         $statement->bindValue(1, $this->piVars['identifier']);
@@ -948,14 +948,14 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
 
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_dlf_documents');
 
-        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.oai_name ORDER BY tx_dlf_collections.oai_name SEPARATOR " ") AS `collections` ' .
+        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.`oai_name` ORDER BY `tx_dlf_collections`.`oai_name` SEPARATOR " ") AS `collections` ' .
             'FROM `tx_dlf_documents` ' .
             'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
             'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE tx_dlf_documents.uid IN ( ? ) ' .
-            'AND tx_dlf_documents.pid = ? ' .
-            'AND tx_dlf_collections.pid = ? ' .
-            'AND tx_dlf_relations.ident="docs_colls" ' .
+            'WHERE `tx_dlf_documents`.`uid` IN ( ? ) ' .
+            'AND `tx_dlf_documents`.`pid` = ? ' .
+            'AND `tx_dlf_collections`.`pid` = ? ' .
+            'AND `tx_dlf_relations`.`ident`="docs_colls" ' .
             'AND ' . Helper::whereExpression('tx_dlf_collections') .
             ' LIMIT ?';
 

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -960,6 +960,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             'AND `tx_dlf_documents`.`pid` = ? ' .
             'AND `tx_dlf_collections`.`pid` = ? ' .
             'AND `tx_dlf_relations`.`ident`="docs_colls" ' .
+            'AND ' . Helper::whereExpression('tx_dlf_collections') . ' ' .
             'GROUP BY `tx_dlf_documents`.`uid` ' .
             'LIMIT ?';
 


### PR DESCRIPTION
refactores $GLOBALS['TYPO3_DB'] to Doctrine/Dbal plain SQL calls. The use of the QueryBuilder is not possible because the QueryBuilder doesn't support GROUP_CONCAT (by the way, GROUP_CONCAT is not very compatible with e.g. PostgreSQL).