### PR TITLE
Add empty space after last span of the text line

### DIFF
--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -506,5 +506,6 @@ dlfViewerFullTextControl.prototype.appendTextLineSpan = function(textLine) {
         textLineSpan.append(span);
     }
 
+    textLineSpan.append('<span class="textline" id="sp"> </span>');
     $('#tx-dlf-fulltextselection').append(textLineSpan);
 };


### PR DESCRIPTION
There is missing white space after end of the line.

<img width="698" alt="ws" src="https://user-images.githubusercontent.com/9614459/106455849-0ad79900-648d-11eb-8bdd-58817a315267.png">
