### PR TITLE
Update Solarium to 5.1.6

### DIFF
--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -578,7 +578,7 @@ class Solr
                     'scheme' => $solrInfo['scheme'],
                     'host' => $solrInfo['host'],
                     'port' => $solrInfo['port'],
-                    'path' => '/' . $solrInfo['path'],
+                    'path' => '/' . $solrInfo['path'] . '/',
                     'core' => $core,
                     'username' => $solrInfo['username'],
                     'password' => $solrInfo['password'],

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -248,7 +248,7 @@ class Solr
         // Set port if not set.
         $solrInfo['port'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
         // Append core name to path.
-        $solrInfo['path'] = trim($conf['solrPath'], '/') . '/solr';
+        $solrInfo['path'] = trim($conf['solrPath'], '/');
         // Timeout
         $solrInfo['timeout'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);
         return $solrInfo;
@@ -276,7 +276,7 @@ class Solr
             $host = $solrInfo['host'];
         }
         // Return entire request URL.
-        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/' . $solrInfo['path'] . '/' . $core;
+        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/' . $solrInfo['path'] . '/solr/' . $core;
     }
 
     /**
@@ -578,7 +578,7 @@ class Solr
                     'scheme' => $solrInfo['scheme'],
                     'host' => $solrInfo['host'],
                     'port' => $solrInfo['port'],
-                    'path' => '/',
+                    'path' => '/' . $solrInfo['path'],
                     'core' => $core,
                     'username' => $solrInfo['username'],
                     'password' => $solrInfo['password'],

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -274,7 +274,7 @@ class Solr
             $host = $solrInfo['host'];
         }
         // Return entire request URL.
-        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/solr/' . $core;
+        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/' . $solrInfo['path'] . '/' . $core;
     }
 
     /**

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -247,8 +247,6 @@ class Solr
         $solrInfo['password'] = $conf['solrPass'];
         // Set port if not set.
         $solrInfo['port'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
-        // Append core name to path.
-        $solrInfo['path'] = trim($conf['solrPath'], '/');
         // Timeout
         $solrInfo['timeout'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);
         return $solrInfo;
@@ -276,7 +274,7 @@ class Solr
             $host = $solrInfo['host'];
         }
         // Return entire request URL.
-        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/' . $solrInfo['path'] . '/' . $core;
+        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/solr/' . $core;
     }
 
     /**
@@ -578,8 +576,10 @@ class Solr
                     'scheme' => $solrInfo['scheme'],
                     'host' => $solrInfo['host'],
                     'port' => $solrInfo['port'],
-                    'path' => '/' . $solrInfo['path'] . '/',
+                    'path' => '/',
                     'core' => $core,
+                    // For Solr Cloud you need to provide a collection instead of core:
+                    // 'collection' => $core
                     'username' => $solrInfo['username'],
                     'password' => $solrInfo['password'],
                     'timeout' => $solrInfo['timeout']

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -247,7 +247,7 @@ class Solr
         $solrInfo['password'] = $conf['solrPass'];
         // Set port if not set.
         $solrInfo['port'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
-        // Append core name to path.
+        // Trim path of slashes.
         $solrInfo['path'] = trim($conf['solrPath'], '/');
         // Timeout
         $solrInfo['timeout'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -247,6 +247,8 @@ class Solr
         $solrInfo['password'] = $conf['solrPass'];
         // Set port if not set.
         $solrInfo['port'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
+        // Append core name to path.
+        $solrInfo['path'] = trim($conf['solrPath'], '/') . '/solr';
         // Timeout
         $solrInfo['timeout'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);
         return $solrInfo;
@@ -578,8 +580,6 @@ class Solr
                     'port' => $solrInfo['port'],
                     'path' => '/',
                     'core' => $core,
-                    // For Solr Cloud you need to provide a collection instead of core:
-                    // 'collection' => $core
                     'username' => $solrInfo['username'],
                     'password' => $solrInfo['password'],
                     'timeout' => $solrInfo['timeout']

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -192,7 +192,7 @@
             <label index="config.solrHttps">Use https: (default is "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (default is "localhost")</label>
             <label index="config.solrPort">Solr Server Port: (default is "8983")</label>
-            <label index="config.solrPath">Solr Server Path: (default is "/solr/")</label>
+            <label index="config.solrPath">Solr Server Path: (default is "/")</label>
             <label index="config.solrUser">Solr Server User: (default is "")</label>
             <label index="config.solrPass">Solr Server Password: (default is "")</label>
             <label index="config.solrTimeout">Solr Server Timeout: (default is "10")</label>
@@ -375,7 +375,7 @@
             <label index="config.solrHttps">Https verwenden: (Standard ist "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (Standard ist "localhost")</label>
             <label index="config.solrPort">Solr Server Port: (Standard ist "8983")</label>
-            <label index="config.solrPath">Solr Server Pfad: (Standard ist "/solr/")</label>
+            <label index="config.solrPath">Solr Server Pfad: (Standard ist "/")</label>
             <label index="config.solrUser">Solr Server Benutzername: (Standard ist "")</label>
             <label index="config.solrPass">Solr Server Kennwort: (Standard ist "")</label>
             <label index="config.solrTimeout">Solr Server Timeout: (Standard ist "10")</label>

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -192,7 +192,7 @@
             <label index="config.solrHttps">Use https: (default is "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (default is "localhost")</label>
             <label index="config.solrPort">Solr Server Port: (default is "8983")</label>
-            <label index="config.solrPath">Solr Server Path: (default is "/")</label>
+            <label index="config.solrPath">Solr Server Path: without API endpoint "/solr" (default is "/")</label>
             <label index="config.solrUser">Solr Server User: (default is "")</label>
             <label index="config.solrPass">Solr Server Password: (default is "")</label>
             <label index="config.solrTimeout">Solr Server Timeout: (default is "10")</label>
@@ -375,7 +375,7 @@
             <label index="config.solrHttps">Https verwenden: (Standard ist "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (Standard ist "localhost")</label>
             <label index="config.solrPort">Solr Server Port: (Standard ist "8983")</label>
-            <label index="config.solrPath">Solr Server Pfad: (Standard ist "/")</label>
+            <label index="config.solrPath">Solr Server Pfad: ohne API-Endpunkt "/solr" (Standard ist "/")</label>
             <label index="config.solrUser">Solr Server Benutzername: (Standard ist "")</label>
             <label index="config.solrPass">Solr Server Kennwort: (Standard ist "")</label>
             <label index="config.solrTimeout">Solr Server Timeout: (Standard ist "10")</label>

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "typo3/cms-core": "~8.7.32|~9.5.17",
     "typo3/cms-tstemplate": "~8.7.32|~9.5.17",
     "ubl/php-iiif-prezi-reader": "0.3.0",
-    "solarium/solarium": "^4.2"
+    "solarium/solarium": "^5.1.6"
   },
   "replace": {
     "typo3-ter/dlf": "self.version"

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -37,7 +37,7 @@ solrHost = localhost
 # cat=Solr; type=int[0-65535]; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.solrPort
 solrPort = 8983
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.solrPath
-solrPath = /solr/
+solrPath = /
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.solrUser
 solrUser =
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.solrPass


### PR DESCRIPTION
The highest possible now update of Solarium. Necessary change (https://solarium.readthedocs.io/en/stable/getting-started/):

> In the past, the V1 API endpoint solr was not added automatically, so most users set it as path on the endpoint. This bug was discovered with the addition of V2 API support. In almost every setup, the path has to be set to / instead of /solr with this release!

> For the same reason it is a must to explicit configure the core or collection.

Since version 5.2 needed is EventDispatcher which in TYPO3 is first available in ver. 10 (https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Hooks/EventDispatcher/Index.html).