### PR TITLE
Highlight exact word

### DIFF
--- a/Classes/Plugin/Tools/FulltextTool.php
+++ b/Classes/Plugin/Tools/FulltextTool.php
@@ -77,7 +77,13 @@ class FulltextTool extends \Kitodo\Dlf\Common\AbstractPlugin
         $this->getTemplate();
         $fullTextFile = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['files'][$this->conf['fileGrpFulltext']];
         if (!empty($fullTextFile)) {
-            $markerArray['###FULLTEXT_SELECT###'] = '<a class="select switchoff" id="tx-dlf-tools-fulltext" title="" data-dic="fulltext:' . htmlspecialchars($this->pi_getLL('fulltext', '')) . ';fulltext-on:' . htmlspecialchars($this->pi_getLL('fulltext-on', '')) . ';fulltext-off:' . htmlspecialchars($this->pi_getLL('fulltext-off', '')) . ';activate-full-text-initially:' . MathUtility::forceIntegerInRange($this->conf['activateFullTextInitially'], 0, 1, 0) . ';full-text-scroll-element:' . $this->conf['fullTextScrollElement'] . '">&nbsp;</a>';
+            $markerArray['###FULLTEXT_SELECT###'] = '<a class="select switchoff" id="tx-dlf-tools-fulltext" title="" data-dic="'
+            . 'fulltext:' . htmlspecialchars($this->pi_getLL('fulltext', ''))
+            . ';fulltext-on:' . htmlspecialchars($this->pi_getLL('fulltext-on', ''))
+            . ';fulltext-off:' . htmlspecialchars($this->pi_getLL('fulltext-off', ''))
+            . ';activate-full-text-initially:' . MathUtility::forceIntegerInRange($this->conf['activateFullTextInitially'], 0, 1, 0)
+            . ';full-text-scroll-element:' . $this->conf['fullTextScrollElement']
+            . ';search-hl-elements:' . $this->conf['searchHlElements'] . '">&nbsp;</a>';
         } else {
             $markerArray['###FULLTEXT_SELECT###'] = '<span class="no-fulltext">' . htmlspecialchars($this->pi_getLL('fulltext-not-available', '')) . '</span>';
         }

--- a/Configuration/TypoScript/Toolbox/setup.txt
+++ b/Configuration/TypoScript/Toolbox/setup.txt
@@ -1,6 +1,7 @@
 plugin.tx_dlf_annotationtool.templateFile = EXT:dlf/Resources/Private/Templates/AnnotationTool.tmpl
 plugin.tx_dlf_fulltexttool.activateFullTextInitially = 0
 plugin.tx_dlf_fulltexttool.fullTextScrollElement = html, body
+plugin.tx_dlf_fulltexttool.searchHlElements = tx_dlf[highlight_word]
 plugin.tx_dlf_fulltexttool.templateFile = EXT:dlf/Resources/Private/Templates/FulltextTool.tmpl
 plugin.tx_dlf_fulltextdownloadtool.templateFile = EXT:dlf/Resources/Private/Templates/FulltextDownloadTool.tmpl
 plugin.tx_dlf_imagedownloadtool.templateFile = EXT:dlf/Resources/Private/Templates/ImageDownloadTool.tmpl

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -1069,9 +1069,16 @@ The default behaviour is to show the fulltext after click on the toggle link. Th
    :Data Type:
        :ref:`t3tsref:data-type-string`
    :Default:
-        html, body       
+        html, body
+
+ - :Property:
+       searchHlElements
+   :Data Type:
+       :ref:`t3tsref:data-type-string`
+   :Default:
+        tx_dlf[highlight_word]
 
 
-The fulltext is fetched and rendered by JavaSript into the `<div id="tx-dlf-fulltextselection">` of the pageview plugin.
+The fulltext is fetched and rendered by JavaScript into the `<div id="tx-dlf-fulltextselection">` of the pageview plugin.
 
-**Please note**: To allow JavaScript fetching the fulltext, the `CORS headers <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_ muste be configured appropriate on the providing webserver.
+**Please note**: To allow JavaScript fetching the fulltext, the `CORS headers <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_ must be configured appropriate on the providing webserver.

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -1037,7 +1037,9 @@ Fulltext Tool
 ^^^^^^^^^^^^^
 This plugin adds an activation link for fulltext to the toolbox. If no fulltext is available for the current page, a span-tag is rendered instead.
 
-The default behaviour is to show the fulltext after click on the toggle link. There is a TypoScript configuration to show the fulltext initially.
+The default behavior is to show the fulltext after click on the toggle link. There is a TypoScript configuration to show the fulltext initially.
+
+Plugin allows also to configure (searchHlElements) by which URL parameters words will be highlighted in the image. The first defined parameter on the configuration has highest priority, if not found it checks the next ones.
 
 :typoscript:`plugin.tx_dlf_fulltexttool.`
 

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -57,7 +57,13 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
      */
     this.dic = $('#tx-dlf-tools-fulltext').length > 0 && $('#tx-dlf-tools-fulltext').attr('data-dic') ?
         dlfUtils.parseDataDic($('#tx-dlf-tools-fulltext')) :
-        {'fulltext':'Fulltext', 'fulltext-on':'Activate Fulltext','fulltext-off':'Deactivate Fulltext', 'activate-full-text-initially':'0', 'full-text-scroll-element':'html, body'};
+        {
+            'fulltext':'Fulltext',
+            'fulltext-on':'Activate Fulltext',
+            'fulltext-off':'Deactivate Fulltext',
+            'activate-full-text-initially':'0',
+            'full-text-scroll-element':'html, body',
+            'search-hl-elements':'tx_dlf[highlight_word]'};
 
     /**
      * @type {number}
@@ -70,6 +76,12 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
      * @private
      */
     this.fullTextScrollElement = this.dic['full-text-scroll-element'];
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.searchHlElements = this.dic['search-hl-elements'];
     
     /**
      * @type {ol.Feature|undefined}

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -74,6 +74,12 @@ var dlfViewer = function(settings){
     this.highlightFieldParams = undefined;
 
     /**
+     * @type {string|undefined}
+     * @private
+     */
+    this.highlightKeys = undefined;
+
+    /**
      * @type {Object|undefined}
      * @private
      */
@@ -149,7 +155,7 @@ var dlfViewer = function(settings){
  *
  * @param {Array.<string>} controlNames
  */
-dlfViewer.prototype.addCustomControls = function(controlNames) {
+dlfViewer.prototype.addCustomControls = function() {
     var fulltextControl = undefined,
         fulltextDownloadControl = undefined,
         annotationControl = undefined,
@@ -161,6 +167,7 @@ dlfViewer.prototype.addCustomControls = function(controlNames) {
     if (this.fulltexts[0] !== undefined && this.fulltexts[0].length !== 0 && this.fulltexts[0].url !== '' && this.images.length === 1) {
         fulltextControl = new dlfViewerFullTextControl(this.map, this.images[0], this.fulltexts[0].url);
         fulltextDownloadControl = new dlfViewerFullTextDownloadControl(this.map, this.images[0], this.fulltexts[0].url);
+        this.highlightKeys = fulltextControl.searchHlElements;
     } else {
         $('#tx-dlf-tools-fulltext').remove();
     }
@@ -280,7 +287,7 @@ dlfViewer.prototype.createControls_ = function(controlNames, layers) {
 };
 
 /**
- * Displayes highlight words
+ * Displays highlight words
  */
 dlfViewer.prototype.displayHighlightWord = function() {
 
@@ -322,12 +329,24 @@ dlfViewer.prototype.displayHighlightWord = function() {
         }
     }
 
+    // check keys for which highlighting should be made
+    var keys = this.highlightKeys.split(',');
     // check if highlight by words is set
-    var key = 'tx_dlf[highlight_word]',
-        urlParams = dlfUtils.getUrlParams();
+    var urlParams = dlfUtils.getUrlParams();
 
-    if (urlParams !== undefined && urlParams.hasOwnProperty(key) && this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
-        var value = urlParams[key],
+    var hasOwnProperty = false;
+    var param = '';
+
+    for(let key of keys) {
+        if(urlParams !== undefined && urlParams.hasOwnProperty(key.trim())) {
+            hasOwnProperty = true;
+            param = key.trim();
+            break;
+        }
+    };
+
+    if (hasOwnProperty && this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
+        var value = urlParams[param],
             values = value.split(';'),
             fulltextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[0].url, this.images[0]),
             fulltextDataImageTwo = undefined;
@@ -418,10 +437,10 @@ dlfViewer.prototype.init = function(controlNames) {
                 }
             }
 
+            this.addCustomControls();
+
             // highlight word in case a highlight field is registered
             this.displayHighlightWord();
-
-            this.addCustomControls(controls);
 
             // trigger event after all has been initialize
             $(window).trigger("map-loadend", window);

--- a/Resources/Public/Javascript/PageView/Utility.js
+++ b/Resources/Public/Javascript/PageView/Utility.js
@@ -862,7 +862,36 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, opt_off
 };
 
 /**
- * Search a feature collcetion for a feature with the given text
+ * Trim text in the feature to avoid comparison against for e.g. ',' or '.'.
+ * @param {string} string
+ * @param {string} character
+ * @return {string}
+ */
+function trimByChar(string, character) {
+    const arr = Array.from(string);
+    const first = arr.findIndex((char) => char !== character);
+    const last = arr.reverse().findIndex((char) => char !== character);
+    return (first === -1 && last === -1) ? '' : string.substring(first, string.length - last);
+}
+
+/**
+ * Trim text in the feature to avoid comparison against given list of chars.
+ * @param {string} string
+ * @param {Array} characters
+ * @return {string}
+ */
+function trimByChars(string, characters) {
+    var trimmed = string;
+
+    for (const character of characters) {
+        trimmed = trimByChar(trimmed, character);
+    }
+
+    return trimmed;
+}
+
+/**
+ * Search a feature collection for a feature with the given text
  * @param {Array.<ol.Feature>} featureCollection
  * @param {string} text
  * @return {Array.<ol.Feature>|undefined}
@@ -871,7 +900,13 @@ dlfUtils.searchFeatureCollectionForText = function (featureCollection, text) {
     var features = [];
     featureCollection.forEach(function (ft) {
         if (ft.get('fulltext') !== undefined) {
-            if (ft.get('fulltext').toLowerCase().indexOf(text.toLowerCase()) > -1) features.push(ft);
+            var trimmedFt = trimByChars(
+                ft.get('fulltext'),
+                [',', '.', ';', ':', '-', '\'', '"', '!', '?', '(', ')', '[', ']']
+                );
+            if (trimmedFt.toLowerCase() == text.toLowerCase()) {
+                features.push(ft);
+            }
         }
     });
     return features.length > 0 ? features : undefined;

--- a/Resources/Public/Javascript/PageView/Utility.js
+++ b/Resources/Public/Javascript/PageView/Utility.js
@@ -904,7 +904,7 @@ dlfUtils.searchFeatureCollectionForText = function (featureCollection, text) {
                 ft.get('fulltext'),
                 [',', '.', ';', ':', '-', '\'', '"', '!', '?', '(', ')', '[', ']']
                 );
-            if (trimmedFt.toLowerCase() == text.toLowerCase()) {
+            if (trimmedFt.toLowerCase() === text.toLowerCase()) {
                 features.push(ft);
             }
         }


### PR DESCRIPTION
DDB has reported that highlight of the found word includes words which should not be there. 

Example:
`the` will highlight also '**the**ir', '**the**y' or '**The**odore'.

Depends on #588 

