### PR TITLE
Remove double submit of the search form

### DIFF
--- a/Resources/Public/Javascript/Search/SearchInDocument.js
+++ b/Resources/Public/Javascript/Search/SearchInDocument.js
@@ -41,7 +41,6 @@ function previousResultPage() {
  */
 function resetStart() {
     $("#tx-dlf-search-in-document-form input[name='tx_dlf[start]']").val(0);
-    $('#tx-dlf-search-in-document-form').submit();
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
Method `resetStart` is called on the submit button, so at the end `submit` method is called two times.