### PR TITLE
Prepare Release of v3.1.1

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Kitodo.Presentation',
     'description' => 'Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.',
-    'version' => '3.1.0',
+    'version' => '3.1.1',
     'category' => 'misc',
     'constraints' => [
         'depends' => [


### PR DESCRIPTION
Raising the version number in `ext_emconf.php` in preparation of upcoming release.
(Is there no better way of handling the version number?)