### PR TITLE
Disable coverage report in SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,3 +9,4 @@ sonar.pullrequest.github.summary_comment=true
 sonar.issues.defaultAssigneeLogin=sebastian-meyer@github
 sonar.php.file.suffixes=php
 sonar.php.exclusions=
+sonar.coverage.exclusions=**/*


### PR DESCRIPTION
Since we do not have any tests, Coverage testing by SonarCloud should be disabled (otherwise every scan fails).