### PR TITLE
Pass scroll id as param to method to avoid undefined value

### DIFF
--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -332,19 +332,20 @@ dlfViewerFullTextControl.prototype.addHighlightEffect = function(textlineFeature
         
         if (targetElem.length > 0 && !targetElem.hasClass('highlight')) {
             targetElem.addClass('highlight');
-            setTimeout(this.scrollToText, 1000, targetElem);
+            setTimeout(this.scrollToText, 1000, targetElem, this.fullTextScrollElement);
             hoverSourceTextline_.addFeature(textlineFeature);
         }
     }
 };
 
 /**
- * Check if full text element is highlighted
+ * Scroll to full text element if ot is highlighted
  * @param {any} element 
+ * @param {string} fullTextScrollElement
  */
-dlfViewerFullTextControl.prototype.scrollToText = function(element) {
+dlfViewerFullTextControl.prototype.scrollToText = function(element, fullTextScrollElement) {
     if (element.hasClass('highlight')) {
-        $(this.fullTextScrollElement).animate({
+        $(fullTextScrollElement).animate({
             scrollTop: element.offset().top
         }, 500);
     }

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -339,7 +339,7 @@ dlfViewerFullTextControl.prototype.addHighlightEffect = function(textlineFeature
 };
 
 /**
- * Scroll to full text element if ot is highlighted
+ * Scroll to full text element if it is highlighted
  * @param {any} element 
  * @param {string} fullTextScrollElement
  */


### PR DESCRIPTION
For some reason using `this.fullTextScrollElement` inside `scrollToText` method sometimes return undefined. To make call more reliable pass it as paramater to this method.