### PR TITLE
Don't add second slash to solr path if it was default /

### DIFF
--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -578,7 +578,7 @@ class Solr
                     'scheme' => $solrInfo['scheme'],
                     'host' => $solrInfo['host'],
                     'port' => $solrInfo['port'],
-                    'path' => '/' . $solrInfo['path'] . '/',
+                    'path' => $solrInfo['path'] !== '' ? '/' . $solrInfo['path'] . '/' : '/',
                     'core' => $core,
                     'username' => $solrInfo['username'],
                     'password' => $solrInfo['password'],


### PR DESCRIPTION
Fix for #566 