### PR TITLE
Show all subparts in collection view

### DIFF
--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -1169,7 +1169,10 @@ abstract class Document
                 $metadata['volume'] = $metadata['year'];
             }
             if (empty($metadata['volume_sorting'][0])) {
-                if (!empty($metadata['year_sorting'][0])) {
+                // If mets ORDER label is given it is prefered over year_sorting and year.
+                if (!empty($metadata['mets_order'][0])) {
+                    $metadata['volume_sorting'][0] = $metadata['mets_order'][0];
+                } elseif (!empty($metadata['year_sorting'][0])) {
                     $metadata['volume_sorting'][0] = $metadata['year_sorting'][0];
                 } elseif (!empty($metadata['year'][0])) {
                     $metadata['volume_sorting'][0] = $metadata['year'][0];
@@ -1249,6 +1252,7 @@ abstract class Document
             'collections' => $metadata['collection'],
             'mets_label' => $metadata['mets_label'][0],
             'mets_orderlabel' => $metadata['mets_orderlabel'][0],
+            'mets_order' => $metadata['mets_order'][0],
             'owner' => $metadata['owner'][0],
             'solrcore' => $core,
             'status' => 0,

--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -1178,10 +1178,12 @@ abstract class Document
                     $metadata['volume_sorting'][0] = $metadata['year'][0];
                 }
             }
-            // If volume_sorting is still empty, try to use title_sorting finally (workaround for newspapers)
+            // If volume_sorting is still empty, try to use title_sorting or mets_orderlabel finally (workaround for newspapers)
             if (empty($metadata['volume_sorting'][0])) {
                 if (!empty($metadata['title_sorting'][0])) {
                     $metadata['volume_sorting'][0] = $metadata['title_sorting'][0];
+                } elseif (!empty($metadata['mets_orderlabel'][0])) {
+                    $metadata['volume_sorting'][0] = $metadata['mets_orderlabel'][0];
                 }
             }
         }

--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -1169,7 +1169,7 @@ abstract class Document
                 $metadata['volume'] = $metadata['year'];
             }
             if (empty($metadata['volume_sorting'][0])) {
-                // If mets ORDER label is given it is prefered over year_sorting and year.
+                // If METS @ORDER is given it is preferred over year_sorting and year.
                 if (!empty($metadata['mets_order'][0])) {
                     $metadata['volume_sorting'][0] = $metadata['mets_order'][0];
                 } elseif (!empty($metadata['year_sorting'][0])) {
@@ -1178,7 +1178,7 @@ abstract class Document
                     $metadata['volume_sorting'][0] = $metadata['year'][0];
                 }
             }
-            // If volume_sorting is still empty, try to use title_sorting or mets_orderlabel finally (workaround for newspapers)
+            // If volume_sorting is still empty, try to use title_sorting or METS @ORDERLABEL finally (workaround for newspapers)
             if (empty($metadata['volume_sorting'][0])) {
                 if (!empty($metadata['title_sorting'][0])) {
                     $metadata['volume_sorting'][0] = $metadata['title_sorting'][0];

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -131,6 +131,7 @@ final class MetsDocument extends Document
     {
         $details = $this->getLogicalStructure($id);
         if (!empty($details)) {
+            $metadata['mets_order'][0] = $details['order'];
             $metadata['mets_label'][0] = $details['label'];
             $metadata['mets_orderlabel'][0] = $details['orderlabel'];
         }

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -404,7 +404,7 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
                 ];
             } else {
                 // volume_sorting should be always set - but it's not a required field. We append the uid to the array key to make it always unique.
-                $subparts[$resArray['partof']][$resArray['volume_sorting'] . $resArray['uid']] = [
+                $subparts[$resArray['partof']][$resArray['volume_sorting'] . str_pad($resArray['uid'], 9, '0', STR_PAD_LEFT)] = [
                     'u' => $resArray['uid'],
                     'h' => '',
                     's' => $sorting,

--- a/Classes/Plugin/Collection.php
+++ b/Classes/Plugin/Collection.php
@@ -403,7 +403,8 @@ class Collection extends \Kitodo\Dlf\Common\AbstractPlugin
                     'p' => []
                 ];
             } else {
-                $subparts[$resArray['partof']][$resArray['volume_sorting']] = [
+                // volume_sorting should be always set - but it's not a required field. We append the uid to the array key to make it always unique.
+                $subparts[$resArray['partof']][$resArray['volume_sorting'] . $resArray['uid']] = [
                     'u' => $resArray['uid'],
                     'h' => '',
                     's' => $sorting,


### PR DESCRIPTION
This will fix #559.

### Case 1 - year_sorting is not unique

Examples:

* https://digital.slub-dresden.de/data/kitodo/Dien_1683658167_0006/Dien_1683658167_0006_mets.xml
* https://digital.slub-dresden.de/data/kitodo/Dien_1683659783_0008/Dien_1683659783_0008_mets.xml

Both have `year_sorting == 1900`

### Case 2 - Newspaper/Ephemera structure year

Examples:

* https://digital.slub-dresden.de/data/kitodo/Brsfded_39946221X-19450106/Brsfded_39946221X-19450106_year.xml
* https://digital.slub-dresden.de/data/kitodo/Brsfded_39946221X-19441202/Brsfded_39946221X-19441202_year.xml

Both have no `title` or `title_sorting` set.

### Case 3 - other reasons

For possible other reasons why the volume_sorting is missing, the collection plugin adds the uid to the array key of the subparts to list. This makes sure to list all subparts even if the order may be wrong.