### PR TITLE
Replace deprecated usage of shortcut methold .load().

### DIFF
--- a/Resources/Public/Javascript/PageView/OL3Sources.js
+++ b/Resources/Public/Javascript/PageView/OL3Sources.js
@@ -71,7 +71,7 @@ dlfViewerSource.tileLoadFunction = function(tileSize, tile, url) {
     var img = tile.getImage(),
         tileWidth = Array.isArray(tileSize) ? tileSize[0] : tileSize,
         tileHeight = Array.isArray(tileSize) ? tileSize[1] : tileSize;
-    $(img).load(function() {
+    $(img).on('load', function() {
         if (img.naturalWidth > 0 &&
           (img.naturalWidth !== tileWidth || img.naturalHeight !== tileHeight)) {
             var canvas = document.createElement('canvas');


### PR DESCRIPTION
Background: https://api.jquery.com/load-event/

<pre>
Note: This API has been removed in jQuery 3.0; please use .on( "load", handler ) 
instead of .load( handler ) and .trigger( "load" ) instead of .load().
</pre>

Fix for #538.