### PR TITLE
Make usage of absolute links configurable

### DIFF
--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -217,7 +217,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
     /**
      * Link string to the current page.
      * @see \TYPO3\CMS\Frontend\Plugin\AbstractPlugin->pi_linkTP()
-     * 
+     *
      * @access public
      *
      * @param string $str: The content string to wrap in <a> tags

--- a/Classes/Plugin/Basket.php
+++ b/Classes/Plugin/Basket.php
@@ -213,6 +213,8 @@ class Basket extends \Kitodo\Dlf\Common\AbstractPlugin
             $label = $this->pi_getLL('goBasket', '', true);
             $basketConf = [
                 'parameter' => $this->conf['targetBasket'],
+                'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                 'title' => $label
             ];
             $markerArray['###BASKET###'] = $this->cObj->typoLink($label, $basketConf);

--- a/Classes/Plugin/Basket.php
+++ b/Classes/Plugin/Basket.php
@@ -130,7 +130,8 @@ class Basket extends \Kitodo\Dlf\Common\AbstractPlugin
             }
         }
         // set marker
-        $markerArray['###ACTION###'] = $this->pi_getPageLink($GLOBALS['TSFE']->id);
+        $linkToCurrentPage = $this->pi_linkTP('|');
+        $markerArray['###ACTION###'] = !empty($linkToCurrentPage) ? $this->cObj->lastTypoLinkUrl : '';
         $markerArray['###LISTTITLE###'] = $this->pi_getLL('basket', '', true);
         if ($basketData['doc_ids']) {
             if (is_object($basketData['doc_ids'])) {

--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -204,6 +204,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
         $linkConf = [
             'useCacheHash' => 1,
             'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($this->doc->uid),
         ];
         $linkTitleData = $this->doc->getTitledata();
@@ -213,6 +215,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
         $linkConf = [
             'useCacheHash' => 1,
             'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($this->doc->parentId),
         ];
         $allYearsLink = $this->cObj->typoLink($this->pi_getLL('allYears', '', true) . ' ' . $this->doc->getTitle($this->doc->parentId), $linkConf);
@@ -298,6 +302,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
                                         $linkConf = [
                                             'useCacheHash' => 1,
                                             'parameter' => $this->conf['targetPid'],
+                                            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                                            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                                             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($issue['uid']),
                                             'ATagParams' => ' class="title"',
                                         ];
@@ -410,6 +416,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
                 $linkConf = [
                     'useCacheHash' => 1,
                     'parameter' => $GLOBALS['TSFE']->id,
+                    'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                    'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                     'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($year['uid']),
                     'title' => $titleAnchor . ': ' . $year['title']
                 ];
@@ -423,6 +431,8 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
         $linkConf = [
             'useCacheHash' => 1,
             'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
             'additionalParams' => '&' . $this->prefixId . '[id]=' . $this->doc->uid,
         ];
         $allYearsLink = $this->cObj->typoLink($this->pi_getLL('allYears', '', true) . ' ' . $this->doc->getTitle($this->doc->uid), $linkConf);

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -204,6 +204,8 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
             $conf = [
                 'useCacheHash' => 1,
                 'parameter' => $GLOBALS['TSFE']->id,
+                'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                 'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
             ];
             // Link collection's title to list view.
@@ -423,7 +425,12 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
         // Clean output buffer.
         ob_end_clean();
         // Send headers.
-        header('Location: ' . \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->cObj->typoLink_URL(['parameter' => $this->conf['targetPid']])));
+        $linkConf = [
+            'parameter' => $this->conf['targetPid'],
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
+        ];
+        header('Location: ' . \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($this->cObj->typoLink_URL($linkConf)));
         exit;
     }
 }

--- a/Classes/Plugin/Feeds.php
+++ b/Classes/Plugin/Feeds.php
@@ -144,6 +144,7 @@ class Feeds extends \Kitodo\Dlf\Common\AbstractPlugin
                     $linkConf = [
                         'parameter' => $this->conf['targetPid'],
                         'forceAbsoluteUrl' => 1,
+                        'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                         'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, ['id' => $resArray['uid']], '', true, false)
                     ];
                     $item->appendChild($rss->createElement('link', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8')));

--- a/Classes/Plugin/ListView.php
+++ b/Classes/Plugin/ListView.php
@@ -164,6 +164,8 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
                         $conf = [
                             'useCacheHash' => 1,
                             'parameter' => $this->conf['targetPid'],
+                            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                             'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
                         ];
                         $value = $this->cObj->typoLink(htmlspecialchars($value), $conf);
@@ -209,6 +211,8 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
             $conf = [
                 'useCacheHash' => 1,
                 'parameter' => $this->conf['targetBasket'],
+                'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                 'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
             ];
             $link = $this->cObj->typoLink($this->pi_getLL('addBasket', '', true), $conf);
@@ -253,7 +257,9 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
         $prefix = Helper::getUnqualifiedClassName(get_class($this));
         // Configure @action URL for form.
         $linkConf = [
-            'parameter' => $GLOBALS['TSFE']->id
+            'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
         ];
         if (!empty($this->piVars['logicalPage'])) {
             $linkConf['additionalParams'] = \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, ['logicalPage' => $this->piVars['logicalPage']], '', true, false);
@@ -336,6 +342,8 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
                             // we don't want cHash in case of search parameters
                             'useCacheHash' => empty($this->list->metadata['searchString']) ? 1 : 0,
                             'parameter' => $this->conf['targetPid'],
+                            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                             'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
                         ];
                         $value = $this->cObj->typoLink(htmlspecialchars($value), $conf);
@@ -382,6 +390,8 @@ class ListView extends \Kitodo\Dlf\Common\AbstractPlugin
                 $conf = [
                     'useCacheHash' => 1,
                     'parameter' => $this->conf['targetBasket'],
+                    'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                    'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                     'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false)
                 ];
                 $link = $this->cObj->typoLink($this->pi_getLL('addBasket', '', true), $conf);

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -179,6 +179,8 @@ class Metadata extends \Kitodo\Dlf\Common\AbstractPlugin
             $iiifLink['value.']['required'] = 1;
             $iiifLink['value.']['setContentToCurrent'] = 1;
             $iiifLink['value.']['typolink.']['parameter.']['current'] = 1;
+            $iiifLink['value.']['typolink.']['forceAbsoluteUrl'] = !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0;
+            $iiifLink['value.']['typolink.']['forceAbsoluteUrl.']['scheme'] = !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http';
             $iiifLink['value.']['wrap'] = '<dd>|</dd>';
             foreach ($metadataArray as $metadata) {
                 foreach ($metadata as $key => $group) {

--- a/Classes/Plugin/Navigation.php
+++ b/Classes/Plugin/Navigation.php
@@ -44,6 +44,8 @@ class Navigation extends \Kitodo\Dlf\Common\AbstractPlugin
                 $conf = [
                     'useCacheHash' => 1,
                     'parameter' => $this->conf['targetPid'],
+                    'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                    'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                     'title' => $this->pi_getLL('linkToList', '', true)
                 ];
                 return $this->cObj->typoLink($this->pi_getLL('linkToList', '', true), $conf);
@@ -63,7 +65,9 @@ class Navigation extends \Kitodo\Dlf\Common\AbstractPlugin
     {
         // Configure @action URL for form.
         $linkConf = [
-            'parameter' => $GLOBALS['TSFE']->id
+            'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
         ];
         $output = '<form action="' . $this->cObj->typoLink_URL($linkConf) . '" method="get"><div><input type="hidden" name="id" value="' . $GLOBALS['TSFE']->id . '" />';
         // Add plugin variables.
@@ -220,6 +224,8 @@ class Navigation extends \Kitodo\Dlf\Common\AbstractPlugin
         $conf = [
             'useCacheHash' => 1,
             'parameter' => $GLOBALS['TSFE']->id,
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
             'ATagParams' => $aTagParams,
             'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $overrulePIvars, '', true, false),
             'title' => $label

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -380,7 +380,8 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         // Add request.
         $linkConf = [
             'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
+            'forceAbsoluteUrl' => 1,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
         ];
         $request = $this->oai->createElementNS('http://www.openarchives.org/OAI/2.0/', 'request', htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES, 'UTF-8'));
         if (!$this->error) {
@@ -587,7 +588,8 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         }
         $linkConf = [
             'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
+            'forceAbsoluteUrl' => 1,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
         ];
         $baseURL = htmlspecialchars($this->cObj->typoLink_URL($linkConf), ENT_NOQUOTES);
         // Add identification node.

--- a/Classes/Plugin/PageGrid.php
+++ b/Classes/Plugin/PageGrid.php
@@ -67,6 +67,8 @@ class PageGrid extends \Kitodo\Dlf\Common\AbstractPlugin
         $linkConf = [
             'useCacheHash' => 1,
             'parameter' => $this->conf['targetPid'],
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
             'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $piVars, '', true, false),
             'title' => $markerArray['###PAGINATION###']
         ];

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -156,6 +156,8 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
             }
             $basketConf = [
                 'parameter' => $this->conf['targetBasket'],
+                'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                 'additionalParams' => \TYPO3\CMS\Core\Utility\GeneralUtility::implodeArrayForUrl($this->prefixId, $params, '', true, false),
                 'title' => $label
             ];
@@ -201,6 +203,8 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
                     // Configure @action URL for form.
                     $linkConf = [
                         'parameter' => $GLOBALS['TSFE']->id,
+                        'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                        'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                         'additionalParams' => '&eID=tx_dlf_pageview_proxy&url=' . urlencode($image['url']),
                     ];
                     $image['url'] = $this->cObj->typoLink_URL($linkConf);
@@ -233,6 +237,8 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
                 // Configure @action URL for form.
                 $linkConf = [
                     'parameter' => $GLOBALS['TSFE']->id,
+                    'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                    'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                     'additionalParams' => '&eID=tx_dlf_pageview_proxy&url=' . urlencode($fulltext['url']),
                 ];
                 $fulltext['url'] = $this->cObj->typoLink_URL($linkConf);

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -369,7 +369,9 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin
             $this->getTemplate();
             // Configure @action URL for form.
             $linkConf = [
-                'parameter' => $GLOBALS['TSFE']->id
+                'parameter' => $GLOBALS['TSFE']->id,
+                'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
             ];
             // Fill markers.
             $markerArray = [
@@ -523,6 +525,8 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin
                     $additionalParams['asc'] = !empty($this->piVars['asc']) ? '1' : '0';
                 }
             }
+            $linkConf['forceAbsoluteUrl'] = !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0;
+            $linkConf['forceAbsoluteUrl.']['scheme'] = !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http';
             $linkConf['additionalParams'] = GeneralUtility::implodeArrayForUrl($this->prefixId, $additionalParams, '', true, false);
             // Send headers.
             header('Location: ' . GeneralUtility::locationHeaderUrl($this->cObj->typoLink_URL($linkConf)));

--- a/Classes/Plugin/Tools/ImageDownloadTool.php
+++ b/Classes/Plugin/Tools/ImageDownloadTool.php
@@ -112,6 +112,8 @@ class ImageDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
                 }
                 $linkConf = [
                     'parameter' => $image['url'],
+                    'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                    'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
                     'title' => $label . ' ' . $mimetypeLabel,
                     'additionalParams' => '',
                 ];

--- a/Classes/Plugin/Tools/PdfDownloadTool.php
+++ b/Classes/Plugin/Tools/PdfDownloadTool.php
@@ -117,15 +117,24 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
             Helper::devLog('File not found in fileGrp "' . $this->conf['fileGrpDownload'] . '"', DEVLOG_SEVERITY_WARNING);
         }
         // Wrap URLs with HTML.
+        $linkConf = [
+            'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
+        ];
         if (!empty($page1Link)) {
+            $linkConf['parameter'] = $page1Link;
             if ($this->piVars['double']) {
-                $page1Link = $this->cObj->typoLink($this->pi_getLL('leftPage', ''), ['parameter' => $page1Link, 'title' => $this->pi_getLL('leftPage', '')]);
+                $linkConf['title'] = $this->pi_getLL('leftPage', '');
+                $page1Link = $this->cObj->typoLink($this->pi_getLL('leftPage', ''), $linkConf);
             } else {
-                $page1Link = $this->cObj->typoLink($this->pi_getLL('singlePage', ''), ['parameter' => $page1Link, 'title' => $this->pi_getLL('singlePage', '')]);
+                $linkConf['title'] = $this->pi_getLL('singlePage', '');
+                $page1Link = $this->cObj->typoLink($this->pi_getLL('singlePage', ''), $linkConf);
             }
         }
         if (!empty($page2Link)) {
-            $page2Link = $this->cObj->typoLink($this->pi_getLL('rightPage', ''), ['parameter' => $page2Link, 'title' => $this->pi_getLL('rightPage', '')]);
+            $linkConf['parameter'] = $page2Link;
+            $linkConf['title'] = $this->pi_getLL('rightPage', '');
+            $page2Link = $this->cObj->typoLink($this->pi_getLL('rightPage', ''), $linkConf);
         }
         return $page1Link . $page2Link;
     }
@@ -151,7 +160,13 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
         }
         // Wrap URLs with HTML.
         if (!empty($workLink)) {
-            $workLink = $this->cObj->typoLink($this->pi_getLL('work', ''), ['parameter' => $workLink, 'title' => $this->pi_getLL('work', '')]);
+            $linkConf = [
+                'parameter' => $workLink,
+                'forceAbsoluteUrl' => !empty($this->conf['forceAbsoluteUrl']) ? 1 : 0,
+                'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
+                'title' => $this->pi_getLL('work', '')
+            ];
+            $workLink = $this->cObj->typoLink($this->pi_getLL('work', ''), $linkConf);
         } else {
             Helper::devLog('File not found in fileGrp "' . $this->conf['fileGrpDownload'] . '"', DEVLOG_SEVERITY_WARNING);
         }

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -90,7 +90,8 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin
         // Configure @action URL for form.
         $linkConf = [
             'parameter' => $GLOBALS['TSFE']->id,
-            'forceAbsoluteUrl' => 1
+            'forceAbsoluteUrl' => 1,
+            'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http']
         ];
 
         $encryptedSolr = $this->getEncryptedCoreName();

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -175,8 +175,8 @@
             <label index="tt_content.dlf_validator">DLF: Validator</label>
             <label index="config.metadataFormats">Default metadata namespaces</label>
             <label index="config.useragent">DLF User-Agent: (default is "Kitodo.Presentation")</label>
-            <label index="config.forceAbsoluteUrl">Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments (default is "FALSE")</label>
-            <label index="config.forceAbsoluteUrlHttps">Use HTTPS for absolute links?: (default is "FALSE")</label>
+            <label index="config.forceAbsoluteUrl">Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments; requires a fully qualified Entry Point in Site Configuration (default is "FALSE")</label>
+            <label index="config.forceAbsoluteUrlHttps">Use HTTPS for absolute links?: requires a valid Entry Point with "https://..." in Site Configuration (default is "FALSE")</label>
             <label index="config.caching">Cache parsed METS files / IIIF manifests: Caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</label>
             <label index="config.publishNewCollections">Publish new collections?: Should new collections automatically be published in the OAI-PMH interface? (default is "TRUE")</label>
             <label index="config.unhideOnIndex">Unhide indexed documents?: Should hidden documents be unhidden when re-indexing them? (default is "FALSE")</label>
@@ -358,8 +358,8 @@
             <label index="tt_content.dlf_validator">DLF: Validator</label>
             <label index="config.metadataFormats">Standard-Namensräume für Metadaten</label>
             <label index="config.useragent">DLF User-Agent: (Standard ist "Kitodo.Presentation")</label>
-            <label index="config.forceAbsoluteUrl">Verwende nur absolute Links für Seiten und Ressourcen?: Wird nur in speziellen Multi-Domain-Umgebungen benötigt (Standard ist "FALSE")</label>
-            <label index="config.forceAbsoluteUrlHttps">Verwende HTTPS for absolute Links?: (Standard ist "FALSE")</label>
+            <label index="config.forceAbsoluteUrl">Verwende nur absolute Links für Seiten und Ressourcen?: Wird nur in speziellen Multi-Domain-Umgebungen benötigt; erfordert einen voll qualifizierten Einstiegspunkt in der Seitenkonfiguration (Standard ist "FALSE")</label>
+            <label index="config.forceAbsoluteUrlHttps">Verwende HTTPS for absolute Links?: erfordert einen Einstiegspunkt mit "https://..." in der Seitenkonfiguration (Standard ist "FALSE")</label>
             <label index="config.caching">Eingelesene METS Dateien / IIIF-Manifeste zwischenspeichern: Dies kann die Geschwindigkeit geringfügig verbessern, führt aber zu einer sehr großen "fe_session_data" Tabelle (Standard ist "FALSE")</label>
             <label index="config.publishNewCollections">Neue Kollektionen publizieren?: Sollen neue Kollektionen automatisch in der OAI-PMH-Schnittstelle veröffentlicht werden? (Standard ist "TRUE")</label>
             <label index="config.unhideOnIndex">Indexierte Dokumente einblenden?: Sollen ausgeblendete Dokumente bei der erneuten Indexierung wieder eingeblendet werden? (Standard ist "FALSE")</label>

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -175,7 +175,9 @@
             <label index="tt_content.dlf_validator">DLF: Validator</label>
             <label index="config.metadataFormats">Default metadata namespaces</label>
             <label index="config.useragent">DLF User-Agent: (default is "Kitodo.Presentation")</label>
-            <label index="config.caching">Cache parsed METS files / IIIF manifests: caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</label>
+            <label index="config.forceAbsoluteUrl">Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments (default is "FALSE")</label>
+            <label index="config.forceAbsoluteUrlHttps">Use HTTPS for absolute links?: (default is "FALSE")</label>
+            <label index="config.caching">Cache parsed METS files / IIIF manifests: Caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</label>
             <label index="config.publishNewCollections">Publish new collections?: Should new collections automatically be published in the OAI-PMH interface? (default is "TRUE")</label>
             <label index="config.unhideOnIndex">Unhide indexed documents?: Should hidden documents be unhidden when re-indexing them? (default is "FALSE")</label>
             <label index="config.fileGrps">Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "MIN,DEFAULT,MAX")</label>
@@ -183,9 +185,9 @@
             <label index="config.fileGrpDownload">Download fileGrp: @USE attribute value (default is "DOWNLOAD")</label>
             <label index="config.fileGrpFulltext">Fulltext fileGrp: @USE attribute value (default is "FULLTEXT")</label>
             <label index="config.fileGrpAudio">Audio fileGrp: @USE attribute value (default is "AUDIO")</label>
-			<label index="config.indexAnnotations">Index IIIF annotations with motivation "painting" as fulltext</label>
-			<label index="config.iiifThumbnailWidth">Maximum thumbnail width for IIIF images without a thumbnail declaration</label>
-			<label index="config.iiifThumbnailHeight">Maximum thumbnail height for IIIF images without a thumbnail declaration</label>
+			<label index="config.indexAnnotations">Handle IIIF annotations with motivation "painting" as fulltext?: Handling annotations as fulltexts means they are indexed (default is "FALSE")</label>
+			<label index="config.iiifThumbnailWidth">Maximum thumbnail width for IIIF images: Only for images without a thumbnail declaration (default is "150")</label>
+			<label index="config.iiifThumbnailHeight">Maximum thumbnail height for IIIF images: Only for images without a thumbnail declaration (default is "150")</label>
             <label index="config.solrConnect">Solr Connection</label>
             <label index="config.solrHttps">Use https: (default is "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (default is "localhost")</label>
@@ -356,6 +358,8 @@
             <label index="tt_content.dlf_validator">DLF: Validator</label>
             <label index="config.metadataFormats">Standard-Namensräume für Metadaten</label>
             <label index="config.useragent">DLF User-Agent: (Standard ist "Kitodo.Presentation")</label>
+            <label index="config.forceAbsoluteUrl">Verwende nur absolute Links für Seiten und Ressourcen?: Wird nur in speziellen Multi-Domain-Umgebungen benötigt (Standard ist "FALSE")</label>
+            <label index="config.forceAbsoluteUrlHttps">Verwende HTTPS for absolute Links?: (Standard ist "FALSE")</label>
             <label index="config.caching">Eingelesene METS Dateien / IIIF-Manifeste zwischenspeichern: Dies kann die Geschwindigkeit geringfügig verbessern, führt aber zu einer sehr großen "fe_session_data" Tabelle (Standard ist "FALSE")</label>
             <label index="config.publishNewCollections">Neue Kollektionen publizieren?: Sollen neue Kollektionen automatisch in der OAI-PMH-Schnittstelle veröffentlicht werden? (Standard ist "TRUE")</label>
             <label index="config.unhideOnIndex">Indexierte Dokumente einblenden?: Sollen ausgeblendete Dokumente bei der erneuten Indexierung wieder eingeblendet werden? (Standard ist "FALSE")</label>
@@ -364,9 +368,9 @@
             <label index="config.fileGrpDownload">Download fileGrp: @USE Attributwert der Downloads (Standard ist "DOWNLOAD")</label>
             <label index="config.fileGrpFulltext">Volltext fileGrp: @USE Attributwert der Volltexte (Standard ist "FULLTEXT")</label>
             <label index="config.fileGrpAudio">Audio fileGrp: @USE Attributwert der Audiodateien (Standard ist "AUDIO")</label>
-			<label index="config.indexAnnotations">IIIF-Annotationen mit Motivation "painting" als Volltext im Suchindex speichern</label>
-			<label index="config.iiifThumbnailWidth">Maximale Thumbnail-Breite für IIIF-Images ohne Thumbnail-Angaben</label>
-			<label index="config.iiifThumbnailHeight">Maximale Thumbnail-Höhe für IIIF-Images ohne Thumbnail-Angaben</label>
+			<label index="config.indexAnnotations">IIIF-Annotationen mit Motivation "painting" als Volltext behandeln?: Als Volltext behandelte Annotationen werden im Suchindex indexiert (Standard ist "FALSE")</label>
+			<label index="config.iiifThumbnailWidth">Maximale Thumbnail-Breite für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</label>
+			<label index="config.iiifThumbnailHeight">Maximale Thumbnail-Höhe für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</label>
             <label index="config.solrConnect">Solr Verbindung</label>
             <label index="config.solrHttps">Https verwenden: (Standard ist "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (Standard ist "localhost")</label>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,6 +2,10 @@
 metadataFormats = 0
 # cat=Basic; type=string; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.useragent
 useragent = Kitodo.Presentation
+# cat=Basic; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.forceAbsoluteUrl
+forceAbsoluteUrl = 0
+# cat=Basic; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.forceAbsoluteUrlHttps
+forceAbsoluteUrlHttps = 0
 # cat=Basic; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.caching
 caching = 0
 # cat=Basic; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.publishNewCollections


### PR DESCRIPTION
In multi-domain environments like the Zeitungsportal we need the option to force all links to be absolute. Since TYPO3 9.x the Typoscript configuration option `config.absRefPrefix` only effects links generated by Typoscript, but doesn't work globally.

This Pull-Request introduces new extension-wide configuration options to force all generated links to be absolute. In addition it allows using HTTPS as default scheme for those URLs.

The default is to not use absolute links, so existing instances should behave exactly like before.