### PR TITLE
Add CORS header to file proxy

### DIFF
--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -69,6 +69,7 @@ class PageViewProxy
         $response = GeneralUtility::makeInstance(Response::class);
         if ($fetchedData) {
             $response->getBody()->write($fetchedData);
+            $response = $response->withHeader('Access-Control-Allow-Origin', '*');
             $response = $response->withHeader('Content-Type', finfo_buffer(finfo_open(FILEINFO_MIME), $fetchedData));
         }
         if ($header === 0 && !empty($lastModified)) {

--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -69,8 +69,8 @@ class PageViewProxy
         $response = GeneralUtility::makeInstance(Response::class);
         if ($fetchedData) {
             $response->getBody()->write($fetchedData);
-            $response = $response->withHeader('Access-Control-Allow-Origin', '*');
             $response = $response->withHeader('Access-Control-Allow-Methods', 'GET');
+            $response = $response->withHeader('Access-Control-Allow-Origin', $request->getHeader('Origin'));
             $response = $response->withHeader('Content-Type', finfo_buffer(finfo_open(FILEINFO_MIME), $fetchedData));
         }
         if ($header === 0 && !empty($lastModified)) {

--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -70,6 +70,7 @@ class PageViewProxy
         if ($fetchedData) {
             $response->getBody()->write($fetchedData);
             $response = $response->withHeader('Access-Control-Allow-Origin', '*');
+            $response = $response->withHeader('Access-Control-Allow-Methods', 'GET');
             $response = $response->withHeader('Content-Type', finfo_buffer(finfo_open(FILEINFO_MIME), $fetchedData));
         }
         if ($header === 0 && !empty($lastModified)) {


### PR DESCRIPTION
This adds a valid CORS header for files delivered via the `PageViewProxy`. This is needed when integrating the Page View with other applications on a different domain (i. e. the Zeitungsportal).