### PR TITLE
Use AES-256-CTR and SHA256

### DIFF
--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -417,7 +417,7 @@ abstract class Document
         // Sanitize input.
         $pid = max(intval($pid), 0);
         if (!$forceReload) {
-            $regObj = md5($uid);
+            $regObj = Helper::digest($uid);
             if (
                 is_object(self::$registry[$regObj])
                 && self::$registry[$regObj] instanceof self
@@ -550,9 +550,9 @@ abstract class Document
         if (
             $instance instanceof self
             && $instance->ready) {
-            self::$registry[md5($instance->uid)] = $instance;
+            self::$registry[Helper::digest($instance->uid)] = $instance;
             if ($instance->uid != $instance->location) {
-                self::$registry[md5($instance->location)] = $instance;
+                self::$registry[Helper::digest($instance->location)] = $instance;
             }
             // Load extension configuration
             $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']);

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -189,7 +189,7 @@ class Helper
         $data = substr($encrypted, openssl_cipher_iv_length(self::$cipherAlgorithm));
         $key = openssl_digest($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], self::$hashAlgorithm, true);
         // Decrypt data.
-        $decrypted = openssl_decrypt($data, self::$cipherAlgorithm, $key, OPENSSL_RAW_DATA, $iv);
+        $decrypted = openssl_decrypt($data, self::$cipherAlgorithm, $key, 0, $iv);
         return $decrypted;
     }
 
@@ -282,7 +282,7 @@ class Helper
         $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(self::$cipherAlgorithm));
         $key = openssl_digest($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], self::$hashAlgorithm, true);
         // Encrypt data.
-        $encrypted = openssl_encrypt($string, self::$cipherAlgorithm, $key, OPENSSL_RAW_DATA, $iv);
+        $encrypted = openssl_encrypt($string, self::$cipherAlgorithm, $key, 0, $iv);
         // Merge initialisation vector and encrypted data.
         if ($encrypted !== false) {
             $encrypted = $iv . $encrypted;

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -185,11 +185,12 @@ class Helper
             return false;
         }
         // Split initialisation vector and encrypted data.
-        $iv = substr($encrypted, 0, openssl_cipher_iv_length(self::$cipherAlgorithm));
-        $data = substr($encrypted, openssl_cipher_iv_length(self::$cipherAlgorithm));
+        $binary = base64_decode($encrypted);
+        $iv = substr($binary, 0, openssl_cipher_iv_length(self::$cipherAlgorithm));
+        $data = substr($binary, openssl_cipher_iv_length(self::$cipherAlgorithm));
         $key = openssl_digest($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], self::$hashAlgorithm, true);
         // Decrypt data.
-        $decrypted = openssl_decrypt($data, self::$cipherAlgorithm, $key, 0, $iv);
+        $decrypted = openssl_decrypt($data, self::$cipherAlgorithm, $key, OPENSSL_RAW_DATA, $iv);
         return $decrypted;
     }
 
@@ -282,10 +283,10 @@ class Helper
         $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(self::$cipherAlgorithm));
         $key = openssl_digest($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], self::$hashAlgorithm, true);
         // Encrypt data.
-        $encrypted = openssl_encrypt($string, self::$cipherAlgorithm, $key, 0, $iv);
+        $encrypted = openssl_encrypt($string, self::$cipherAlgorithm, $key, OPENSSL_RAW_DATA, $iv);
         // Merge initialisation vector and encrypted data.
         if ($encrypted !== false) {
-            $encrypted = $iv . $encrypted;
+            $encrypted = base64_encode($iv . $encrypted);
         }
         return $encrypted;
     }

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -243,7 +243,7 @@ class Helper
      *
      * @param string $string: The string to encrypt
      *
-     * @return string Encrypted string or false on error
+     * @return mixed Encrypted string or false on error
      */
     public static function encrypt($string)
     {

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -237,6 +237,26 @@ class Helper
     }
 
     /**
+     * Digest the given string
+     *
+     * @access public
+     *
+     * @param string $string: The string to encrypt
+     *
+     * @return mixed Hashed string or false on error
+     */
+    public static function digest($string)
+    {
+        if (!in_array(self::$hashAlgorithm, openssl_get_md_methods(true))) {
+            self::devLog('OpenSSL library doesn\'t support hash algorithm', DEVLOG_SEVERITY_ERROR);
+            return false;
+        }
+        // Hash string.
+        $hashed = openssl_digest($string, self::$hashAlgorithm);
+        return $hashed;
+    }
+
+    /**
      * Encrypt the given string
      *
      * @access public

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -35,6 +35,24 @@ class Helper
     public static $extKey = 'dlf';
 
     /**
+     * This holds the cipher algorithm
+     * @see openssl_get_cipher_methods() for options
+     *
+     * @var string
+     * @access protected
+     */
+    protected static $cipherAlgorithm = 'aes-256-gcm';
+
+    /**
+     * This holds the hash algorithm
+     * @see openssl_get_md_methods() for options
+     *
+     * @var string
+     * @access protected
+     */
+    protected static $hashAlgorithm = 'sha256';
+
+    /**
      * The locallang array for flash messages
      *
      * @var array
@@ -143,31 +161,35 @@ class Helper
      * @access public
      *
      * @param string $encrypted: The encrypted value to decrypt
-     * @param string $hash: The control hash for decrypting
      *
-     * @return mixed The decrypted value or null on error
+     * @return mixed The decrypted value or false on error
      */
-    public static function decrypt($encrypted, $hash)
+    public static function decrypt($encrypted)
     {
         if (
-            empty($encrypted)
-            || empty($hash)
+            !in_array(self::$cipherAlgorithm, openssl_get_cipher_methods(true))
+            || !in_array(self::$hashAlgorithm, openssl_get_md_methods(true))
         ) {
-            self::devLog('Invalid parameters given for decryption', DEVLOG_SEVERITY_ERROR);
-            return;
+            self::devLog('OpenSSL library doesn\'t support cipher and/or hash algorithm', DEVLOG_SEVERITY_ERROR);
+            return false;
         }
         if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'])) {
             self::devLog('No encryption key set in TYPO3 configuration', DEVLOG_SEVERITY_ERROR);
-            return;
+            return false;
         }
-        $iv = substr(md5($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']), 0, openssl_cipher_iv_length('BF-CFB'));
-        $decrypted = openssl_decrypt($encrypted, 'BF-CFB', substr($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 0, 56), 0, $iv);
-        $salt = substr($hash, 0, 10);
-        $hashed = $salt . substr(sha1($salt . $decrypted), -10);
-        if ($hashed !== $hash) {
-            self::devLog('Invalid hash "' . $hash . '" given for decryption', DEVLOG_SEVERITY_WARNING);
-            return;
+        if (
+            empty($encrypted)
+            || strlen($encrypted) < openssl_cipher_iv_length(self::$cipherAlgorithm)
+        ) {
+            self::devLog('Invalid parameters given for decryption', DEVLOG_SEVERITY_ERROR);
+            return false;
         }
+        // Split initialisation vector and encrypted data.
+        $iv = substr($encrypted, 0, openssl_cipher_iv_length(self::$cipherAlgorithm));
+        $data = substr($encrypted, openssl_cipher_iv_length(self::$cipherAlgorithm));
+        $key = openssl_digest($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], self::$hashAlgorithm, true);
+        // Decrypt data.
+        $decrypted = openssl_decrypt($data, self::$cipherAlgorithm, $key, OPENSSL_RAW_DATA, $iv);
         return $decrypted;
     }
 
@@ -221,19 +243,31 @@ class Helper
      *
      * @param string $string: The string to encrypt
      *
-     * @return array Array with encrypted string and control hash
+     * @return string Encrypted string or false on error
      */
     public static function encrypt($string)
     {
+        if (
+            !in_array(self::$cipherAlgorithm, openssl_get_cipher_methods(true))
+            || !in_array(self::$hashAlgorithm, openssl_get_md_methods(true))
+        ) {
+            self::devLog('OpenSSL library doesn\'t support cipher and/or hash algorithm', DEVLOG_SEVERITY_ERROR);
+            return false;
+        }
         if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'])) {
             self::devLog('No encryption key set in TYPO3 configuration', DEVLOG_SEVERITY_ERROR);
-            return;
+            return false;
         }
-        $iv = substr(md5($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']), 0, openssl_cipher_iv_length('BF-CFB'));
-        $encrypted = openssl_encrypt($string, 'BF-CFB', substr($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 0, 56), 0, $iv);
-        $salt = substr(md5(uniqid(rand(), true)), 0, 10);
-        $hash = $salt . substr(sha1($salt . $string), -10);
-        return ['encrypted' => $encrypted, 'hash' => $hash];
+        // Generate random initialisation vector.
+        $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(self::$cipherAlgorithm));
+        $key = openssl_digest($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], self::$hashAlgorithm, true);
+        // Encrypt data.
+        $encrypted = openssl_encrypt($string, self::$cipherAlgorithm, $key, OPENSSL_RAW_DATA, $iv);
+        // Merge initialisation vector and encrypted data.
+        if ($encrypted !== false) {
+            $encrypted = $iv . $encrypted;
+        }
+        return $encrypted;
     }
 
     /**

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -41,7 +41,7 @@ class Helper
      * @var string
      * @access protected
      */
-    protected static $cipherAlgorithm = 'aes-256-gcm';
+    protected static $cipherAlgorithm = 'aes-256-ctr';
 
     /**
      * This holds the hash algorithm

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -428,7 +428,7 @@ class Solr
         $parameters['query'] = $query;
 
         // calculate cache identifier
-        $cacheIdentifier = hash('md5', print_r(array_merge($this->params, $parameters), 1));
+        $cacheIdentifier = Helper::digest(print_r(array_merge($this->params, $parameters), true));
         $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('tx_dlf_solr');
 
         $resultSet = [];

--- a/Classes/Plugin/Eid/SearchInDocument.php
+++ b/Classes/Plugin/Eid/SearchInDocument.php
@@ -44,12 +44,11 @@ class SearchInDocument
         // Get input parameters and decrypt core name.
         $parameters = $request->getParsedBody();
         $encrypted = (string) $parameters['encrypted'];
-        $hashed = (string) $parameters['hashed'];
         $count = intval($parameters['start']);
-        if (empty($encrypted) || empty($hashed)) {
+        if (empty($encrypted)) {
             throw new \InvalidArgumentException('No valid parameter passed!', 1580585079);
         }
-        $core = Helper::decrypt($encrypted, $hashed);
+        $core = Helper::decrypt($encrypted);
         // Perform Solr query.
         $solr = Solr::getInstance($core);
         if ($solr->ready) {

--- a/Classes/Plugin/Eid/SearchSuggest.php
+++ b/Classes/Plugin/Eid/SearchSuggest.php
@@ -42,11 +42,10 @@ class SearchSuggest
         // Get input parameters and decrypt core name.
         $parameters = $request->getParsedBody();
         $encrypted = (string) $parameters['encrypted'];
-        $hashed = (string) $parameters['hashed'];
-        if (empty($encrypted) || empty($hashed)) {
+        if (empty($encrypted)) {
             throw new \InvalidArgumentException('No valid parameter passed!', 1580585079);
         }
-        $core = Helper::decrypt($encrypted, $hashed);
+        $core = Helper::decrypt($encrypted);
         // Perform Solr query.
         $solr = Solr::getInstance($core);
         if ($solr->ready) {

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -150,8 +150,8 @@ class Search extends \Kitodo\Dlf\Common\AbstractPlugin
             $name = Helper::encrypt($name);
         }
         // Add encrypted fields to search form.
-        if (is_array($name)) {
-            return '<input type="hidden" name="' . $this->prefixId . '[encrypted]" value="' . $name['encrypted'] . '" /><input type="hidden" name="' . $this->prefixId . '[hashed]" value="' . $name['hash'] . '" />';
+        if ($name !== false) {
+            return '<input type="hidden" name="' . $this->prefixId . '[encrypted]" value="' . $name . '" />';
         } else {
             return '';
         }

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -108,8 +108,7 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin
             '###LABEL_PAGE###' => htmlspecialchars($this->pi_getLL('label.logicalPage')),
             '###LABEL_NORESULT###' => htmlspecialchars($this->pi_getLL('label.noresult')),
             '###CURRENT_DOCUMENT###' => $this->doc->uid,
-            '###SOLR_ENCRYPTED###' => isset($encryptedSolr['encrypted']) ? $encryptedSolr['encrypted'] : '',
-            '###SOLR_HASH###' => isset($encryptedSolr['hash']) ? $encryptedSolr['hash'] : '',
+            '###SOLR_ENCRYPTED###' => $encryptedSolr ?: '',
         ];
 
         $content .= $this->templateService->substituteMarkerArray($this->template, $markerArray);
@@ -134,7 +133,7 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin
      *
      * @access protected
      *
-     * @return array with encrypted core name and hash
+     * @return string with encrypted core name
      */
     protected function getEncryptedCoreName()
     {

--- a/Resources/Private/Templates/SearchInDocumentTool.tmpl
+++ b/Resources/Private/Templates/SearchInDocumentTool.tmpl
@@ -17,7 +17,6 @@
     <input type="hidden" name="tx_dlf[start]" value="0" />
     <input type="hidden" name="tx_dlf[id]" value="###CURRENT_DOCUMENT###" />
     <input type="hidden" name="tx_dlf[encrypted]" value="###SOLR_ENCRYPTED###" />
-    <input type="hidden" name="tx_dlf[hashed]" value="###SOLR_HASH###" />
   </div>
 </form>
 <div id="tx-dlf-search-in-document-loading" style="display: none;">###LABEL_LOADING###...</div>


### PR DESCRIPTION
Currently Kitodo.Presentation uses a blowfish algorithm (`BF-CFB`) for encrypting/decrypting form data. This is considered weak nowadays (see [SonarCloud Analysis](https://sonarcloud.io/project/issues?id=kitodo-presentation&resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=VULNERABILITY)).

This pull request changes the defaults to `AES-256-CTR` as ciphering algorithm and `SHA256` as hashing algorithm.

Furthermore it removes the additional hashed value, because this opens a potential security hole and provides no real value.