### PR TITLE
Add FullTextUtility for methods common for full text plugins

### DIFF
--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -90,6 +90,7 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
             'Resources/Public/Javascript/PageView/AnnotationControl.js',
             'Resources/Public/Javascript/PageView/ImageManipulationControl.js',
             'Resources/Public/Javascript/PageView/FulltextControl.js',
+            'Resources/Public/Javascript/PageView/FullTextUtility.js',
             'Resources/Public/Javascript/PageView/PageView.js'
         ];
         // Viewer configuration.

--- a/Resources/Public/Javascript/PageView/FullTextUtility.js
+++ b/Resources/Public/Javascript/PageView/FullTextUtility.js
@@ -1,0 +1,63 @@
+/**
+ * Base namespace for utility functions used by the dlf module.
+ *
+ * @const
+ */
+var dlfFullTextUtils = dlfFullTextUtils || {};
+
+/**
+ * Get feature from given source
+ * @param {Object} source
+ * @return {ol.Feature|undefined}
+ * @static
+ */
+dlfFullTextUtils.getFeature = function(source){
+    return source.getFeatures().length > 0 ? source.getFeatures()[0] : undefined;
+};
+
+/**
+ * Check if given element is equal to given feature
+ * @param {Object} element
+ * @param {Object} feature
+ * @return {boolean}
+ * @static
+ */
+dlfFullTextUtils.isFeatureEqual = function(element, feature){
+    return element !== undefined && feature !== undefined && element.getId() === feature.getId();
+};
+
+/**
+ * Method fetches the fulltext data from the server
+ * @param {string} url
+ * @param {Object} image
+ * @param {number=} optOffset
+ * @return {ol.Feature|undefined}
+ * @static
+ */
+dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset){
+    // fetch data from server
+    var request = $.ajax({
+        url,
+        async: false
+    });
+
+    var offset = dlfUtils.exists(optOffset) ? optOffset : undefined;
+
+    return dlfFullTextUtils.parseAltoData(image, offset, request);
+};
+
+/**
+ * Method parses ALTO data
+ * @param {Object} image
+ * @param {number=} offset
+ * @param {Object} request
+ * @return {ol.Feature|undefined}
+ * @static
+ */
+dlfFullTextUtils.parseAltoData = function(image, offset, request){
+    var parser = new dlfAltoParser(image, undefined, undefined, offset),
+      fulltextCoordinates = request.responseXML ? parser.parseFeatures(request.responseXML) :
+            request.responseText ? parser.parseFeatures(request.responseText) : [];
+
+    return fulltextCoordinates.length > 0 ? fulltextCoordinates[0] : undefined;
+};

--- a/Resources/Public/Javascript/PageView/FullTextUtility.js
+++ b/Resources/Public/Javascript/PageView/FullTextUtility.js
@@ -1,9 +1,22 @@
+'use strict';
+
 /**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+ /**
  * Base namespace for utility functions used by the dlf module.
  *
  * @const
  */
-var dlfFullTextUtils = dlfFullTextUtils || {};
+var dlfFullTextUtils;
+dlfFullTextUtils = dlfFullTextUtils || {};
 
 /**
  * Get feature from given source

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -120,7 +120,7 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
                     this.selectedFeature_ = undefined;
                     this.showFulltext(undefined);
                     return;
-                };
+                }
 
                 // highlight features
                 if (this.selectedFeature_) {
@@ -153,7 +153,7 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
                 // hover in case of dragging
                 if (event['dragging']) {
                     return;
-                };
+                }
 
                 var hoverSourceTextblock_ = this.layers_.hoverTextblock.getSource(),
                     hoverSourceTextline_ = this.layers_.hoverTextline.getSource(),
@@ -174,14 +174,10 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
                 //
                 // Handle TextBlock elements
                 //
-                var activeSelectTextBlockEl_ = selectSource_.getFeatures().length > 0 ?
-                        selectSource_.getFeatures()[0] : undefined,
-                    activeHoverTextBlockEl_ = hoverSourceTextblock_.getFeatures().length > 0 ?
-                        hoverSourceTextblock_.getFeatures()[0] : undefined,
-                    isFeatureEqualSelectFeature_ = activeSelectTextBlockEl_ !== undefined && textblockFeature !== undefined &&
-                    activeSelectTextBlockEl_.getId() === textblockFeature.getId() ? true : false,
-                    isFeatureEqualToOldHoverFeature_ = activeHoverTextBlockEl_ !== undefined && textblockFeature !== undefined &&
-                    activeHoverTextBlockEl_.getId() === textblockFeature.getId() ? true : false;
+                var activeSelectTextBlockEl_ = dlfFullTextUtils.getFeature(selectSource_),
+                    activeHoverTextBlockEl_ = dlfFullTextUtils.getFeature(hoverSourceTextblock_),
+                    isFeatureEqualSelectFeature_ = dlfFullTextUtils.isFeatureEqual(activeSelectTextBlockEl_, textblockFeature),
+                    isFeatureEqualToOldHoverFeature_ = dlfFullTextUtils.isFeatureEqual(activeHoverTextBlockEl_);
 
                 if (!isFeatureEqualToOldHoverFeature_ && !isFeatureEqualSelectFeature_) {
 
@@ -198,10 +194,8 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
                 //
                 // Handle TextLine elements
                 //
-                var activeHoverTextBlockEl_ = hoverSourceTextline_.getFeatures().length > 0 ?
-                        hoverSourceTextline_.getFeatures()[0] : undefined,
-                    isFeatureEqualToOldHoverFeature_ = activeHoverTextBlockEl_ !== undefined && textlineFeature !== undefined &&
-                    activeHoverTextBlockEl_.getId() === textlineFeature.getId() ? true : false;
+                var activeHoverTextBlockEl_ = dlfFullTextUtils.getFeature(hoverSourceTextline_),
+                    isFeatureEqualToOldHoverFeature_ = dlfFullTextUtils.isFeatureEqual(activeHoverTextBlockEl_, textlineFeature);
 
                 if (!isFeatureEqualToOldHoverFeature_) {
 
@@ -292,7 +286,7 @@ dlfViewerFullTextControl.prototype.activate = function() {
     // if the activate method is called for the first time fetch
     // fulltext data from server
     if (this.fulltextData_ === undefined)  {
-        this.fulltextData_ = dlfViewerFullTextControl.fetchFulltextDataFromServer(this.url, this.image);
+        this.fulltextData_ = dlfFullTextUtils.fetchFullTextDataFromServer(this.url, this.image);
 
         if (this.fulltextData_ !== undefined) {
             // add features to fulltext layer
@@ -389,34 +383,6 @@ dlfViewerFullTextControl.prototype.enableFulltextSelect = function(textBlockFeat
     $('#tx-dlf-fulltextselection').addClass(className);
     $('#tx-dlf-fulltextselection').show();
     $('body').addClass(className);
-};
-
-/**
- * Method fetches the fulltext data from the server
- * @param {string} url
- * @param {Object} image
- * @param {number=} opt_offset
- * @return {ol.Feature|undefined}
- * @static
- */
-dlfViewerFullTextControl.fetchFulltextDataFromServer = function(url, image, opt_offset){
-    // fetch data from server
-    var request = $.ajax({
-        url,
-        async: false
-    });
-
-    // parse alto data
-    var offset = dlfUtils.exists(opt_offset) ? opt_offset : undefined,
-      parser = new dlfAltoParser(image, undefined, undefined, offset),
-      fulltextCoordinates = request.responseXML ? parser.parseFeatures(request.responseXML) :
-            request.responseText ? parser.parseFeatures(request.responseText) : [];
-
-    if (fulltextCoordinates.length > 0) {
-        return fulltextCoordinates[0];
-    }
-
-    return undefined;
 };
 
 /**

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -194,8 +194,8 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
                 //
                 // Handle TextLine elements
                 //
-                var activeHoverTextBlockEl_ = dlfFullTextUtils.getFeature(hoverSourceTextline_),
-                    isFeatureEqualToOldHoverFeature_ = dlfFullTextUtils.isFeatureEqual(activeHoverTextBlockEl_, textlineFeature);
+                activeHoverTextBlockEl_ = dlfFullTextUtils.getFeature(hoverSourceTextline_);
+                isFeatureEqualToOldHoverFeature_ = dlfFullTextUtils.isFeatureEqual(activeHoverTextBlockEl_, textlineFeature);
 
                 if (!isFeatureEqualToOldHoverFeature_) {
 

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -327,14 +327,14 @@ dlfViewer.prototype.displayHighlightWord = function() {
     if (urlParams !== undefined && urlParams.hasOwnProperty(key) && this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
         var value = urlParams[key],
             values = value.split(';'),
-            fulltextData = dlfViewerFullTextControl.fetchFulltextDataFromServer(this.fulltexts[0].url, this.images[0]),
+            fulltextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[0].url, this.images[0]),
             fulltextDataImageTwo = undefined;
 
         // check if there is another image / fulltext to look for
         if (this.images.length === 2 & this.fulltexts[1] !== undefined && this.fulltexts[1].url !== '') {
             var image = $.extend({}, this.images[1]);
             image.width = image.width + this.images[0].width;
-            fulltextDataImageTwo = dlfViewerFullTextControl.fetchFulltextDataFromServer(this.fulltexts[1].url, this.images[1], this.images[0].width);
+            fulltextDataImageTwo = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[1].url, this.images[1], this.images[0].width);
         }
 
         var stringFeatures = fulltextDataImageTwo === undefined ? fulltextData.getStringFeatures() :


### PR DESCRIPTION
Methods as `fetchFullTextDataFromServer` will be used by different text plugins (display full text / download full text). It is extracted to utility class to avoid redundancies.