### PR TITLE
Add core status widget

### DIFF
--- a/Classes/Hooks/Form/FieldInformation/EditInProductionWarning.php
+++ b/Classes/Hooks/Form/FieldInformation/EditInProductionWarning.php
@@ -42,7 +42,7 @@ class EditInProductionWarning extends AbstractNode
             // Create flash message.
             Helper::addMessage(
                 htmlspecialchars($GLOBALS['LANG']->getLL('flash.editInProductionWarning')),
-                htmlspecialchars($GLOBALS['LANG']->getLL('flash.attention')),
+                '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
                 \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING
             );
             // Add message to result array.

--- a/Classes/Hooks/Form/FieldInformation/EditInProductionWarning.php
+++ b/Classes/Hooks/Form/FieldInformation/EditInProductionWarning.php
@@ -10,7 +10,7 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
-namespace Kitodo\Dlf\Hooks\Form\FieldWizard;
+namespace Kitodo\Dlf\Hooks\Form\FieldInformation;
 
 use Kitodo\Dlf\Common\Helper;
 use TYPO3\CMS\Backend\Form\AbstractNode;

--- a/Classes/Hooks/Form/FieldInformation/EditInProductionWarning.php
+++ b/Classes/Hooks/Form/FieldInformation/EditInProductionWarning.php
@@ -16,7 +16,7 @@ use Kitodo\Dlf\Common\Helper;
 use TYPO3\CMS\Backend\Form\AbstractNode;
 
 /**
- * FieldWizard renderType for TYPO3 FormEngine
+ * FieldInformation renderType for TYPO3 FormEngine
  *
  * @author Sebastian Meyer <sebastian.meyer@slub-dresden.de>
  * @package TYPO3

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -10,7 +10,7 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
-namespace Kitodo\Dlf\Hooks\Form\FieldWizard;
+namespace Kitodo\Dlf\Hooks\Form\FieldInformation;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -32,6 +32,7 @@ class SolrCoreStatus extends AbstractNode
      * @access public
      *
      * @return array As defined in initializeResultArray() of AbstractNode
+     *               Allowed tags are: "<a><br><br/><div><em><i><p><strong><span><code>"
      */
     public function render(): array
     {
@@ -57,15 +58,15 @@ class SolrCoreStatus extends AbstractNode
                 $lastModified = $response->getLastModified() ? date_format($response->getLastModified(), 'c') : 'N/A';
                 // Create flash message.
                 Helper::addMessage(
-                    htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatusDetails'), $startTime, $uptime, $lastModified, $numDocuments)),
-                    htmlspecialchars($GLOBALS['LANG']->getLL('flash.coreStatus')),
+                    htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments)),
+                    '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
                     \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
                 );
             } else {
                 // Could not fetch core status.
                 Helper::addMessage(
                     htmlspecialchars($GLOBALS['LANG']->getLL('solr.error')),
-                    htmlspecialchars($GLOBALS['LANG']->getLL('solr.notConnected')),
+                    '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
                     \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR
                 );
             }

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -58,7 +58,7 @@ class SolrCoreStatus extends AbstractNode
                 $lastModified = $response->getLastModified() ? date_format($response->getLastModified(), 'c') : 'N/A';
                 // Create flash message.
                 Helper::addMessage(
-                    htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments)),
+                    sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),
                     '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
                     \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
                 );

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -51,17 +51,26 @@ class SolrCoreStatus extends AbstractNode
                 $action->setCore($core);
                 $coreAdminQuery->setAction($action);
                 $response = $solr->service->coreAdmin($coreAdminQuery)->getStatusResult();
-                $uptimeInSeconds = floor($response->getUptime() / 1000);
-                $uptime = floor($uptimeInSeconds / 3600) . gmdate(":i:s.", $uptimeInSeconds % 3600) . $response->getUptime() % 1000;
-                $numDocuments = $response->getNumberOfDocuments();
-                $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
-                $lastModified = $response->getLastModified() ? strftime('%c'. $response->getLastModified()->getTimestamp()) : 'N/A';
-                // Create flash message.
-                Helper::addMessage(
-                    sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),
-                    '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
-                    \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
-                );
+                if ($response) {
+                    $uptimeInSeconds = floor($response->getUptime() / 1000);
+                    $dateTimeFrom = new \DateTime('@0');
+                    $dateTimeTo = new \DateTime("@$uptimeInSeconds");
+                    $uptime = $dateTimeFrom->diff($dateTimeTo)->format('%a ' . $GLOBALS['LANG']->getLL('flash.days') . ', %H:%I:%S');
+
+                    $numDocuments = $response->getNumberOfDocuments();
+
+                    $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
+                    $startTimeTimestamp = $response->getStartTime()->getTimestamp();
+
+                    $lastModifiedTimestamp = $response->getLastModified()->getTimestamp();
+                    $lastModified = $response->getLastModified() ? strftime('%c', $response->getLastModified()->getTimestamp()) : 'N/A';
+                    // Create flash message.
+                    Helper::addMessage(
+                        sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),
+                        '', // We must not set a title/header, because <h4> isn't allowed in FieldInformation.
+                        \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
+                    );
+                }
             } else {
                 // Could not fetch core status.
                 Helper::addMessage(

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -17,7 +17,7 @@ use Kitodo\Dlf\Common\Solr;
 use TYPO3\CMS\Backend\Form\AbstractNode;
 
 /**
- * FieldWizard renderType for TYPO3 FormEngine
+ * FieldInformation renderType for TYPO3 FormEngine
  *
  * @author Sebastian Meyer <sebastian.meyer@slub-dresden.de>
  * @package TYPO3
@@ -49,15 +49,16 @@ class SolrCoreStatus extends AbstractNode
                 $action = $coreAdminQuery->createStatus();
                 $action->setCore($core);
                 $coreAdminQuery->setAction($action);
-                $result = $solr->service->coreAdmin($coreAdminQuery)->getStatusResult();
-                $uptime = $result->getUptime();
-                $numDocuments = $result->getNumberOfDocuments();
-                $startTime = $result->getStartTime() ? date_format($result->getStartTime(), 'c') : 'N/A';
-                $lastModified = $result->getLastModified() ? date_format($result->getLastModified(), 'c') : 'N/A';
+                $response = $solr->service->coreAdmin($coreAdminQuery)->getStatusResult();
+                $uptimeInSeconds = floor($response->getUptime() / 1000);
+                $uptime = floor($uptimeInSeconds / 3600) . gmdate(":i:s.", $uptimeInSeconds % 3600) . $response->getUptime() % 1000;
+                $numDocuments = $response->getNumberOfDocuments();
+                $startTime = $response->getStartTime() ? date_format($response->getStartTime(), 'c') : 'N/A';
+                $lastModified = $response->getLastModified() ? date_format($response->getLastModified(), 'c') : 'N/A';
                 // Create flash message.
                 Helper::addMessage(
-                    nl2br(htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatusDetails'), $startTime, $uptime, $lastModified, $numDocuments))),
-                    htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $core)),
+                    htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatusDetails'), $startTime, $uptime, $lastModified, $numDocuments)),
+                    htmlspecialchars($GLOBALS['LANG']->getLL('flash.coreStatus')),
                     \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
                 );
             } else {

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -56,13 +56,8 @@ class SolrCoreStatus extends AbstractNode
                     $dateTimeFrom = new \DateTime('@0');
                     $dateTimeTo = new \DateTime("@$uptimeInSeconds");
                     $uptime = $dateTimeFrom->diff($dateTimeTo)->format('%a ' . $GLOBALS['LANG']->getLL('flash.days') . ', %H:%I:%S');
-
                     $numDocuments = $response->getNumberOfDocuments();
-
                     $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
-                    $startTimeTimestamp = $response->getStartTime()->getTimestamp();
-
-                    $lastModifiedTimestamp = $response->getLastModified()->getTimestamp();
                     $lastModified = $response->getLastModified() ? strftime('%c', $response->getLastModified()->getTimestamp()) : 'N/A';
                     // Create flash message.
                     Helper::addMessage(

--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -54,8 +54,8 @@ class SolrCoreStatus extends AbstractNode
                 $uptimeInSeconds = floor($response->getUptime() / 1000);
                 $uptime = floor($uptimeInSeconds / 3600) . gmdate(":i:s.", $uptimeInSeconds % 3600) . $response->getUptime() % 1000;
                 $numDocuments = $response->getNumberOfDocuments();
-                $startTime = $response->getStartTime() ? date_format($response->getStartTime(), 'c') : 'N/A';
-                $lastModified = $response->getLastModified() ? date_format($response->getLastModified(), 'c') : 'N/A';
+                $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
+                $lastModified = $response->getLastModified() ? strftime('%c'. $response->getLastModified()->getTimestamp()) : 'N/A';
                 // Create flash message.
                 Helper::addMessage(
                     sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),

--- a/Classes/Hooks/Form/FieldWizard/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldWizard/SolrCoreStatus.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Hooks\Form\FieldWizard;
+
+use Kitodo\Dlf\Common\Helper;
+use Kitodo\Dlf\Common\Solr;
+use TYPO3\CMS\Backend\Form\AbstractNode;
+
+/**
+ * FieldWizard renderType for TYPO3 FormEngine
+ *
+ * @author Sebastian Meyer <sebastian.meyer@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class SolrCoreStatus extends AbstractNode
+{
+    /**
+     * Shows Solr core status for given 'index_name'
+     *
+     * @access public
+     *
+     * @return array As defined in initializeResultArray() of AbstractNode
+     */
+    public function render(): array
+    {
+        $result = $this->initializeResultArray();
+        // Show only when editing existing records.
+        if ($this->data['command'] !== 'new') {
+            $core = $this->data['databaseRow']['index_name'];
+            // Load localization file.
+            $GLOBALS['LANG']->includeLLFile('EXT:dlf/Resources/Private/Language/FlashMessages.xml');
+            // Get Solr instance.
+            $solr = Solr::getInstance($core);
+            if ($solr->ready) {
+                // Get core data.
+                $coreAdminQuery = $solr->service->createCoreAdmin();
+                $action = $coreAdminQuery->createStatus();
+                $action->setCore($core);
+                $coreAdminQuery->setAction($action);
+                $result = $solr->service->coreAdmin($coreAdminQuery)->getStatusResult();
+                $uptime = $result->getUptime();
+                $numDocuments = $result->getNumberOfDocuments();
+                $startTime = $result->getStartTime() ? date_format($result->getStartTime(), 'c') : 'N/A';
+                $lastModified = $result->getLastModified() ? date_format($result->getLastModified(), 'c') : 'N/A';
+                // Create flash message.
+                Helper::addMessage(
+                    nl2br(htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatusDetails'), $startTime, $uptime, $lastModified, $numDocuments))),
+                    htmlspecialchars(sprintf($GLOBALS['LANG']->getLL('flash.coreStatus'), $core)),
+                    \TYPO3\CMS\Core\Messaging\FlashMessage::INFO
+                );
+            } else {
+                // Could not fetch core status.
+                Helper::addMessage(
+                    htmlspecialchars($GLOBALS['LANG']->getLL('solr.error')),
+                    htmlspecialchars($GLOBALS['LANG']->getLL('solr.notConnected')),
+                    \TYPO3\CMS\Core\Messaging\FlashMessage::ERROR
+                );
+            }
+            // Add message to result array.
+            $result['html'] = Helper::renderFlashMessages();
+        }
+        return $result;
+    }
+}

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -125,7 +125,7 @@ return [
                 'max' => 255,
                 'eval' => 'required,uniqueInPid',
                 'default' => '',
-                'fieldWizard' => [
+                'fieldInformation' => [
                     'editInProductionWarning' => [
                         'renderType' => 'editInProductionWarning',
                     ],

--- a/Configuration/TCA/tx_dlf_libraries.php
+++ b/Configuration/TCA/tx_dlf_libraries.php
@@ -89,7 +89,7 @@ return [
                 'max' => 255,
                 'eval' => 'required,uniqueInPid',
                 'default' => '',
-                'fieldWizard' => [
+                'fieldInformation' => [
                     'editInProductionWarning' => [
                         'renderType' => 'editInProductionWarning',
                     ],

--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -101,7 +101,7 @@ return [
                 'max' => 255,
                 'eval' => 'required,nospace,alphanum_x,uniqueInPid',
                 'default' => '',
-                'fieldWizard' => [
+                'fieldInformation' => [
                     'editInProductionWarning' => [
                         'renderType' => 'editInProductionWarning',
                     ],

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -50,7 +50,7 @@ return [
                 'eval' => 'alphanum,nospace,required,unique',
                 'default' => '',
                 'readOnly' => true,
-                'fieldWizard' => [
+                'fieldInformation' => [
                     'solrCoreStatus' => [
                         'renderType' => 'solrCoreStatus',
                     ],

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -44,11 +44,17 @@ return [
         'index_name' => [
             'label' => 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_solrcores.index_name',
             'config' => [
-                'type' => 'none',
+                'type' => 'input',
                 'size' => 30,
                 'max' => 255,
-                'eval' => 'alphanum,unique',
+                'eval' => 'alphanum,nospace,required,unique',
                 'default' => '',
+                'readOnly' => true,
+                'fieldWizard' => [
+                    'solrCoreStatus' => [
+                        'renderType' => 'solrCoreStatus',
+                    ],
+                ],
             ],
         ],
     ],

--- a/Configuration/TCA/tx_dlf_structures.php
+++ b/Configuration/TCA/tx_dlf_structures.php
@@ -111,7 +111,7 @@ return [
                 'max' => 255,
                 'eval' => 'required,nospace,alphanum_x,uniqueInPid',
                 'default' => '',
-                'fieldWizard' => [
+                'fieldInformation' => [
                     'editInProductionWarning' => [
                         'renderType' => 'editInProductionWarning',
                     ],

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -19,8 +19,7 @@
             <label index="flash.done">Done!</label>
             <label index="flash.warning">Warning!</label>
             <label index="flash.error">Error!</label>
-            <label index="flash.coreStatus">Status of Solr Core</label>
-            <label index="flash.coreStatusDetails">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
+            <label index="flash.coreStatus">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
             <label index="flash.running">Please wait...</label>
             <label index="flash.newCollection">New collection "%s" [%u] added to database.</label>
             <label index="flash.newLibrary">New library "%s" [%u] added to database.</label>
@@ -94,8 +93,7 @@
             <label index="flash.done">Fertig!</label>
             <label index="flash.warning">Warnung!</label>
             <label index="flash.error">Fehler!</label>
-            <label index="flash.coreStatus">Status des Solr-Kerns</label>
-            <label index="flash.coreStatusDetails">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
+            <label index="flash.coreStatus">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
             <label index="flash.running">Indexierung läuft...</label>
             <label index="flash.newCollection">Neue Sammlung "%s" [%u] zur Datenbank hinzugefügt.</label>
             <label index="flash.newLibrary">Neue Bibliothek "%s" [%u] zur Datenbank hinzugefügt.</label>

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -19,6 +19,8 @@
             <label index="flash.done">Done!</label>
             <label index="flash.warning">Warning!</label>
             <label index="flash.error">Error!</label>
+            <label index="flash.coreStatus">Status of Solr Core "%s"</label>
+            <label index="flash.coreStatusDetails">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
             <label index="flash.running">Please wait...</label>
             <label index="flash.newCollection">New collection "%s" [%u] added to database.</label>
             <label index="flash.newLibrary">New library "%s" [%u] added to database.</label>
@@ -92,6 +94,8 @@
             <label index="flash.done">Fertig!</label>
             <label index="flash.warning">Warnung!</label>
             <label index="flash.error">Fehler!</label>
+            <label index="flash.coreStatus">Status des Solr-Kerns "%s"</label>
+            <label index="flash.coreStatusDetails">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
             <label index="flash.running">Indexierung läuft...</label>
             <label index="flash.newCollection">Neue Sammlung "%s" [%u] zur Datenbank hinzugefügt.</label>
             <label index="flash.newLibrary">Neue Bibliothek "%s" [%u] zur Datenbank hinzugefügt.</label>

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -20,6 +20,7 @@
             <label index="flash.warning">Warning!</label>
             <label index="flash.error">Error!</label>
             <label index="flash.coreStatus">Start Time: %s&lt;br /&gt;Uptime: %s&lt;br /&gt;Last Modified: %s&lt;br /&gt;Number of Documents: %u</label>
+            <label index="flash.days">days</label>
             <label index="flash.running">Please wait...</label>
             <label index="flash.newCollection">New collection "%s" [%u] added to database.</label>
             <label index="flash.newLibrary">New library "%s" [%u] added to database.</label>
@@ -94,6 +95,7 @@
             <label index="flash.warning">Warnung!</label>
             <label index="flash.error">Fehler!</label>
             <label index="flash.coreStatus">Startzeit: %s&lt;br /&gt;Laufzeit: %s&lt;br /&gt;Letzte Änderung: %s&lt;br /&gt;Anzahl Dokumente: %u</label>
+            <label index="flash.days">Tage</label>
             <label index="flash.running">Indexierung läuft...</label>
             <label index="flash.newCollection">Neue Sammlung "%s" [%u] zur Datenbank hinzugefügt.</label>
             <label index="flash.newLibrary">Neue Bibliothek "%s" [%u] zur Datenbank hinzugefügt.</label>

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -19,7 +19,7 @@
             <label index="flash.done">Done!</label>
             <label index="flash.warning">Warning!</label>
             <label index="flash.error">Error!</label>
-            <label index="flash.coreStatus">Status of Solr Core "%s"</label>
+            <label index="flash.coreStatus">Status of Solr Core</label>
             <label index="flash.coreStatusDetails">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
             <label index="flash.running">Please wait...</label>
             <label index="flash.newCollection">New collection "%s" [%u] added to database.</label>
@@ -94,7 +94,7 @@
             <label index="flash.done">Fertig!</label>
             <label index="flash.warning">Warnung!</label>
             <label index="flash.error">Fehler!</label>
-            <label index="flash.coreStatus">Status des Solr-Kerns "%s"</label>
+            <label index="flash.coreStatus">Status des Solr-Kerns</label>
             <label index="flash.coreStatusDetails">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
             <label index="flash.running">Indexierung läuft...</label>
             <label index="flash.newCollection">Neue Sammlung "%s" [%u] zur Datenbank hinzugefügt.</label>

--- a/Resources/Private/Language/FlashMessages.xml
+++ b/Resources/Private/Language/FlashMessages.xml
@@ -19,7 +19,7 @@
             <label index="flash.done">Done!</label>
             <label index="flash.warning">Warning!</label>
             <label index="flash.error">Error!</label>
-            <label index="flash.coreStatus">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
+            <label index="flash.coreStatus">Start Time: %s&lt;br /&gt;Uptime: %s&lt;br /&gt;Last Modified: %s&lt;br /&gt;Number of Documents: %u</label>
             <label index="flash.running">Please wait...</label>
             <label index="flash.newCollection">New collection "%s" [%u] added to database.</label>
             <label index="flash.newLibrary">New library "%s" [%u] added to database.</label>
@@ -93,7 +93,7 @@
             <label index="flash.done">Fertig!</label>
             <label index="flash.warning">Warnung!</label>
             <label index="flash.error">Fehler!</label>
-            <label index="flash.coreStatus">Start Time: %s\nUptime: %s\nLast Modified: %s\nNumber of Documents: %s</label>
+            <label index="flash.coreStatus">Startzeit: %s&lt;br /&gt;Laufzeit: %s&lt;br /&gt;Letzte Änderung: %s&lt;br /&gt;Anzahl Dokumente: %u</label>
             <label index="flash.running">Indexierung läuft...</label>
             <label index="flash.newCollection">Neue Sammlung "%s" [%u] zur Datenbank hinzugefügt.</label>
             <label index="flash.newLibrary">Neue Bibliothek "%s" [%u] zur Datenbank hinzugefügt.</label>

--- a/Resources/Private/Language/Labels.xml
+++ b/Resources/Private/Language/Labels.xml
@@ -107,7 +107,7 @@
             <label index="tx_dlf_formats.tab1">General</label>
             <label index="tx_dlf_solrcores">Solr Cores</label>
             <label index="tx_dlf_solrcores.label">Display Label</label>
-            <label index="tx_dlf_solrcores.index_name">Solr Name</label>
+            <label index="tx_dlf_solrcores.index_name">Solr Core</label>
             <label index="tx_dlf_solrcores.tab1">General</label>
             <label index="tx_dlf_collections">Collections</label>
             <label index="tx_dlf_collections.label">Display Label</label>
@@ -292,7 +292,7 @@
             <label index="tx_dlf_formats.tab1">Allgemein</label>
             <label index="tx_dlf_solrcores">Solr Kerne</label>
             <label index="tx_dlf_solrcores.label">Anzeigeform</label>
-            <label index="tx_dlf_solrcores.index_name">Solr-Bezeichnung</label>
+            <label index="tx_dlf_solrcores.index_name">Solr-Kern</label>
             <label index="tx_dlf_solrcores.tab1">Allgemein</label>
             <label index="tx_dlf_collections">Sammlungen</label>
             <label index="tx_dlf_collections.label">Anzeigeform</label>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -256,3 +256,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][] = [
     'priority' => 30,
     'class' => \Kitodo\Dlf\Hooks\Form\FieldWizard\EditInProductionWarning::class
 ];
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][] = [
+    'nodeName' => 'solrCoreStatus',
+    'priority' => 30,
+    'class' => \Kitodo\Dlf\Hooks\Form\FieldWizard\SolrCoreStatus::class
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -254,10 +254,10 @@ if (\TYPO3_MODE === 'FE') {
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][] = [
     'nodeName' => 'editInProductionWarning',
     'priority' => 30,
-    'class' => \Kitodo\Dlf\Hooks\Form\FieldWizard\EditInProductionWarning::class
+    'class' => \Kitodo\Dlf\Hooks\Form\FieldInformation\EditInProductionWarning::class
 ];
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][] = [
     'nodeName' => 'solrCoreStatus',
     'priority' => 30,
-    'class' => \Kitodo\Dlf\Hooks\Form\FieldWizard\SolrCoreStatus::class
+    'class' => \Kitodo\Dlf\Hooks\Form\FieldInformation\SolrCoreStatus::class
 ];


### PR DESCRIPTION
This pull request adds a small status message for Solr cores. When editing a `tx_dlf_solrcores` record in the backend, the status of the respective core is fetched from Solr and shown as flash message.

This is done by implementing a new `FieldInformation` renderType for input fields.

---

In addition this pull request refactors the recently introduced warning message for changing the `index_name` of records (#553) from `FieldWizard` to `FieldInformation` as well. Originally this was implemented as `FieldWizard` because `FieldInformation` doesn't allow all HTML tags of a flash message. But in fact, only the `<h4>` tag of the flash message's title is disallowed, so by just omitting the title we can still use flash messages as `FieldInformation`.
Since a static warning message should logically be a `FieldInformation` I decided to refactor this.