### PR TITLE
Fix condition check for adding full text control

### DIFF
--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -157,7 +157,7 @@ dlfViewer.prototype.addCustomControls = function(controlNames) {
 
     // Adds fulltext behavior only if there is fulltext available and no double page
     // behavior is active
-    if (this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length === 1) {
+    if (this.fulltexts[0] !== undefined && this.fulltexts[0].length !== 0 && this.fulltexts[0].url !== '' && this.images.length === 1) {
         fulltextControl = new dlfViewerFullTextControl(this.map, this.images[0], this.fulltexts[0].url);
     } else {
         $('#tx-dlf-tools-fulltext').remove();


### PR DESCRIPTION
Property this.fulltexts[0] is actually an empty array, so it passed check for undefined. Its url was not empty string as it doesn't exists. All in all it was trying to add full text control for documents without it.

```
at Function.S.parseXML (jquery-3.5.1.min.js?1607018142:2)
    at dlfAltoParser.parseXML_ (AltoParser.js:357)
    at dlfAltoParser.parseFeatures (AltoParser.js:114)
    .....
    at dlfViewer.addCustomControls (PageView.js:167)
    at dlfViewer.<anonymous> (PageView.js:429)
```
