### PR TITLE
Add option to put JS in template

### DIFF
--- a/Classes/Plugin/AudioPlayer.php
+++ b/Classes/Plugin/AudioPlayer.php
@@ -82,9 +82,9 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin
             $pageRenderer->addJsFooterInlineCode('kitodo-audioplayer-configuration', $audioplayerConfiguration);
         } else {
             foreach ($jsFiles as $jsFile) {
-                $markerArray .= '<script>' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '</script>' . "\n";
+                $markerArray .= '<script type="text/javascript" src="' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '"></script>' . "\n";
             }
-            $markerArray .= '<script>' . $audioplayerConfiguration . '</script>';
+            $markerArray .= '<script type="text/javascript">' . $audioplayerConfiguration . '</script>';
         }
         return $markerArray;
     }

--- a/Classes/Plugin/AudioPlayer.php
+++ b/Classes/Plugin/AudioPlayer.php
@@ -84,7 +84,13 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin
             foreach ($jsFiles as $jsFile) {
                 $markerArray .= '<script type="text/javascript" src="' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '"></script>' . "\n";
             }
-            $markerArray .= '<script type="text/javascript">' . $audioplayerConfiguration . '</script>';
+            $markerArray .= '
+                <script type="text/javascript"> 
+                /*<![CDATA[*/
+                /*kitodo-audioplayer-configuration*/
+                ' . $audioplayerConfiguration . '
+                /*]]>*/
+                </script>';
         }
         return $markerArray;
     }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -119,9 +119,9 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
             $pageRenderer->addJsFooterInlineCode('kitodo-pageview-configuration', $viewerConfiguration);
         } else {
             foreach ($jsFiles as $jsFile) {
-                $markerArray['###JAVASCRIPT###'] .= '<script>' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '</script>' . "\n";
+                $markerArray .= '<script>' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '</script>' . "\n";
             }
-            $markerArray['###JAVASCRIPT###'] .= '<script>' . $viewerConfiguration . '</script>';
+            $markerArray .= '<script>' . $viewerConfiguration . '</script>';
         }
         return $markerArray;
     }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -119,9 +119,9 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
             $pageRenderer->addJsFooterInlineCode('kitodo-pageview-configuration', $viewerConfiguration);
         } else {
             foreach ($jsFiles as $jsFile) {
-                $markerArray .= '<script>' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '</script>' . "\n";
+                $markerArray .= '<script type="text/javascript" src="' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '"></script>' . "\n";
             }
-            $markerArray .= '<script>' . $viewerConfiguration . '</script>';
+            $markerArray .= '<script type="text/javascript">' . $viewerConfiguration . '</script>';
         }
         return $markerArray;
     }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -121,7 +121,13 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
             foreach ($jsFiles as $jsFile) {
                 $markerArray .= '<script type="text/javascript" src="' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '"></script>' . "\n";
             }
-            $markerArray .= '<script type="text/javascript">' . $viewerConfiguration . '</script>';
+            $markerArray .= '
+                <script type="text/javascript">
+                /*<![CDATA[*/
+                /*kitodo-pageview-configuration*/
+                ' . $viewerConfiguration . '
+                /*]]>*/
+                </script>';
         }
         return $markerArray;
     }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -66,30 +66,33 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
      *
      * @access protected
      *
-     * @return void
+     * @return string The output string for the ###JAVASCRIPT### template marker
      */
     protected function addViewerJS()
     {
-
-        $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
-        // Add OpenLayers library.
-        $pageRenderer->addCssFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/OpenLayers/ol3.css');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/OpenLayers/glif.min.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/OpenLayers/ol3-dlf.js');
-        // Add viewer library.
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/Utility.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/OL3.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/OL3Styles.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/OL3Sources.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/AltoParser.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/ImageManipulationControl.js');
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/FulltextControl.js');
-        if ($this->doc instanceof IiifManifest) {
-            $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/AnnotationParser.js');
-            $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/AnnotationControl.js');
-        }
-        $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . 'Resources/Public/Javascript/PageView/PageView.js');
-        // Add viewer configuration.
+        $markerArray = '';
+        // CSS files.
+        $cssFiles = [
+            'Resources/Public/Javascript/OpenLayers/ol3.css'
+        ];
+        // Javascript files.
+        $jsFiles = [
+            // OpenLayers
+            'Resources/Public/Javascript/OpenLayers/glif.min.js',
+            'Resources/Public/Javascript/OpenLayers/ol3-dlf.js',
+            // Viewer
+            'Resources/Public/Javascript/PageView/Utility.js',
+            'Resources/Public/Javascript/PageView/OL3.js',
+            'Resources/Public/Javascript/PageView/OL3Styles.js',
+            'Resources/Public/Javascript/PageView/OL3Sources.js',
+            'Resources/Public/Javascript/PageView/AltoParser.js',
+            'Resources/Public/Javascript/PageView/AnnotationParser.js',
+            'Resources/Public/Javascript/PageView/AnnotationControl.js',
+            'Resources/Public/Javascript/PageView/ImageManipulationControl.js',
+            'Resources/Public/Javascript/PageView/FulltextControl.js',
+            'Resources/Public/Javascript/PageView/PageView.js'
+        ];
+        // Viewer configuration.
         $viewerConfiguration = '
             $(document).ready(function() {
                 if (dlfUtils.exists(dlfViewer)) {
@@ -103,8 +106,24 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
                     });
                 }
             });
-            ';
-        $pageRenderer->addJsFooterInlineCode('kitodo-pageview-configuration', $viewerConfiguration);
+        ';
+        // Add Javascript to page footer if not configured otherwise.
+        if (empty($this->conf['addJStoBody'])) {
+            $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+            foreach ($cssFiles as $cssFile) {
+                $pageRenderer->addCssFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $cssFile);
+            }
+            foreach ($jsFiles as $jsFile) {
+                $pageRenderer->addJsFooterFile(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile);
+            }
+            $pageRenderer->addJsFooterInlineCode('kitodo-pageview-configuration', $viewerConfiguration);
+        } else {
+            foreach ($jsFiles as $jsFile) {
+                $markerArray['###JAVASCRIPT###'] .= '<script>' . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath($this->extKey) . $jsFile . '</script>' . "\n";
+            }
+            $markerArray['###JAVASCRIPT###'] .= '<script>' . $viewerConfiguration . '</script>';
+        }
+        return $markerArray;
     }
 
     /**
@@ -351,8 +370,8 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
         // Get the controls for the map.
         $this->controls = explode(',', $this->conf['features']);
         // Fill in the template markers.
-        $this->addViewerJS();
         $markerArray = array_merge($this->addInteraction(), $this->addBasketForm());
+        $markerArray['###JAVASCRIPT###'] = $this->addViewerJS();
         $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
         return $this->pi_wrapInBaseClass($content);
     }

--- a/Configuration/Flexforms/AudioPlayer.xml
+++ b/Configuration/Flexforms/AudioPlayer.xml
@@ -61,6 +61,16 @@
                             </config>
                         </TCEforms>
                     </elementId>
+                    <addJStoBody>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/AudioPlayer.xml:tt_content.pi_flexform.addJStoBody</label>
+                            <config>
+                                <type>check</type>
+                                <default>0</default>
+                            </config>
+                        </TCEforms>
+                    </addJStoBody>
                     <templateFile>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/Configuration/Flexforms/PageView.xml
+++ b/Configuration/Flexforms/PageView.xml
@@ -84,6 +84,16 @@
                             </config>
                         </TCEforms>
                     </elementId>
+                    <addJStoBody>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/PageView.xml:tt_content.pi_flexform.addJStoBody</label>
+                            <config>
+                                <type>check</type>
+                                <default>0</default>
+                            </config>
+                        </TCEforms>
+                    </addJStoBody>
                     <crop>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/Resources/Private/Language/AudioPlayer.xml
+++ b/Resources/Private/Language/AudioPlayer.xml
@@ -18,12 +18,14 @@
             <label index="tt_content.pi_flexform.sheet_general">Options</label>
             <label index="tt_content.pi_flexform.excludeOther">Show only documents from the selected page</label>
             <label index="tt_content.pi_flexform.elementId">@ID value of the HTML element for the audio player</label>
+            <label index="tt_content.pi_flexform.addJStoBody">Add Javascript files to ###JAVASCRIPT### template marker instead of page footer?</label>
             <label index="tt_content.pi_flexform.templateFile">Template file</label>
         </languageKey>
         <languageKey index="de" type="array">
             <label index="tt_content.pi_flexform.sheet_general">Einstellungen</label>
             <label index="tt_content.pi_flexform.excludeOther">Nur Dokumente der ausgewählten Seite anzeigen</label>
             <label index="tt_content.pi_flexform.elementId">@ID-Wert des HTML-Elements für den Audioplayer</label>
+            <label index="tt_content.pi_flexform.addJStoBody">Javascript-Dateien im ###JAVASCRIPT### Template-Marker anstatt im Footer ausgeben?</label>
             <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
         </languageKey>
     </data>

--- a/Resources/Private/Language/PageView.xml
+++ b/Resources/Private/Language/PageView.xml
@@ -22,6 +22,7 @@
             <label index="tt_content.pi_flexform.features.overviewmap">Overview Image</label>
             <label index="tt_content.pi_flexform.features.zoompanel">Zoom Panel</label>
             <label index="tt_content.pi_flexform.elementId">@ID value of the HTML element for the page view</label>
+            <label index="tt_content.pi_flexform.addJStoBody">Add Javascript files to ###JAVASCRIPT### template marker instead of page footer?</label>
             <label index="tt_content.pi_flexform.templateFile">Template file</label>
             <label index="tt_content.pi_flexform.useInternalProxy">Use Internal Proxy</label>
             <label index="tt_content.pi_flexform.crop">Enable cropping</label>
@@ -41,6 +42,7 @@
             <label index="tt_content.pi_flexform.features.overviewmap">Übersichtsbild</label>
             <label index="tt_content.pi_flexform.features.zoompanel">Zoom-Knöpfe</label>
             <label index="tt_content.pi_flexform.elementId">@ID-Wert des HTML-Elements für die Seitenansicht</label>
+            <label index="tt_content.pi_flexform.addJStoBody">Javascript-Dateien im ###JAVASCRIPT### Template-Marker anstatt im Footer ausgeben?</label>
             <label index="tt_content.pi_flexform.templateFile">HTML-Template</label>
             <label index="tt_content.pi_flexform.useInternalProxy">Internen Proxy verwenden</label>
             <label index="tt_content.pi_flexform.crop">Funktion zum Erstellen eines Bildausschnitts aktivieren</label>

--- a/Resources/Private/Templates/AudioPlayer.tmpl
+++ b/Resources/Private/Templates/AudioPlayer.tmpl
@@ -9,4 +9,5 @@
 -->
 <!-- ###TEMPLATE### -->
 <div id="tx-dlf-audio" class="tx-dlf-audio"></div>
+###JAVASCRIPT###
 <!-- ###TEMPLATE### -->

--- a/Resources/Private/Templates/PageView.tmpl
+++ b/Resources/Private/Templates/PageView.tmpl
@@ -17,4 +17,5 @@
 <div class="tx-dlf-navigation-editRemove">###EDITREMOVE###</div>
 <div class="tx-dlf-navigation-magnifier">###MAGNIFIER###</div>
 <div class="tx-dlf-interaction-addbasket">###BASKETBUTTON###</div>
+###JAVASCRIPT###
 <!-- ###TEMPLATE### -->


### PR DESCRIPTION
For the Zeitungsportal (or other widget-based integrations) we omit all header and footer rendering. Basically only the plugins' template-based HTML is rendered. For the Page View plugin this means all Javascript added to the page footer getting lost.

This pull request adds the option to include the Javascript into the template-based output instead. However, the default option remains to add it to the page footer.