### PR TITLE
Finish Solarium upgrade

### DIFF
--- a/Classes/Common/DocumentList.php
+++ b/Classes/Common/DocumentList.php
@@ -565,7 +565,10 @@ class DocumentList implements \ArrayAccess, \Countable, \Iterator, \TYPO3\CMS\Co
         // Get Solr instance.
         if (!$this->solr) {
             // Connect to Solr server.
-            if ($this->solr = Solr::getInstance($this->metadata['options']['core'])) {
+            $solr = Solr::getInstance($this->metadata['options']['core']);
+            if ($solr->ready) {
+                $this->solr = $solr;
+                // Get indexed fields.
                 $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                     ->getQueryBuilderForTable('tx_dlf_metadata');
 

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -560,7 +560,9 @@ class Indexer
         // Get Solr instance.
         if (!self::$solr) {
             // Connect to Solr server.
-            if (self::$solr = Solr::getInstance($core)) {
+            $solr = Solr::getInstance($core);
+            if ($solr->ready) {
+                self::$solr = $solr;
                 // Load indexing configuration if needed.
                 if ($pid) {
                     self::loadIndexConf($pid);

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -326,7 +326,7 @@ class Solr
             $config['port'] = MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
             // Trim path of slashes and (re-)add trailing slash if path not empty.
             $config['path'] = trim($conf['solrPath'], '/');
-            if (!empty($solrInfo['path'])) {
+            if (!empty($config['path'])) {
                 $config['path'] .= '/';
             }
             // Timeout

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -296,9 +296,7 @@ class Solr
         // Create new instance...
         $instance = new self($core);
         // ...and save it to registry.
-        if (!$instance->ready) {
-            Helper::devLog('Could not connect to Apache Solr service', DEVLOG_SEVERITY_ERROR);
-        } elseif (!empty($instance->core)) {
+        if (!empty($instance->core)) {
             self::$registry[$instance->core] = $instance;
         }
         return $instance;
@@ -660,7 +658,7 @@ class Solr
             if ($response->getWasSuccessful()) {
                 // Solr is reachable, but is the core as well?
                 if ($core !== null) {
-                    $result = $response->getStatusResultByCoreName($core);
+                    $result = $response->getStatusResult();
                     if (
                         $result instanceof \Solarium\QueryType\Server\CoreAdmin\Result\StatusResult
                         && $result->getUptime() > 0

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -241,27 +241,6 @@ class Solr
     }
 
     /**
-     * Get next unused Solr core number
-     *
-     * @access public
-     *
-     * @param int $number: Number to start with
-     *
-     * @return int First unused core number found
-     */
-    public static function getNextCoreNumber($number = 0)
-    {
-        $number = max(intval($number), 0);
-        // Check if core already exists.
-        $solr = self::getInstance('dlfCore' . $number);
-        if (!$solr->ready) {
-            return $number;
-        } else {
-            return self::getNextCoreNumber($number + 1);
-        }
-    }
-
-    /**
      * This is a singleton class, thus instances must be created by this method
      *
      * @access public
@@ -300,6 +279,27 @@ class Solr
             self::$registry[$instance->core] = $instance;
         }
         return $instance;
+    }
+
+    /**
+     * Get next unused Solr core number
+     *
+     * @access public
+     *
+     * @param int $number: Number to start with
+     *
+     * @return int First unused core number found
+     */
+    public static function getNextCoreNumber($number = 0)
+    {
+        $number = max(intval($number), 0);
+        // Check if core already exists.
+        $solr = self::getInstance('dlfCore' . $number);
+        if (!$solr->ready) {
+            return $number;
+        } else {
+            return self::getNextCoreNumber($number + 1);
+        }
     }
 
     /**

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -12,8 +12,10 @@
 
 namespace Kitodo\Dlf\Common;
 
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * Solr class for the 'dlf' extension
@@ -33,12 +35,20 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class Solr
 {
     /**
-     * This holds the core name
+     * This holds the Solr configuration
      *
-     * @var string
+     * @var array
      * @access protected
      */
-    protected $core = '';
+    protected $config = [];
+
+    /**
+     * This holds the core name
+     *
+     * @var string|null
+     * @access protected
+     */
+    protected $core = null;
 
     /**
      * This holds the PID for the configuration
@@ -105,6 +115,52 @@ class Solr
     protected $service;
 
     /**
+     * Add a new core to Apache Solr
+     *
+     * @access public
+     *
+     * @param string $core: The name of the new core. If empty, the next available core name is used.
+     *
+     * @return string The name of the new core
+     */
+    public static function createCore($core = '')
+    {
+        // Get available core name if none given.
+        if (empty($core)) {
+            $core = 'dlfCore' . self::getCoreNumber();
+        }
+        // Get Solr service instance.
+        $solr = self::getInstance($core);
+        // Create new core if core with given name doesn't exist.
+        if ($solr->core === null) {
+            // Core doesn't exist yet.
+            $query = $solr->service->createCoreAdmin();
+            $action = $query->createCreate();
+            $action->setConfigSet('dlf');
+            $action->setCore($core);
+            $action->setDataDir('data');
+            $action->setInstanceDir($core);
+            $query->setAction($action);
+            try {
+                $response = $solr->service->coreAdmin($query);
+                if ($response->getWasSuccessful()) {
+                    // Core successfully created.
+                    return $core;
+                } else {
+                    // Core creation failed.
+                    return '';
+                }
+            } catch (\Exception $e) {
+                // Core creation failed.
+                return '';
+            }
+        } else {
+            // Core already exists.
+            return $core;
+        }
+    }
+
+    /**
      * Escape all special characters in a query string
      *
      * @access public
@@ -115,13 +171,13 @@ class Solr
      */
     public static function escapeQuery($query)
     {
-        $helper = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Solarium\Core\Query\Helper::class);
+        $helper = GeneralUtility::makeInstance(\Solarium\Core\Query\Helper::class);
         // Escape query phrase or term.
         if (preg_match('/^".*"$/', $query)) {
             return $helper->escapePhrase(trim($query, '"'));
         } else {
             // Using a modified escape function here to retain whitespace, '*' and '?' for search truncation.
-            // @see https://github.com/solariumphp/solarium/blob/4.x/src/Core/Query/Helper.php#L68 for reference
+            // @see https://github.com/solariumphp/solarium/blob/5.x/src/Core/Query/Helper.php#L70 for reference
             /* return $helper->escapeTerm($query); */
             return preg_replace('/(\+|-|&&|\|\||!|\(|\)|\{|}|\[|]|\^|"|~|:|\/|\\\)/', '\\\$1', $query);
         }
@@ -175,108 +231,10 @@ class Solr
             } else {
                 $query = self::escapeQuery($query);
             }
-        } elseif (
-            !empty($query)
-            && $query !== '*'
-        ) {
-            // Don't escape plain asterisk search.
+        } else {
             $query = self::escapeQuery($query);
         }
         return $query;
-    }
-
-    /**
-     * This is a singleton class, thus instances must be created by this method
-     *
-     * @access public
-     *
-     * @param mixed $core: Name or UID of the core to load
-     *
-     * @return \Kitodo\Dlf\Common\Solr Instance of this class
-     */
-    public static function getInstance($core)
-    {
-        // Get core name if UID is given.
-        if (\TYPO3\CMS\Core\Utility\MathUtility::canBeInterpretedAsInteger($core)) {
-            $core = Helper::getIndexNameFromUid($core, 'tx_dlf_solrcores');
-        }
-        // Check if core is set.
-        if (empty($core)) {
-            Helper::devLog('Invalid core name "' . $core . '" for Apache Solr', DEVLOG_SEVERITY_ERROR);
-            return;
-        }
-        // Check if there is an instance in the registry already.
-        if (
-            is_object(self::$registry[$core])
-            && self::$registry[$core] instanceof self
-        ) {
-            // Return singleton instance if available.
-            return self::$registry[$core];
-        }
-        // Create new instance...
-        $instance = new self($core);
-        // ...and save it to registry.
-        if ($instance->ready) {
-            self::$registry[$core] = $instance;
-            // Return new instance.
-            return $instance;
-        } else {
-            Helper::devLog('Could not connect to Apache Solr server', DEVLOG_SEVERITY_ERROR);
-            return;
-        }
-    }
-
-    /**
-     * Returns the connection information for Solr
-     *
-     * @access public
-     *
-     * @return array The connection parameters for a specific Solr core
-     */
-    public static function getSolrConnectionInfo()
-    {
-        $solrInfo = [];
-        // Extract extension configuration.
-        $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
-        // Derive Solr scheme
-        $solrInfo['scheme'] = empty($conf['solrHttps']) ? 'http' : 'https';
-        // Derive Solr host name.
-        $solrInfo['host'] = ($conf['solrHost'] ? $conf['solrHost'] : '127.0.0.1');
-        // Set username and password.
-        $solrInfo['username'] = $conf['solrUser'];
-        $solrInfo['password'] = $conf['solrPass'];
-        // Set port if not set.
-        $solrInfo['port'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
-        // Trim path of slashes.
-        $solrInfo['path'] = trim($conf['solrPath'], '/');
-        // Timeout
-        $solrInfo['timeout'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);
-        return $solrInfo;
-    }
-
-    /**
-     * Returns the request URL for a specific Solr core
-     *
-     * @access public
-     *
-     * @param string $core: Name of the core to load
-     *
-     * @return string The request URL for a specific Solr core
-     */
-    public static function getSolrUrl($core = '')
-    {
-        // Get Solr connection information.
-        $solrInfo = self::getSolrConnectionInfo();
-        if (
-            $solrInfo['username']
-            && $solrInfo['password']
-        ) {
-            $host = $solrInfo['username'] . ':' . $solrInfo['password'] . '@' . $solrInfo['host'];
-        } else {
-            $host = $solrInfo['host'];
-        }
-        // Return entire request URL.
-        return $solrInfo['scheme'] . '://' . $host . ':' . $solrInfo['port'] . '/' . $solrInfo['path'] . '/solr/' . $core;
     }
 
     /**
@@ -284,18 +242,96 @@ class Solr
      *
      * @access public
      *
-     * @param int $start: Number to start with
+     * @param int $number: Number to start with
      *
      * @return int First unused core number found
      */
-    public static function solrGetCoreNumber($start = 0)
+    public static function getCoreNumber($number = 0)
     {
-        $start = max(intval($start), 0);
+        $number = max(intval($number), 0);
         // Check if core already exists.
-        if (self::getInstance('dlfCore' . $start) === null) {
-            return $start;
+        $solr = self::getInstance('dlfCore' . $number);
+        if (empty($solr->core)) {
+            return $number;
         } else {
-            return self::solrGetCoreNumber($start + 1);
+            return self::solrGetCoreNumber($number + 1);
+        }
+    }
+
+    /**
+     * This is a singleton class, thus instances must be created by this method
+     *
+     * @access public
+     *
+     * @param mixed $core: Name or UID of the core to load or null to get core admin endpoint
+     *
+     * @return \Kitodo\Dlf\Common\Solr Instance of this class
+     */
+    public static function getInstance($core = null)
+    {
+        // Get core name if UID is given.
+        if (MathUtility::canBeInterpretedAsInteger($core)) {
+            $core = Helper::getIndexNameFromUid($core, 'tx_dlf_solrcores');
+        }
+        // Check if core is set or null.
+        if (empty($core) && $core !== null) {
+            Helper::devLog('Invalid core UID or name given for Apache Solr', DEVLOG_SEVERITY_ERROR);
+            return;
+        }
+        if (!empty($core)) {
+            // Check if there is an instance in the registry already.
+            if (
+                is_object(self::$registry[$core])
+                && self::$registry[$core] instanceof self
+            ) {
+                // Return singleton instance if available.
+                return self::$registry[$core];
+            }
+        }
+        // Create new instance...
+        $instance = new self($core);
+        // ...and save it to registry.
+        if (
+            $instance->ready
+            && !empty($instance->core)
+        ) {
+            self::$registry[$instance->core] = $instance;
+        } else {
+            Helper::devLog('Could not connect to Apache Solr service', DEVLOG_SEVERITY_ERROR);
+        }
+        return $instance;
+    }
+
+    /**
+     * Sets the connection information for Solr
+     *
+     * @access protected
+     *
+     * @return void
+     */
+    protected function loadSolrConnectionInfo()
+    {
+        if (empty($this->config)) {
+            $config = [];
+            // Extract extension configuration.
+            $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            // Derive Solr scheme
+            $config['scheme'] = empty($conf['solrHttps']) ? 'http' : 'https';
+            // Derive Solr host name.
+            $config['host'] = ($conf['solrHost'] ? $conf['solrHost'] : '127.0.0.1');
+            // Set username and password.
+            $config['username'] = $conf['solrUser'];
+            $config['password'] = $conf['solrPass'];
+            // Set port if not set.
+            $config['port'] = MathUtility::forceIntegerInRange($conf['solrPort'], 1, 65535, 8983);
+            // Trim path of slashes and (re-)add trailing slash if path not empty.
+            $config['path'] = trim($conf['solrPath'], '/');
+            if (!empty($solrInfo['path'])) {
+                $config['path'] .= '/';
+            }
+            // Timeout
+            $config['timeout'] = MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);
+            $this->config = $config;
         }
     }
 
@@ -348,7 +384,7 @@ class Solr
             ];
         }
         // Save list of documents.
-        $list = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(DocumentList::class);
+        $list = GeneralUtility::makeInstance(DocumentList::class);
         $list->reset();
         $list->add(array_values($toplevel));
         // Set metadata for search.
@@ -392,7 +428,7 @@ class Solr
 
         // calculate cache identifier
         $cacheIdentifier = hash('md5', print_r(array_merge($this->params, $parameters), 1));
-        $cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('tx_dlf_solr');
+        $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('tx_dlf_solr');
 
         $resultSet = [];
         if (($entry = $cache->get($cacheIdentifier)) === false) {
@@ -408,6 +444,18 @@ class Solr
             $resultSet = $entry;
         }
         return $resultSet;
+    }
+
+    /**
+     * This returns $this->core via __get()
+     *
+     * @access protected
+     *
+     * @return string|null The core name of the current query endpoint or null if core admin endpoint
+     */
+    protected function _getCore()
+    {
+        return $this->core;
     }
 
     /**
@@ -565,37 +613,63 @@ class Solr
      *
      * @access protected
      *
-     * @param string $core: The name of the core to use
+     * @param string|null $core: The name of the core to use or null for core admin endpoint
      *
      * @return void
      */
-    protected function __construct($core)
+    protected function __construct($core = null)
     {
-        $solrInfo = self::getSolrConnectionInfo();
+        // Get Solr connection parameters from configuration.
+        $this->loadSolrConnectionInfo();
+        // Configure connection adapter.
+        $adapter = GeneralUtility::makeInstance(\Solarium\Core\Client\Adapter\Http::class);
+        $adapter->setTimeout($this->config['timeout']);
+        // Configure event dispatcher.
+            // Todo: When updating to TYPO3 >=10.x and Solarium >=6.x
+            // we have to provide an PSR-14 Event Dispatcher instead of
+            // "null".
+            // $eventDispatcher = GeneralUtility::makeInstance(\TYPO3\CMS\Core\EventDispatcher\EventDispatcher::class);
+        $eventDispatcher = null;
+        // Configure endpoint.
         $config = [
             'endpoint' => [
-                'dlf' => [
-                    'scheme' => $solrInfo['scheme'],
-                    'host' => $solrInfo['host'],
-                    'port' => $solrInfo['port'],
-                    'path' => '/' . $solrInfo['path'] . '/',
+                'default' => [
+                    'scheme' => $this->config['scheme'],
+                    'host' => $this->config['host'],
+                    'port' => $this->config['port'],
+                    'path' => '/' . $this->config['path'],
                     'core' => $core,
-                    'username' => $solrInfo['username'],
-                    'password' => $solrInfo['password'],
-                    'timeout' => $solrInfo['timeout']
+                    'username' => $this->config['username'],
+                    'password' => $this->config['password']
                 ]
             ]
         ];
         // Instantiate Solarium\Client class.
-        $this->service = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Solarium\Client::class, $config);
+        $this->service = GeneralUtility::makeInstance(\Solarium\Client::class, $adapter, $eventDispatcher, $config);
         // Check if connection is established.
-        $ping = $this->service->createPing();
+        $query = $this->service->createCoreAdmin();
+        $action = $query->createStatus();
+        if (!empty($core)) {
+            $action->setCore($core);
+        }
+        $query->setAction($action);
         try {
-            $this->service->ping($ping);
-            // Set core name.
-            $this->core = $core;
-            // Instantiation successful!
-            $this->ready = true;
+            $response = $this->service->coreAdmin($query);
+            if ($response->getWasSuccessful()) {
+                // Instantiation successful!
+                $this->ready = true;
+                // Solr is reachable, but is the core as well?
+                if (!empty($core)) {
+                    $result = $response->getStatusResultByCoreName($core);
+                    if (
+                        $result instanceof \Solarium\QueryType\Server\CoreAdmin\Result\StatusResult
+                        && $result->getUptime() > 0
+                    ) {
+                        // Set core name.
+                        $this->core = $core;
+                    }
+                }
+            }
         } catch (\Exception $e) {
             // Nothing to do here.
         }

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -257,7 +257,7 @@ class Solr
         if (!$solr->ready) {
             return $number;
         } else {
-            return self::solrGetCoreNumber($number + 1);
+            return self::getCoreNumber($number + 1);
         }
     }
 

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -128,7 +128,7 @@ class Solr
     {
         // Get next available core name if none given.
         if (empty($core)) {
-            $core = 'dlfCore' . self::getCoreNumber();
+            $core = 'dlfCore' . self::getNextCoreNumber();
         }
         // Get Solr service instance.
         $solr = self::getInstance($core);
@@ -249,7 +249,7 @@ class Solr
      *
      * @return int First unused core number found
      */
-    public static function getCoreNumber($number = 0)
+    public static function getNextCoreNumber($number = 0)
     {
         $number = max(intval($number), 0);
         // Check if core already exists.
@@ -257,7 +257,7 @@ class Solr
         if (!$solr->ready) {
             return $number;
         } else {
-            return self::getCoreNumber($number + 1);
+            return self::getNextCoreNumber($number + 1);
         }
     }
 

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -329,8 +329,9 @@ class Solr
             if (!empty($config['path'])) {
                 $config['path'] .= '/';
             }
-            // Timeout
-            $config['timeout'] = MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, intval(ini_get('max_execution_time')), 10);
+            // Set connection timeout lower than PHP's max_execution_time.
+            $max_execution_time = intval(ini_get('max_execution_time')) ?: 30;
+            $config['timeout'] = MathUtility::forceIntegerInRange($conf['solrTimeout'], 1, $max_execution_time, 10);
             $this->config = $config;
         }
     }

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -246,7 +246,8 @@ class DataHandler
                             $resArray = $allResults[0];
                             if ($resArray['hidden']) {
                                 // Establish Solr connection.
-                                if ($solr = Solr::getInstance($resArray['core'])) {
+                                $solr = Solr::getInstance($resArray['core']);
+                                if ($solr->ready) {
                                     // Delete Solr document.
                                     $updateQuery = $solr->service->createUpdate();
                                     $updateQuery->addDeleteQuery('uid:' . $id);
@@ -325,7 +326,8 @@ class DataHandler
                     case 'move':
                     case 'delete':
                         // Establish Solr connection.
-                        if ($solr = Solr::getInstance($resArray['core'])) {
+                        $solr = Solr::getInstance($resArray['core']);
+                        if ($solr->ready) {
                             // Delete Solr document.
                             $updateQuery = $solr->service->createUpdate();
                             $updateQuery->addDeleteQuery('uid:' . $id);

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -353,48 +353,52 @@ class DataHandler
             $command === 'delete'
             && $table == 'tx_dlf_solrcores'
         ) {
-            // Delete core from Apache Solr as well.
-            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tx_dlf_solrcores');
-            // Record in "tx_dlf_solrcores" is already deleted at this point.
-            $queryBuilder
-                ->getRestrictions()
-                ->removeByType(DeletedRestriction::class);
+            // Is core deletion allowed in extension configuration?
+            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']);
+            if (!empty($extConf['solrAllowCoreDelete'])) {
+                // Delete core from Apache Solr as well.
+                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                    ->getQueryBuilderForTable('tx_dlf_solrcores');
+                // Record in "tx_dlf_solrcores" is already deleted at this point.
+                $queryBuilder
+                    ->getRestrictions()
+                    ->removeByType(DeletedRestriction::class);
 
-            $result = $queryBuilder
-                ->select(
-                    'tx_dlf_solrcores.index_name AS core'
-                )
-                ->from('tx_dlf_solrcores')
-                ->where($queryBuilder->expr()->eq('tx_dlf_solrcores.uid', intval($id)))
-                ->setMaxResults(1)
-                ->execute();
+                $result = $queryBuilder
+                    ->select(
+                        'tx_dlf_solrcores.index_name AS core'
+                    )
+                    ->from('tx_dlf_solrcores')
+                    ->where($queryBuilder->expr()->eq('tx_dlf_solrcores.uid', intval($id)))
+                    ->setMaxResults(1)
+                    ->execute();
 
-            $allResults = $result->fetchAll();
+                $allResults = $result->fetchAll();
 
-            if (count($allResults) == 1) {
-                $resArray = $allResults[0];
-                // Establish Solr connection.
-                $solr = Solr::getInstance();
-                if ($solr->ready) {
-                    // Delete Solr core.
-                    $query = $solr->service->createCoreAdmin();
-                    $action = $query->createUnload();
-                    $action->setCore($resArray['core']);
-                    $action->setDeleteDataDir(true);
-                    $action->setDeleteIndex(true);
-                    $action->setDeleteInstanceDir(true);
-                    $query->setAction($action);
-                    try {
-                        $response = $solr->service->coreAdmin($query);
-                        if ($response->getWasSuccessful()) {
-                            return;
+                if (count($allResults) == 1) {
+                    $resArray = $allResults[0];
+                    // Establish Solr connection.
+                    $solr = Solr::getInstance();
+                    if ($solr->ready) {
+                        // Delete Solr core.
+                        $query = $solr->service->createCoreAdmin();
+                        $action = $query->createUnload();
+                        $action->setCore($resArray['core']);
+                        $action->setDeleteDataDir(true);
+                        $action->setDeleteIndex(true);
+                        $action->setDeleteInstanceDir(true);
+                        $query->setAction($action);
+                        try {
+                            $response = $solr->service->coreAdmin($query);
+                            if ($response->getWasSuccessful()) {
+                                return;
+                            }
+                        } catch (\Exception $e) {
+                            // Nothing to do here.
                         }
-                    } catch (\Exception $e) {
-                        // Nothing to do here.
                     }
+                    Helper::devLog('Core ' . $resArray['core'] . ' could not be deleted from Apache Solr', DEVLOG_SEVERITY_WARNING);
                 }
-                Helper::devLog('Core ' . $resArray['core'] . ' could not be deleted from Apache Solr', DEVLOG_SEVERITY_WARNING);
             }
         }
     }

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -142,6 +142,10 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
             $this->showSingleCollection(intval($resArray['uid']));
         }
         $solr = Solr::getInstance($this->conf['solrcore']);
+        if (!$solr->ready) {
+            Helper::devLog('Apache Solr not available', DEVLOG_SEVERITY_ERROR);
+            return $content;
+        }
         // We only care about the UID and partOf in the results and want them sorted
         $params['fields'] = 'uid,partof';
         $params['sort'] = ['uid' => 'asc'];

--- a/Classes/Plugin/Eid/SearchInDocument.php
+++ b/Classes/Plugin/Eid/SearchInDocument.php
@@ -53,10 +53,7 @@ class SearchInDocument
         $core = Helper::decrypt($encrypted, $hashed);
         // Perform Solr query.
         $solr = Solr::getInstance($core);
-        if (
-            $solr->ready
-            && $solr->core === $core
-        ) {
+        if ($solr->ready) {
             $query = $solr->service->createSelect();
             $query->setFields(['id', 'uid', 'page']);
             $query->setQuery('fulltext:(' . Solr::escapeQuery((string) $parameters['q']) . ') AND uid:' . intval($parameters['uid']));

--- a/Classes/Plugin/Eid/SearchInDocument.php
+++ b/Classes/Plugin/Eid/SearchInDocument.php
@@ -14,7 +14,6 @@ namespace Kitodo\Dlf\Plugin\Eid;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
-
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\Response;
@@ -59,18 +58,18 @@ class SearchInDocument
             $query->setQuery('fulltext:(' . Solr::escapeQuery((string) $parameters['q']) . ') AND uid:' . intval($parameters['uid']));
             $query->setStart($count)->setRows(20);
             $hl = $query->getHighlighting();
-            $hl->setFields('fulltext');
-            $hl->setMethod('fastVector');
+            $hl->setFields(['fulltext']);
+            $hl->setUseFastVectorHighlighter(true);
             $results = $solr->service->select($query);
             $output['numFound'] = $results->getNumFound();
             $highlighting = $results->getHighlighting();
             foreach ($results as $result) {
-                $snippet = $highlighting->getResult($result->id);
+                $snippet = $highlighting->getResult($result->id)->getField('fulltext');
                 $document = [
                     'id' => $result->id,
                     'uid' => $result->uid,
                     'page' => $result->page,
-                    'snippet' => $snippet['fulltext']
+                    'snippet' => !empty($snippet) ? implode(' [...] ', $snippet) : ''
                 ];
                 $output['documents'][$count] = $document;
                 $count++;

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -57,8 +57,10 @@ class SearchSuggest
             $results = $solr->service->select($query)->getResponse()->getBody();
             $result = json_decode($results);
             foreach ($result->spellcheck->suggestions as $suggestions) {
-                foreach ($suggestions->suggestion as $suggestion) {
-                    $output[] = $suggestion;
+                if (is_object($suggestions)) {
+                    foreach ($suggestions->suggestion as $suggestion) {
+                        $output[] = $suggestion;
+                    }
                 }
             }
         }

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -50,13 +50,16 @@ class SearchSuggest
         // Perform Solr query.
         $solr = Solr::getInstance($core);
         if ($solr->ready) {
-            $query = $solr->service->createSuggester();
-            $query->setCount(10);
-            $query->setDictionary('suggest');
+            $query = $solr->service->createSelect();
+            $query->setHandler('suggest');
             $query->setQuery(Solr::escapeQuery((string) $parameters['q']));
-            $results = $solr->service->suggester($query)->getAll();
-            foreach ($results as $result) {
-                $output[] = $result;
+            $query->setRows(0);
+            $results = $solr->service->select($query)->getResponse()->getBody();
+            $result = json_decode($results);
+            foreach ($result->spellcheck->suggestions as $suggestions) {
+                foreach ($suggestions->suggestion as $suggestion) {
+                    $output[] = $suggestion;
+                }
             }
         }
         // Create response object.

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -54,9 +54,9 @@ class SearchSuggest
             $query->setCount(10);
             $query->setDictionary('suggest');
             $query->setQuery(Solr::escapeQuery((string) $parameters['q']));
-            $results = $solr->service->suggester($query);
+            $results = $solr->service->suggester($query)->getAll();
             foreach ($results as $result) {
-                $output = array_merge($output, $result);
+                $output[] = $result;
             }
         }
         // Create response object.

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -49,10 +49,7 @@ class SearchSuggest
         $core = Helper::decrypt($encrypted, $hashed);
         // Perform Solr query.
         $solr = Solr::getInstance($core);
-        if (
-            $solr->ready
-            && $solr->core === $core
-        ) {
+        if ($solr->ready) {
             $query = $solr->service->createSuggester();
             $query->setCount(10);
             $query->setDictionary('suggest');

--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -923,6 +923,10 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
         $solr_query .= ' AND timestamp:[' . $from . ' TO ' . $until . ']';
         $documentSet = [];
         $solr = Solr::getInstance($this->conf['solrcore']);
+        if (!$solr->ready) {
+            Helper::devLog('Apache Solr not available', DEVLOG_SEVERITY_ERROR);
+            return $documentSet;
+        }
         if (intval($this->conf['solr_limit']) > 0) {
             $solr->limit = intval($this->conf['solr_limit']);
         }

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -76,9 +76,9 @@
 			<label index="update.documentSetFormatForOldEntriesOkay">...successfully completed!</label>
 			<label index="update.documentSetFormatForOldEntriesNotOkay">...incomplete! Please set missing tx_dlf_document.document_format values to 'METS'.</label>
             <label index="solr.connected">Connection established!</label>
-            <label index="solr.status">The status code returned by Apache Solr is &lt;strong&gt;%s&lt;/strong&gt;.</label>
+            <label index="solr.status">Apache Solr is running and taking requests.</label>
             <label index="solr.notConnected">Connection failed!</label>
-            <label index="solr.error">Apache Solr was not reachable under &lt;strong&gt;%s&lt;/strong&gt;.</label>
+            <label index="solr.error">Apache Solr not reachable with given configuration.</label>
             <label index="metadataFormats.nsOkay">Default namespaces found!</label>
             <label index="metadataFormats.nsOkayMsg">The namespace definitions for MODS, TEIHDR and ALTO do exist.</label>
             <label index="metadataFormats.nsCreated">Default namespaces created successfully!</label>
@@ -148,9 +148,9 @@
 			<label index="update.documentSetFormatForOldEntriesOkay">...erfolgreich beendet!</label>
 			<label index="update.documentSetFormatForOldEntriesNotOkay">...abgebrochen! Bitte in der Tabelle tx_dlf_document.document_format 'METS'.</label>
             <label index="solr.connected">Verbindung hergestellt!</label>
-            <label index="solr.status">Apache Solr gibt den Statuscode &lt;strong&gt;%s&lt;/strong&gt; zurück.</label>
+            <label index="solr.status">Apache Solr ist verfügbar und nimmt Anfragen entgegen.</label>
             <label index="solr.notConnected">Verbindung fehlgeschlagen!</label>
-            <label index="solr.error">Apache Solr ist unter &lt;strong&gt;%s&lt;/strong&gt; nicht erreichbar.</label>
+            <label index="solr.error">Apache Solr ist mit der gegebenen Konfiguration nicht erreichbar.</label>
             <label index="metadataFormats.nsOkay">Standard-Namensräume gefunden!</label>
             <label index="metadataFormats.nsOkayMsg">Die Standard-Namensräume für MODS, TEIHDR und ALTO sind definiert.</label>
             <label index="metadataFormats.nsCreated">Standard-Namensräume erfolgreich angelegt!</label>

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -189,13 +189,14 @@
 			<label index="config.iiifThumbnailWidth">Maximum thumbnail width for IIIF images: Only for images without a thumbnail declaration (default is "150")</label>
 			<label index="config.iiifThumbnailHeight">Maximum thumbnail height for IIIF images: Only for images without a thumbnail declaration (default is "150")</label>
             <label index="config.solrConnect">Solr Connection</label>
-            <label index="config.solrHttps">Use https: (default is "FALSE")</label>
+            <label index="config.solrHttps">Use HTTPS: (default is "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (default is "localhost")</label>
             <label index="config.solrPort">Solr Server Port: (default is "8983")</label>
             <label index="config.solrPath">Solr Server Path: without API endpoint "/solr" (default is "/")</label>
             <label index="config.solrUser">Solr Server User: (default is "")</label>
             <label index="config.solrPass">Solr Server Password: (default is "")</label>
             <label index="config.solrTimeout">Solr Server Timeout: (default is "10")</label>
+            <label index="config.solrAllowCoreDelete">Allow Solr Core Deletion?: If a Solr Core is deleted in the TYPO3 Backend, should it be deleted in Apache Solr as well? (Standard ist "FALSE")</label>
         </languageKey>
         <languageKey index="de" type="array">
             <label index="tx_dlf_actionlog">Aktionsprotokoll</label>
@@ -291,7 +292,7 @@
             <label index="tx_dlf_solrcores">Solr Kerne</label>
             <label index="tx_dlf_solrcores.label">Anzeigeform</label>
             <label index="tx_dlf_solrcores.index_name">Solr-Bezeichnung</label>
-            <label index="tx_dlf_solrcores.tab1">General</label>
+            <label index="tx_dlf_solrcores.tab1">Allgemein</label>
             <label index="tx_dlf_collections">Sammlungen</label>
             <label index="tx_dlf_collections.label">Anzeigeform</label>
             <label index="tx_dlf_collections.index_name">Index-Bezeichnung</label>
@@ -372,13 +373,14 @@
 			<label index="config.iiifThumbnailWidth">Maximale Thumbnail-Breite für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</label>
 			<label index="config.iiifThumbnailHeight">Maximale Thumbnail-Höhe für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</label>
             <label index="config.solrConnect">Solr Verbindung</label>
-            <label index="config.solrHttps">Https verwenden: (Standard ist "FALSE")</label>
+            <label index="config.solrHttps">HTTPS verwenden: (Standard ist "FALSE")</label>
             <label index="config.solrHost">Solr Server Host: (Standard ist "localhost")</label>
             <label index="config.solrPort">Solr Server Port: (Standard ist "8983")</label>
             <label index="config.solrPath">Solr Server Pfad: ohne API-Endpunkt "/solr" (Standard ist "/")</label>
             <label index="config.solrUser">Solr Server Benutzername: (Standard ist "")</label>
             <label index="config.solrPass">Solr Server Kennwort: (Standard ist "")</label>
             <label index="config.solrTimeout">Solr Server Timeout: (Standard ist "10")</label>
+            <label index="config.solrAllowCoreDelete">Löschen von Solr Kern zulassen?: Soll beim Löschen eines Solr Kerns im TYPO3 Backend auch der entsprechende Index in Apache Solr gelöscht werden? (Standard ist "FALSE")</label>
         </languageKey>
     </data>
 </T3locallang>

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -67,7 +67,8 @@ $(document).ready(function() {
                 var resultItems = [];
                 var resultList = '<div class="results-active-indicator"></div><ul>';
                 var start = -1;
-                if (data.numFound > 0) {
+                var results = JSON.parse(data);
+                if (results.numFound > 0) {
                     // Take the workview baseUrl from the form action.
                     // The URL may be in the following form
                     // - http://example.com/index.php?id=14
@@ -79,7 +80,7 @@ $(document).ready(function() {
                     } else {
                         baseUrl += '?';
                     }
-                    data.documents.forEach(function (element, i) {
+                    results.documents.forEach(function (element, i) {
                         if (start < 0) {
                             start = i;
                         }
@@ -114,7 +115,7 @@ $(document).ready(function() {
                 if (start > 0) {
                     resultList += '<input type="button" id="tx-dlf-search-in-document-button-previous" class="button-previous" onclick="previousResultPage();" value="' + $('#tx-dlf-search-in-document-label-previous').text() + '" />';
                 }
-                if (data.numFound > (start + 20)) {
+                if (results.numFound > (start + 20)) {
                     resultList += '<input type="button" id="tx-dlf-search-in-document-button-next" class="button-next" onclick="nextResultPage();" value="' + $('#tx-dlf-search-in-document-label-next').text() + '" />';
                 }
                 $('#tx-dlf-search-in-document-results').html(resultList);

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -95,7 +95,7 @@ $(document).ready(function() {
                             resultItems[element['page']] = '<span class="structure">'
                                 + $('#tx-dlf-search-in-document-label-page').text() + ' ' + element['page']
                                 + '</span><br />'
-                                + '<span ="textsnippet">' + 
+                                + '<span ="textsnippet">'
                                 + '<a href=\"' + link + '\">' + element['snippet'] + '</a>'
                                 + '</span>';
                         }

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -67,8 +67,7 @@ $(document).ready(function() {
                 var resultItems = [];
                 var resultList = '<div class="results-active-indicator"></div><ul>';
                 var start = -1;
-                var results = JSON.parse(data);
-                if (results['numFound'] > 0) {
+                if (data['numFound'] > 0) {
                     // Take the workview baseUrl from the form action.
                     // The URL may be in the following form
                     // - http://example.com/index.php?id=14
@@ -80,7 +79,7 @@ $(document).ready(function() {
                     } else {
                         baseUrl += '?';
                     }
-                    results['documents'].forEach(function (element, i) {
+                    data['documents'].forEach(function (element, i) {
                         if (start < 0) {
                             start = i;
                         }
@@ -115,7 +114,7 @@ $(document).ready(function() {
                 if (start > 0) {
                     resultList += '<input type="button" id="tx-dlf-search-in-document-button-previous" class="button-previous" onclick="previousResultPage();" value="' + $('#tx-dlf-search-in-document-label-previous').text() + '" />';
                 }
-                if (results['numFound'] > (start + 20)) {
+                if (data['numFound'] > (start + 20)) {
                     resultList += '<input type="button" id="tx-dlf-search-in-document-button-next" class="button-next" onclick="nextResultPage();" value="' + $('#tx-dlf-search-in-document-label-next').text() + '" />';
                 }
                 $('#tx-dlf-search-in-document-results').html(resultList);

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
                 var resultList = '<div class="results-active-indicator"></div><ul>';
                 var start = -1;
                 var results = JSON.parse(data);
-                if (results.numFound > 0) {
+                if (results['numFound'] > 0) {
                     // Take the workview baseUrl from the form action.
                     // The URL may be in the following form
                     // - http://example.com/index.php?id=14
@@ -80,7 +80,7 @@ $(document).ready(function() {
                     } else {
                         baseUrl += '?';
                     }
-                    results.documents.forEach(function (element, i) {
+                    results['documents'].forEach(function (element, i) {
                         if (start < 0) {
                             start = i;
                         }
@@ -115,7 +115,7 @@ $(document).ready(function() {
                 if (start > 0) {
                     resultList += '<input type="button" id="tx-dlf-search-in-document-button-previous" class="button-previous" onclick="previousResultPage();" value="' + $('#tx-dlf-search-in-document-label-previous').text() + '" />';
                 }
-                if (results.numFound > (start + 20)) {
+                if (results['numFound'] > (start + 20)) {
                     resultList += '<input type="button" id="tx-dlf-search-in-document-button-next" class="button-next" onclick="nextResultPage();" value="' + $('#tx-dlf-search-in-document-label-next').text() + '" />';
                 }
                 $('#tx-dlf-search-in-document-results').html(resultList);

--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -12,12 +12,11 @@
   * This function increases the start parameter of the search form and submits
   * the form.
   *
-  * @param rows
   * @returns void
   */
-function nextResultPage(rows) {
+function nextResultPage() {
     var currentstart = $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val();
-    var newstart = parseInt(currentstart) + rows;
+    var newstart = parseInt(currentstart) + 20;
     $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val(newstart);
     $('#tx-dlf-search-in-document-form').submit();
 };
@@ -26,13 +25,11 @@ function nextResultPage(rows) {
  * This function decreases the start parameter of the search form and submits
  * the form.
  *
- * @param rows
  * @returns void
  */
-function previousResultPage(rows) {
+function previousResultPage() {
     var currentstart = $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val();
-    currentstart = parseInt(currentstart);
-    var newstart = (currentstart > rows) ? (currentstart - rows) : 0;
+    var newstart = (parseInt(currentstart) > 20) ? (parseInt(currentstart) - 20) : 0;
     $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val(newstart);
     $('#tx-dlf-search-in-document-form').submit();
 };
@@ -67,55 +64,60 @@ $(document).ready(function() {
                 hashed: $( "input[name='tx_dlf[hashed]']" ).val(),
             },
             function(data) {
-              var resultItems = [];
-              var resultList = '<div class="results-active-indicator"></div><ul>';
-              if (data.error) {
-                  resultList += '<li class="error">' + data.error + '</li>';
-              } else {
-                  for (var i=0; i < data.response.docs.length; i++) {
+                var resultItems = [];
+                var resultList = '<div class="results-active-indicator"></div><ul>';
+                var start = -1;
+                if (data.numFound > 0) {
+                    // Take the workview baseUrl from the form action.
+                    // The URL may be in the following form
+                    // - http://example.com/index.php?id=14
+                    // - http://example.com/workview (using slug on page with uid=14)
+                    var baseUrl = $("form#tx-dlf-search-in-document-form").attr('action');
 
-                      // Take the workview baseUrl from the form action.
-                      // The URL may be in the following form
-                      // - http://example.com/index.php?id=14
-                      // - http://example.com/workview (using slug on page with uid=14)
-                      var baseUrl = $("form#tx-dlf-search-in-document-form").attr('action');
-
-                      if (baseUrl.indexOf('?')>0) {
+                    if (baseUrl.indexOf('?') > 0) {
                         baseUrl += '&';
-                      } else {
+                    } else {
                         baseUrl += '?';
-                      }
+                    }
+                    data.documents.forEach(function (element, i) {
+                        if (start < 0) {
+                            start = i;
+                        }
+                        var searchWord = element['snippet'];
+                        searchWord = searchWord.substring(searchWord.indexOf('<em>') + 4, searchWord.indexOf('</em>'));
 
-                      var searchHit = data.highlighting[data.response.docs[i].id].fulltext.toString();
-                      searchHit = searchHit.substring(searchHit.indexOf('<em>')+4,searchHit.indexOf('</em>'));
+                        var link = baseUrl
+                            + 'tx_dlf[id]=' + element['uid']
+                            + '&tx_dlf[highlight_word]=' + encodeURIComponent(searchWord)
+                            + '&tx_dlf[page]=' + element['page'];
 
-                      var newlink = baseUrl
-                      + 'tx_dlf[id]=' + data.response.docs[i].uid
-                      + '&tx_dlf[highlight_word]=' + encodeURIComponent(searchHit)
-                      + '&tx_dlf[page]=' + data.response.docs[i].page;
-
-                      if (data.highlighting[data.response.docs[i].id].fulltext) {
-                          resultItems[data.response.docs[i].page] = '<span class="structure">' + $('#tx-dlf-search-in-document-label-page').text() + ' ' + data.response.docs[i].page + '</span><br /><span ="textsnippet"><a href=\"' + newlink + '\">' + data.highlighting[data.response.docs[i].id].fulltext + '</a></span>';
-                      }
-                  }
-                  if (resultItems.length > 0) {
-                    // sort by page as this cannot be done with current solr schema
-                    resultItems.sort(function(a, b){return a-b});
-                    resultItems.forEach(function(item, index){
+                        if (element['snippet'].length > 0) {
+                            resultItems[element['page']] = '<span class="structure">'
+                                + $('#tx-dlf-search-in-document-label-page').text() + ' ' + element['page']
+                                + '</span><br />'
+                                + '<span ="textsnippet">' + 
+                                + '<a href=\"' + link + '\">' + element['snippet'] + '</a>'
+                                + '</span>';
+                        }
+                    });
+                    // Sort result by page.
+                    resultItems.sort(function (a, b) {
+                        return a - b;
+                    });
+                    resultItems.forEach(function (item, index) {
                         resultList += '<li>' + item + '</li>';
                     });
                 } else {
                     resultList += '<li class="noresult">' + $('#tx-dlf-search-in-document-label-noresult').text() + '</li>';
                 }
-              }
-              resultList += '</ul>';
-              if (parseInt(data.response.start) > 0) {
-                  resultList += '<input type="button" id="tx-dlf-search-in-document-button-previous" class="button-previous" onclick="previousResultPage(' + data.responseHeader.params.rows + ');" value="' + $('#tx-dlf-search-in-document-label-previous').text() + '" />';
-              }
-              if (parseInt(data.response.numFound) > (parseInt(data.response.start) + parseInt(data.responseHeader.params.rows))) {
-                  resultList += '<input type="button" id="tx-dlf-search-in-document-button-next" class="button-next" onclick="nextResultPage(' + data.responseHeader.params.rows + ');" value="' + $('#tx-dlf-search-in-document-label-next').text() + '" />';
-              }
-              $('#tx-dlf-search-in-document-results').html(resultList);
+                resultList += '</ul>';
+                if (start > 0) {
+                    resultList += '<input type="button" id="tx-dlf-search-in-document-button-previous" class="button-previous" onclick="previousResultPage();" value="' + $('#tx-dlf-search-in-document-label-previous').text() + '" />';
+                }
+                if (data.numFound > (start + 20)) {
+                    resultList += '<input type="button" id="tx-dlf-search-in-document-button-next" class="button-next" onclick="nextResultPage();" value="' + $('#tx-dlf-search-in-document-label-next').text() + '" />';
+                }
+                $('#tx-dlf-search-in-document-results').html(resultList);
             },
             "json"
         )

--- a/Resources/Public/Javascript/Search/Suggester.js
+++ b/Resources/Public/Javascript/Search/Suggester.js
@@ -31,7 +31,7 @@ $(
 					function(data) {
 						var result = [];
 						var option = "";
-						JSON.parse(data).each(function(i) {
+						data.each(function(i) {
 							option = $(this).text();
 							option = option.replace(/(\?|!|:|\\)/g, "\\\$1");
 							result.push(option);

--- a/Resources/Public/Javascript/Search/Suggester.js
+++ b/Resources/Public/Javascript/Search/Suggester.js
@@ -31,14 +31,14 @@ $(
 					function(data) {
 						var result = [];
 						var option = "";
-						$("arr[name='suggestion'] str", data).each(function(i) {
+						$.parseJSON(data).each(function(i) {
 							option = $(this).text();
 							option = option.replace(/(\?|!|:|\\)/g, "\\\$1");
 							result.push(option);
 						});
 						return response(result);
 					},
-					"xml");
+					"json");
 			},
 			minLength: 3,
 			appendTo: "#tx-dlf-search-suggest"

--- a/Resources/Public/Javascript/Search/Suggester.js
+++ b/Resources/Public/Javascript/Search/Suggester.js
@@ -30,11 +30,9 @@ $(
 					},
 					function(data) {
 						var result = [];
-						var option = "";
-						data.each(function(i) {
-							option = $(this).text();
-							option = option.replace(/(\?|!|:|\\)/g, "\\\$1");
-							result.push(option);
+						data.forEach(function(element, index) {
+							element = element.replace(/(\?|!|:|\\)/g, "\\\$1");
+							result.push(element);
 						});
 						return response(result);
 					},

--- a/Resources/Public/Javascript/Search/Suggester.js
+++ b/Resources/Public/Javascript/Search/Suggester.js
@@ -31,7 +31,7 @@ $(
 					function(data) {
 						var result = [];
 						var option = "";
-						$.parseJSON(data).each(function(i) {
+						JSON.parse(data).each(function(i) {
 							option = $(this).text();
 							option = option.replace(/(\?|!|:|\\)/g, "\\\$1");
 							result.push(option);

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -141,7 +141,7 @@ class ext_update
         while ($resArray = $result->fetch()) {
             // Instantiate search object.
             $solr = Solr::getInstance($resArray['index_name']);
-            if ($solr->core !== $resArray['index_name']) {
+            if (!$solr->ready) {
                 return true;
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "typo3/cms-core": "~8.7.32|~9.5.17",
     "typo3/cms-tstemplate": "~8.7.32|~9.5.17",
     "ubl/php-iiif-prezi-reader": "0.3.0",
-    "solarium/solarium": "^5.1.6"
+    "solarium/solarium": "^5.2"
   },
   "replace": {
     "typo3-ter/dlf": "self.version"

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -44,3 +44,5 @@ solrUser =
 solrPass =
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.solrTimeout
 solrTimeout = 10
+# cat=Solr; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/Labels.xml:config.solrAllowCoreDelete
+solrAllowCoreDelete = 0


### PR DESCRIPTION
This pull requests finishes the Solarium upgrade from #550:

Use Solarium everywhere we communicate with Solr:
- [x] Fetching documents via `\Kitodo\Dlf\Common\DocumentList`
- [x] Indexing documents via `\Kitodo\Dlf\Common\Indexer`
- [x] Checking Solr connection via `\Kitodo\Dlf\Hooks\ConfigurationForm`
- [x] Adding new **or deleting** Solr cores via `\Kitodo\Dlf\Hooks\DataHandler`
- [x] Fetching documents via `\Kitodo\Dlf\Plugin\Collection`
- [x] Search queries via `\Kitodo\Dlf\Plugin\OaiPmh`
- [x] Search queries via `\Kitodo\Dlf\Plugin\Search`
- [x] Search queries via `\Kitodo\Dlf\Plugin\Eid\SearchInDocument`
- [x] Autocomplete queries via `\Kitodo\Dlf\Plugin\Eid\SearchSuggest`
- [x] Checking for Solr updates and recreating cores via `class.ext_update.php`

This should fix #566