### PR TITLE
Fix value attribute of search input field

### DIFF
--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -377,7 +377,7 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin
                 '###LABEL_QUERY###' => (!empty($search['query']) ? htmlspecialchars($search['query']) : $this->pi_getLL('label.query')),
                 '###LABEL_SUBMIT###' => $this->pi_getLL('label.submit'),
                 '###FIELD_QUERY###' => $this->prefixId . '[query]',
-                '###QUERY###' => (!empty($search['query']) ? $search['query'] : ''),
+                '###QUERY###' => (!empty($search['query']) ? htmlspecialchars($search['query']) : ''),
                 '###FULLTEXTSWITCH###' => $this->addFulltextSwitch($list->metadata['fulltextSearch']),
                 '###FIELD_DOC###' => ($this->conf['searchIn'] == 'document' || $this->conf['searchIn'] == 'all' ? $this->addCurrentDocument() : ''),
                 '###FIELD_COLL###' => ($this->conf['searchIn'] == 'collection' || $this->conf['searchIn'] == 'all' ? $this->addCurrentCollection() : ''),


### PR DESCRIPTION
If you do a phrase search with double quoates, the search input field
does not contain the search phrase after return.

Example: Search for "Leipzig Plagwitz".
```
<label for="tx-dlf-search-query">&quot;Leipzig Plagwitz&quot;</label>
<input type="text" id="tx-dlf-search-query" name="tx_dlf[query]" value=""Leipzig Plagwitz"" />
```
Whis is interpreted by the browser as:
```
<label for="tx-dlf-search-query">"Leipzig Plagwitz"</label>
<input type="text" id="tx-dlf-search-query" name="tx_dlf[query]" value="" leipzig="" plagwitz""="">
```

In case of the `<label>`-tag everything is ok. In case of the
`<input>`-tag, the HTML-markup is broken.