### PR TITLE
Remove unused scrollTo method from full text control

### DIFF
--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -9,22 +9,6 @@
  */
 
 /**
- * This is necessary to support the scrolling of the element into the viewport
- * in case of text hover on the map.
- *
- * @param elem
- * @param speed
- * @returns {jQuery}
- */
-jQuery.fn.scrollTo = function(elem, speed) {
-    var manualOffsetTop = $(elem).parent().height() / 2;
-    $(this).animate({
-        scrollTop:  $(this).scrollTop() - $(this).offset().top + $(elem).offset().top - manualOffsetTop
-    }, speed === undefined ? 1000 : speed);
-    return this;
-};
-
-/**
  * Encapsulates especially the fulltext behavior
  * @constructor
  * @param {ol.Map} map


### PR DESCRIPTION
Is it still necessary for some special cases? Scrolling works for me without it.