### PR TITLE
Remove solr.StandardFilterFactory as it is unused and breaks Solr 8.

### DIFF
--- a/Configuration/ApacheSolr/configsets/dlf/conf/schema.xml
+++ b/Configuration/ApacheSolr/configsets/dlf/conf/schema.xml
@@ -26,7 +26,6 @@ limitations under the License.
         <fieldType name="standard" class="solr.TextField" positionIncrementGap="100">
             <analyzer>
                 <tokenizer class="solr.StandardTokenizerFactory" />
-                <filter class="solr.StandardFilterFactory" />
                 <filter class="solr.LowerCaseFilterFactory" />
             </analyzer>
         </fieldType>


### PR DESCRIPTION
The StandardFilterFactory did nothing for several Solr / Lucene
version. That's why it has been removed in Solr 8.

Having this filter still in schema.xml breaks creating new dlfCores with
Solr 8.

The fix is removing standardFilterFactory.

See:
* https://stackoverflow.com/questions/56913835/upgrade-filter-in-schema-xml-with-solr-standardfilterfactory-from-existing-core
* https://github.com/apache/lucene-solr/blob/branch_8_0/lucene/CHANGES.txt
* https://issues.apache.org/jira/browse/LUCENE-8356