### PR TITLE
Fix for SearchInDocument plugin if using routeEnhancers (Slug)

### DIFF
--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -82,3 +82,39 @@ Please include the Template "Basic Configuration (dlf)". This template adds
 jQuery to your page by setting the following typoscript:
 
 :typoscript:`page.includeJSlibs.jQuery`
+
+
+******************
+Slug Configuration
+******************
+
+With TYPO3 9.5 it is possible to make speaking urls with the builtin advanced
+routing feature ("Slug"). This may be used for extensions too.
+
+TYPO3 documentation about `Advanced Routing Configuration <https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/ApiOverview/Routing/AdvancedRoutingConfiguration.html>`_.
+
+The following code is an example of an routeEnhancer for the workview page on uid=14.
+
+.. code-block:: yaml
+   :linenos:
+
+   routeEnhancers:
+     KitodoWorkview:
+       type: Plugin
+       namespace: tx_dlf
+       limitToPages:
+         - 14
+       routePath: '/{id}/{page}'
+       requirements:
+         id: '(\d+)|(http.*xml)'
+         page: \d+
+     KitodoWorkviewDouble:
+       type: Plugin
+       namespace: tx_dlf
+       limitToPages:
+         - 14
+       routePath: '/{id}/{page}/{double}'
+       requirements:
+         id: '(\d+)|(http.*xml)'
+         page: \d+
+         double: '[0-1]'

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -74,22 +74,22 @@ $(document).ready(function() {
               } else {
                   for (var i=0; i < data.response.docs.length; i++) {
 
-                      // Take the workview base_url from the form action.
-                      // link_action may be in the following form
+                      // Take the workview baseUrl from the form action.
+                      // The URL may be in the following form
                       // - http://example.com/index.php?id=14
                       // - http://example.com/workview (using slug on page with uid=14)
-                      var base_url = $("form#tx-dlf-search-in-document-form").attr('action');
+                      var baseUrl = $("form#tx-dlf-search-in-document-form").attr('action');
 
-                      if (base_url.indexOf('?')>0) {
-                        base_url += '&';
+                      if (baseUrl.indexOf('?')>0) {
+                        baseUrl += '&';
                       } else {
-                        base_url += '?';
+                        baseUrl += '?';
                       }
 
                       var searchHit = data.highlighting[data.response.docs[i].id].fulltext.toString();
                       searchHit = searchHit.substring(searchHit.indexOf('<em>')+4,searchHit.indexOf('</em>'));
 
-                      var newlink = base_url
+                      var newlink = baseUrl
                       + 'tx_dlf[id]=' + data.response.docs[i].uid
                       + '&tx_dlf[highlight_word]=' + encodeURIComponent(searchHit)
                       + '&tx_dlf[page]=' + data.response.docs[i].page;

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -89,9 +89,10 @@ $(document).ready(function() {
                       var searchHit = data.highlighting[data.response.docs[i].id].fulltext.toString();
                       searchHit = searchHit.substring(searchHit.indexOf('<em>')+4,searchHit.indexOf('</em>'));
 
-                      var newlink = base_url + ('tx_dlf[id]=' + data.response.docs[i].uid
+                      var newlink = base_url
+                      + 'tx_dlf[id]=' + data.response.docs[i].uid
                       + '&tx_dlf[highlight_word]=' + encodeURIComponent(searchHit)
-                      + '&tx_dlf[page]=' + (data.response.docs[i].page));
+                      + '&tx_dlf[page]=' + data.response.docs[i].page;
 
                       if (data.highlighting[data.response.docs[i].id].fulltext) {
                           resultItems[data.response.docs[i].page] = '<span class="structure">' + $('#tx-dlf-search-in-document-label-page').text() + ' ' + data.response.docs[i].page + '</span><br /><span ="textsnippet"><a href=\"' + newlink + '\">' + data.highlighting[data.response.docs[i].id].fulltext + '</a></span>';

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -74,22 +74,22 @@ $(document).ready(function() {
               } else {
                   for (var i=0; i < data.response.docs.length; i++) {
 
-                      var link_current = $(location).attr('href');
-                      var link_base = link_current.substring(0, link_current.indexOf('?'));
-                      var link_params = link_current.substring(link_base.length + 1, link_current.length);
-                      var link_id = link_params.match(/id=(\d)*/g);
+                      // Take the workview base_url from the form action.
+                      // link_action may be in the following form
+                      // - http://example.com/index.php?id=14
+                      // - http://example.com/workview (using slug on page with uid=14)
+                      var base_url = $("form#tx-dlf-search-in-document-form").attr('action');
 
-                      if (link_id) {
-                        link_params = link_id + '&';
+                      if (base_url.indexOf('?')>0) {
+                        base_url += '&';
                       } else {
-                        link_params = '&';
+                        base_url += '?';
                       }
 
                       var searchHit = data.highlighting[data.response.docs[i].id].fulltext.toString();
                       searchHit = searchHit.substring(searchHit.indexOf('<em>')+4,searchHit.indexOf('</em>'));
 
-                      var newlink = link_base + '?' + (link_params
-                      + 'tx_dlf[id]=' + data.response.docs[i].uid
+                      var newlink = base_url + ('tx_dlf[id]=' + data.response.docs[i].uid
                       + '&tx_dlf[highlight_word]=' + encodeURIComponent(searchHit)
                       + '&tx_dlf[page]=' + (data.response.docs[i].page));
 


### PR DESCRIPTION
With TYPO3 9.5 the advanced page routing is builtin. There is no need to
install any third party extension like realurl anymore.

Using the routeEnhancer with the pageview makes it possible to write
shorter URLs like

  http://example.com/workview/123/1

which is short for

  http://example.com/workview?tx_dlf[id]=123&tx_dlf[page]=1

The current implementation of the SearchInDocument plugin has to build
the target URLs from the searchresults in JavaScript. It does it by
appending the GET-parameter to the base_url. The resulting URL could
look like this:

  http://example.com/workview/123/1?tx_dlf[id]=123&tx_dlf[page]=5&tx_dlf[highlight_word=searchword

In fact the GET parameter are given twice to TYPO3. This was tolerated
in the past by realurl on TYPO3 8.7 but brings an exception with TYPO3
9.5.

The way the plugin calculates the base URL in JavaScript is even to
complicate. It would be sufficiant to take it from the form action URL.
This way, the double GET parameters are avoided.