### PR TITLE
Fix OAI Plugin for TYPO3 8.7LTS

### DIFF
--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -789,7 +789,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             return $this->error('noSetHierarchy');
         }
         $ListSets = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListSets');
-        while ($resArray = $result->fetch()) {
+        foreach($allResults as $resArray) {
             $set = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'set');
             $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($resArray['oai_name'], ENT_NOQUOTES, 'UTF-8')));
             $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setName', htmlspecialchars($resArray['label'], ENT_NOQUOTES, 'UTF-8')));

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -422,9 +422,8 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             ->select('tx_dlf_tokens.options AS options')
             ->from('tx_dlf_tokens')
             ->where(
-                $queryBuilder->expr()->eq('tx_dlf_tokens.ident', 'oai'),
-                $queryBuilder->expr()->eq('tx_dlf_tokens.token', $queryBuilder->expr()->literal($this->piVars['resumptionToken'])),
-                Helper::whereExpression('tx_dlf_structures')
+                $queryBuilder->expr()->eq('tx_dlf_tokens.ident', $queryBuilder->createNamedParameter('oai')),
+                $queryBuilder->expr()->eq('tx_dlf_tokens.token', $queryBuilder->expr()->literal($this->piVars['resumptionToken']))
             )
             ->setMaxResults(1)
             ->execute();
@@ -777,7 +776,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             ->where(
                 $queryBuilder->expr()->in('tx_dlf_collections.sys_language_uid', [-1, 0]),
                 $queryBuilder->expr()->eq('tx_dlf_collections.pid', intval($this->conf['pages'])),
-                $queryBuilder->expr()->neq('tx_dlf_collections.oai_name', ''),
+                $queryBuilder->expr()->neq('tx_dlf_collections.oai_name', $queryBuilder->createNamedParameter('')),
                 $where,
                 Helper::whereExpression('tx_dlf_collections')
             )

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -789,7 +789,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
             return $this->error('noSetHierarchy');
         }
         $ListSets = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'ListSets');
-        foreach($allResults as $resArray) {
+        foreach ($allResults as $resArray) {
             $set = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'set');
             $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setSpec', htmlspecialchars($resArray['oai_name'], ENT_NOQUOTES, 'UTF-8')));
             $set->appendChild($this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'setName', htmlspecialchars($resArray['label'], ENT_NOQUOTES, 'UTF-8')));


### PR DESCRIPTION
There are three issues in the OAI plugin of current master.

1. resume() does not work (SQL exception)
2. ListSets throws SQL exception
3. ListSets wouldn't show OAI sets even if 2. is fixed.

Provided PR fixes these issues.