### PR TITLE
Update SonarCloud configuration

### DIFF
--- a/.github/workflows/code_analyzer.yml
+++ b/.github/workflows/code_analyzer.yml
@@ -1,12 +1,9 @@
 name: Static Code Analyzing
 
 on:
-  # Trigger analysis when pushing in master, stable branches or pull requests, and when creating a pull request. 
+  # Trigger analysis when pushing in stable branches
   push:
     branches: [master, 2.x]
-  pull_request:
-    branches: [master, 2.x]
-    types: [opened, synchronize, reopened]
 
 jobs:
   sonarcloud:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,11 @@
 sonar.organization=kitodo
 sonar.projectKey=kitodo-presentation
 sonar.sources=.
+sonar.sourceEncoding=UTF-8
 sonar.scm.provider=git
 sonar.pullrequest.provider=GitHub
 sonar.pullrequest.github.repository=kitodo/kitodo-presentation
-sonar.pullrequest.github.summary_comment=True
+sonar.pullrequest.github.summary_comment=true
 sonar.issues.defaultAssigneeLogin=sebastian-meyer@github
 sonar.php.file.suffixes=php
 sonar.php.exclusions=


### PR DESCRIPTION
SonarCloud's encoding is set to the system default which oddly is `us-ascii` for `ubuntu-latest`. We use `UTF-8` so we have to set the encoding in the configuration file.

Analyzing pull requests from forked repositories doesn't work, because forks can't access the main repository's secret `SONAR_TOKEN`. Thus I've removed checks for pull requests, but retained the analysis for push events in the stable branches. This results in the checks being performed *after* a pull request is merged.