### PR TITLE
Add Solr core name on calculation the cache identifier.

### DIFF
--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -428,7 +428,7 @@ class Solr
         $parameters['query'] = $query;
 
         // calculate cache identifier
-        $cacheIdentifier = hash('md5', print_r(array_merge($this->params, $parameters), 1));
+        $cacheIdentifier = hash('md5', $this->core . print_r(array_merge($this->params, $parameters), 1));
         $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('tx_dlf_solr');
 
         $resultSet = [];


### PR DESCRIPTION
As the Solr core name is not part of the parameters array and the
$this->params is empty anyhow. The cacheidentifier of same queries is
identical over different Solr cores.

This just adds the core name to the identifier calculation.

Fix for #582.