### PR TITLE
Fix interaction initialization for OL map

### DIFF
--- a/Resources/Public/Javascript/PageView/ImageManipulationControl.js
+++ b/Resources/Public/Javascript/PageView/ImageManipulationControl.js
@@ -293,7 +293,7 @@ dlfViewerImageManipulationControl.prototype.createMap_ = function() {
             new ol.interaction.PinchZoom(),
             new ol.interaction.MouseWheelZoom(),
             new ol.interaction.KeyboardPan(),
-            new ol.interaction.KeyboardZoom,
+            new ol.interaction.KeyboardZoom(),
             new ol.interaction.DragRotateAndZoom()
         ],
         // necessary for proper working of the keyboard events

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -397,7 +397,7 @@ dlfViewer.prototype.init = function(controlNames) {
                     new ol.interaction.PinchZoom(),
                     new ol.interaction.MouseWheelZoom(),
                     new ol.interaction.KeyboardPan(),
-                    new ol.interaction.KeyboardZoom,
+                    new ol.interaction.KeyboardZoom(),
                     new ol.interaction.DragRotateAndZoom()
                 ],
                 // necessary for proper working of the keyboard events


### PR DESCRIPTION
It looks that missing brackets were causing problems and sometimes method zoomTo on this.map was throwing error.