### PR TITLE
Duplicate full text plugin for always active full text

### DIFF
--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -89,7 +89,11 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
             'Resources/Public/Javascript/PageView/AnnotationParser.js',
             'Resources/Public/Javascript/PageView/AnnotationControl.js',
             'Resources/Public/Javascript/PageView/ImageManipulationControl.js',
+            // full text with switch on/off
             'Resources/Public/Javascript/PageView/FulltextControl.js',
+            // always active full text (DDB)
+            // 'Resources/Public/Javascript/PageView/FulltextOnControl.js',
+            'Resources/Public/Javascript/PageView/FullTextUtility.js',
             'Resources/Public/Javascript/PageView/PageView.js'
         ];
         // Viewer configuration.

--- a/Classes/Plugin/Tools/FulltextOnTool.php
+++ b/Classes/Plugin/Tools/FulltextOnTool.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Plugin\Tools;
+
+use Kitodo\Dlf\Common\Helper;
+
+/**
+ * Fulltext tool with always displayed text for the plugin 'Toolbox' of the 'dlf' extension
+ *
+ * @author Sebastian Meyer <sebastian.meyer@slub-dresden.de>
+ * @author Alexander Bigga <alexander.bigga@slub-dresden.de>
+ * @author Beatrycze Volk <beatrycze.volk@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class FulltextOnTool extends \Kitodo\Dlf\Common\AbstractPlugin
+{
+    public $scriptRelPath = 'Classes/Plugin/Tools/FulltextOnTool.php';
+
+    /**
+     * The main method of the PlugIn
+     *
+     * @access public
+     *
+     * @param string $content: The PlugIn content
+     * @param array $conf: The PlugIn configuration
+     *
+     * @return string The content that is displayed on the website
+     */
+    public function main($content, $conf)
+    {
+        $this->init($conf);
+        // Merge configuration with conf array of toolbox.
+        if (!empty($this->cObj->data['conf'])) {
+            $this->conf = Helper::mergeRecursiveWithOverrule($this->cObj->data['conf'], $this->conf);
+        }
+        // Load current document.
+        $this->loadDocument();
+        if (
+            $this->doc === null
+            || $this->doc->numPages < 1
+            || empty($this->conf['fileGrpFulltext'])
+        ) {
+            // Quit without doing anything if required variables are not set.
+            return $content;
+        } else {
+            if (!empty($this->piVars['logicalPage'])) {
+                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
+                // The logical page parameter should not appear again
+                unset($this->piVars['logicalPage']);
+            }
+            // Set default values if not set.
+            // $this->piVars['page'] may be integer or string (physical structure @ID)
+            if (
+                (int) $this->piVars['page'] > 0
+                || empty($this->piVars['page'])
+            ) {
+                $this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
+            } else {
+                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
+            }
+            $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
+        }
+        // Load template file.
+        $this->getTemplate();
+        $fullTextFile = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
+        if (!empty($fullTextFile)) {
+            $markerArray['###FULLTEXT_SELECT###'] = '<a id="tx-dlf-tools-fulltext" title="' . htmlspecialchars($this->pi_getLL('fulltext', '')) . '">' . htmlspecialchars($this->pi_getLL('fulltext', '')) . '</a>';
+        } else {
+            $markerArray['###FULLTEXT_SELECT###'] = '<span class="no-fulltext">' . htmlspecialchars($this->pi_getLL('fulltext-not-available', '')) . '</span>';
+        }
+        $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
+        return $this->pi_wrapInBaseClass($content);
+    }
+}

--- a/Configuration/TypoScript/Toolbox/setup.txt
+++ b/Configuration/TypoScript/Toolbox/setup.txt
@@ -1,4 +1,5 @@
 plugin.tx_dlf_annotationtool.templateFile = EXT:dlf/Resources/Private/Templates/AnnotationTool.tmpl
+plugin.tx_dlf_fulltextontool.templateFile = EXT:dlf/Resources/Private/Templates/FulltextOnTool.tmpl
 plugin.tx_dlf_fulltexttool.templateFile = EXT:dlf/Resources/Private/Templates/FulltextTool.tmpl
 plugin.tx_dlf_imagedownloadtool.templateFile = EXT:dlf/Resources/Private/Templates/ImageDownloadTool.tmpl
 plugin.tx_dlf_imagemanipulationtool.templateFile = EXT:dlf/Resources/Private/Templates/ImageManipulationTool.tmpl

--- a/Resources/Private/Language/FulltextOnTool.xml
+++ b/Resources/Private/Language/FulltextOnTool.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+<T3locallang>
+    <meta type="array">
+        <type>module</type>
+        <description>Language labels for tool Fulltext</description>
+    </meta>
+    <data type="array">
+        <languageKey index="default" type="array">
+            <label index="fulltext">Fulltext</label>
+            <label index="fulltext-not-available">No Fulltext available</label>
+        </languageKey>
+        <languageKey index="de" type="array">
+            <label index="fulltext">Volltext</label>
+            <label index="fulltext-not-available">Keine Volltexte vorhanden</label>
+        </languageKey>
+    </data>
+</T3locallang>

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -151,6 +151,7 @@
             <label index="tx_dlf_mail">Email</label>
             <label index="tx_dlf_mail.mail">Address</label>
             <label index="tx_dlf_mail.name">Name</label>
+            <label index="tx_dlf_toolbox.fulltextontool">Fulltext</label>
             <label index="tx_dlf_toolbox.fulltexttool">Fulltext</label>
             <label index="tx_dlf_toolbox.annotationtool">IIIF Annotations</label>
             <label index="tx_dlf_toolbox.imagedownloadtool">Image Download</label>
@@ -334,6 +335,7 @@
             <label index="tx_dlf_mail">E-Mail</label>
             <label index="tx_dlf_mail.mail">Adresse</label>
             <label index="tx_dlf_mail.name">Name</label>
+            <label index="tx_dlf_toolbox.fulltextontool">Volltext</label>
             <label index="tx_dlf_toolbox.fulltexttool">Volltext</label>
             <label index="tx_dlf_toolbox.annotationtool">IIIF-Annotationen</label>
             <label index="tx_dlf_toolbox.imagedownloadtool">Bild-Download</label>

--- a/Resources/Public/Javascript/PageView/FullTextUtility.js
+++ b/Resources/Public/Javascript/PageView/FullTextUtility.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+ /**
+ * This is necessary to support the scrolling of the element into the viewport
+ * in case of text hover on the map.
+ *
+ * @param elem
+ * @param speed
+ * @returns {jQuery}
+ */
+jQuery.fn.scrollTo = function(elem, speed) {
+    var manualOffsetTop = $(elem).parent().height() / 2;
+    $(this).animate({
+        scrollTop:  $(this).scrollTop() - $(this).offset().top + $(elem).offset().top - manualOffsetTop
+    }, speed === undefined ? 1000 : speed);
+    return this;
+};
+
+/**
+ * Base namespace for full text utility functions used by the dlf module.
+ *
+ * @const
+ */
+var dlfFullTextUtils = dlfFullTextUtils || {};
+
+/**
+ * Handle TextBlock elements
+ * @param {Object} hoverSourceTextblock_
+ * @param {Object} selectSource_
+ * @þaram {ol.Feature} textblockFeature
+ * @static
+ */
+dlfFullTextUtils.handleTextBlockElements = function(hoverSourceTextblock, selectSource, textblockFeature) {
+    var activeSelectTextBlockEl_ = this.getFeature(selectSource),
+        activeHoverTextBlockEl_ = this.getFeature(hoverSourceTextblock),
+        isFeatureEqualSelectFeature_ = this.isFeatureEqual(activeSelectTextBlockEl_, textblockFeature),
+        isFeatureEqualToOldHoverFeature_ = this.isFeatureEqual(activeHoverTextBlockEl_, textblockFeature);
+
+    if (!isFeatureEqualToOldHoverFeature_ && !isFeatureEqualSelectFeature_) {
+        // remove old textblock hover features
+        hoverSourceTextblock.clear();
+
+        if (textblockFeature) {
+            // add textblock feature to hover
+            hoverSourceTextblock.addFeature(textblockFeature);
+        }
+    }
+};
+
+/**
+ * Handle TextLine elements
+ * @param {Object} hoverSourceTextline
+ * @þaram {ol.Feature} textlineFeature
+ * @static
+ */
+dlfFullTextUtils.handleTextLineElements = function(hoverSourceTextline, textlineFeature) {
+    var activeHoverTextBlockEl_ = this.getFeature(hoverSourceTextline),
+        isFeatureEqualToOldHoverFeature_ = this.isFeatureEqual(activeHoverTextBlockEl_, textlineFeature);
+
+    if (!isFeatureEqualToOldHoverFeature_) {
+
+        if (activeHoverTextBlockEl_) {
+            // remove highlight effect on fulltext view
+            var oldTargetElem = $('#' + activeHoverTextBlockEl_.getId());
+
+            if (oldTargetElem.hasClass('highlight') ) {
+                oldTargetElem.removeClass('highlight');
+            }
+
+            // remove old textline hover features
+            hoverSourceTextline.clear();
+        }
+
+        this.highlightFullText(textlineFeature);
+    }
+};
+
+/**
+ * Highlight full text
+ * @param {Object} hoverSourceTextline
+ * @param {ol.Feature} textlineFeature
+ */
+dlfFullTextUtils.highlightFullText = function(hoverSourceTextline, textlineFeature) {
+    if (textlineFeature) {
+        // add highlight effect to fulltext view
+        var targetElem = $('#' + textlineFeature.getId());
+
+        if (targetElem.length > 0 && !targetElem.hasClass('highlight')) {
+            targetElem.addClass('highlight');
+            $('#tx-dlf-fulltextselection').scrollTo(targetElem, 50);
+            hoverSourceTextline.addFeature(textlineFeature);
+        }
+    }
+};
+
+/**
+ * Get feature from given source
+ * @param {Object} source
+ */
+dlfFullTextUtils.getFeature = function(source) {
+    return source.getFeatures().length > 0 ? source.getFeatures()[0] : undefined;
+};
+
+/**
+ * Check if given feature element is equal to other feature
+ * @param {ol.Feature} element
+ * @þaram {ol.Feature} feature
+ */
+dlfFullTextUtils.isFeatureEqual = function(element, feature) {
+    return element !== undefined && feature !== undefined && element.getId() === feature.getId();
+};
+
+/**
+ * Method fetches the fulltext data from the server
+ * @param {string} url
+ * @param {Object} image
+ * @param {number=} optOffset
+ * @return {ol.Feature|undefined}
+ * @static
+ */
+dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset) {
+    // fetch data from server
+    var request = $.ajax({
+        url,
+        async: false
+    });
+
+    var fulltextCoordinates = this.parseAltoData(request, image, optOffset);
+
+    return fulltextCoordinates.length > 0 ? fulltextCoordinates[0] : undefined;
+};
+
+/**
+ * Method parses ALTO data from request response
+ * @param {string} url
+ * @param {Object} image
+ * @param {number=} optOffset
+ * @return {Array.<ol.Feature>}
+ */
+dlfFullTextUtils.parseAltoData = function(request, image, optOffset) {
+    var offset = dlfUtils.exists(optOffset) ? optOffset : undefined,
+      parser = new dlfAltoParser(image, undefined, undefined, offset);
+
+      return request.responseXML ? parser.parseFeatures(request.responseXML) :
+            request.responseText ? parser.parseFeatures(request.responseText) : [];
+};

--- a/Resources/Public/Javascript/PageView/FulltextOnControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextOnControl.js
@@ -36,14 +36,6 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
     this.url = fulltextUrl;
 
     /**
-     * @type {Object}
-     * @private
-     */
-    this.dic = $('#tx-dlf-tools-fulltext').length > 0 && $('#tx-dlf-tools-fulltext').attr('data-dic') ?
-        dlfUtils.parseDataDic($('#tx-dlf-tools-fulltext')) :
-        {'fulltext-on':'Activate Fulltext','fulltext-off':'Deactivate Fulltext'};
-
-    /**
      * @type {ol.Feature|undefined}
      * @private
      */
@@ -163,35 +155,11 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
         this)
     };
 
-    // add active / deactive behavior in case of click on control
+    // get anchor for activate fulltext
     var anchorEl = $('#tx-dlf-tools-fulltext');
-    if (anchorEl.length > 0){
-        var toogleFulltext = $.proxy(function(event) {
-            event.preventDefault();
 
-            if ($(event.target).hasClass('active')) {
-                this.deactivate();
-                return;
-            }
-
-            this.activate();
-        }, this);
-
-
-        anchorEl.on('click', toogleFulltext);
-        anchorEl.on('touchstart', toogleFulltext);
-    }
-
-    // set initial title of fulltext element
-    $("#tx-dlf-tools-fulltext")
-        .text(this.dic['fulltext-on'])
-        .attr('title', this.dic['fulltext-on']);
-
-    // if fulltext is activated via cookie than run activation methode
-    if (dlfUtils.getCookie("tx-dlf-pageview-fulltext-select") === 'enabled') {
-        // activate the fulltext behavior
-        this.activate(anchorEl);
-    }
+    // activate the fulltext behavior
+    this.activate(anchorEl);
 
 };
 
@@ -232,51 +200,6 @@ dlfViewerFullTextControl.prototype.activate = function() {
 
 /**
  * Activate Fulltext Features
- */
-dlfViewerFullTextControl.prototype.deactivate = function() {
-
-    var controlEl = $('#tx-dlf-tools-fulltext');
-
-    // deactivate fulltext
-    this.disableFulltextSelect();
-    dlfUtils.setCookie("tx-dlf-pageview-fulltext-select", 'disabled');
-    $(controlEl).removeClass('active');
-
-    // trigger event
-    $(this).trigger("deactivate-fulltext", this);
-};
-
-/**
- * Disable Fulltext Features
- *
- * @return void
- */
-dlfViewerFullTextControl.prototype.disableFulltextSelect = function() {
-
-    // register event listeners
-    this.map.un('click', this.handlers_.mapClick);
-    this.map.un('pointermove', this.handlers_.mapHover);
-
-    // remove layers
-    for (var key in this.layers_) {
-        if (this.layers_.hasOwnProperty(key)) {
-            this.map.removeLayer(this.layers_[String(key)]);
-        }
-    };
-
-    var className = 'fulltext-visible';
-    $("#tx-dlf-tools-fulltext").removeClass(className)
-        .text(this.dic['fulltext-on'])
-        .attr('title', this.dic['fulltext-on']);
-
-    $('#tx-dlf-fulltextselection').removeClass(className);
-    $('#tx-dlf-fulltextselection').hide();
-    $('body').removeClass(className);
-
-};
-
-/**
- * Activate Fulltext Features
  * @param {Array.<ol.Feature>} textBlockFeatures
  * @þaram {Array.<ol.Feature>} textLineFeatures
  */
@@ -295,9 +218,7 @@ dlfViewerFullTextControl.prototype.enableFulltextSelect = function(textBlockFeat
 
     // show fulltext container
     var className = 'fulltext-visible';
-    $("#tx-dlf-tools-fulltext").addClass(className)
-      .text(this.dic['fulltext-off'])
-      .attr('title', this.dic['fulltext-off']);
+    $("#tx-dlf-tools-fulltext").addClass(className);
 
     $('#tx-dlf-fulltextselection').addClass(className);
     $('#tx-dlf-fulltextselection').show();

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -327,14 +327,14 @@ dlfViewer.prototype.displayHighlightWord = function() {
     if (urlParams !== undefined && urlParams.hasOwnProperty(key) && this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
         var value = urlParams[key],
             values = value.split(';'),
-            fulltextData = dlfViewerFullTextControl.fetchFulltextDataFromServer(this.fulltexts[0].url, this.images[0]),
+            fulltextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[0].url, this.images[0]),
             fulltextDataImageTwo = undefined;
 
         // check if there is another image / fulltext to look for
         if (this.images.length === 2 & this.fulltexts[1] !== undefined && this.fulltexts[1].url !== '') {
             var image = $.extend({}, this.images[1]);
             image.width = image.width + this.images[0].width;
-            fulltextDataImageTwo = dlfViewerFullTextControl.fetchFulltextDataFromServer(this.fulltexts[1].url, this.images[1], this.images[0].width);
+            fulltextDataImageTwo = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[1].url, this.images[1], this.images[0].width);
         }
 
         var stringFeatures = fulltextDataImageTwo === undefined ? fulltextData.getStringFeatures() :

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -128,6 +128,12 @@ plugin.tx_dlf_validator {
 }
 tt_content.list.20.dlf_validator < plugin.tx_dlf_validator
 
+plugin.tx_dlf_fulltextontool = USER
+plugin.tx_dlf_fulltextontool {
+    userFunc = Kitodo\Dlf\Plugin\Tools\FulltextOnTool->main
+}
+tt_content.list.20.dlf_fulltextontool < plugin.tx_dlf_fulltextontool
+
 plugin.tx_dlf_fulltexttool = USER
 plugin.tx_dlf_fulltexttool {
     userFunc = Kitodo\Dlf\Plugin\Tools\FulltextTool->main
@@ -199,6 +205,7 @@ foreach ($iconArray as $key => $value) {
 );
 // Register tools for toolbox plugin.
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'] = [];
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY) . '_fulltextontool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.fulltextontool';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY) . '_fulltexttool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.fulltexttool';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY) . '_annotationtool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.annotationtool';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['dlf/Classes/Plugin/Toolbox.php']['tools'][\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getCN($_EXTKEY) . '_imagedownloadtool'] = 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_toolbox.imagedownloadtool';


### PR DESCRIPTION
PR #546 was closed because of missing JS file import in PageView. Here change between plugins happens by replacing it.