### PR TITLE
Fix deprecation 82254 and drop support for TYPO3 8.7

### DIFF
--- a/Classes/Common/AbstractModule.php
+++ b/Classes/Common/AbstractModule.php
@@ -12,6 +12,9 @@
 
 namespace Kitodo\Dlf\Common;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Abstract module class for the 'dlf' extension
  *
@@ -96,7 +99,7 @@ abstract class AbstractModule extends \TYPO3\CMS\Backend\Module\BaseScriptClass
      */
     protected function printContent()
     {
-        $this->doc = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Template\DocumentTemplate::class);
+        $this->doc = GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Template\DocumentTemplate::class);
         $this->doc->setModuleTemplate('EXT:' . $this->extKey . '/Resources/Private/Templates/' . Helper::getUnqualifiedClassName(get_class($this)) . '.tmpl');
         $this->doc->backPath = $GLOBALS['BACK_PATH'];
         $this->doc->bodyTagAdditions = 'class="ext-' . $this->extKey . '-modules"';
@@ -129,7 +132,7 @@ abstract class AbstractModule extends \TYPO3\CMS\Backend\Module\BaseScriptClass
     public function __construct()
     {
         $GLOBALS['LANG']->includeLLFile('EXT:' . $this->extKey . '/Resources/Private/Language/' . Helper::getUnqualifiedClassName(get_class($this)) . '.xml');
-        $this->conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey]);
-        $this->data = \TYPO3\CMS\Core\Utility\GeneralUtility::_GPmerged($this->prefixId);
+        $this->conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
+        $this->data = GeneralUtility::_GPmerged($this->prefixId);
     }
 }

--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Common;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -112,7 +113,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
             $conf = Helper::mergeRecursiveWithOverrule($generalConf, $conf);
         }
         // Read extension configuration.
-        $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey]);
+        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
         if (is_array($extConf)) {
             $conf = Helper::mergeRecursiveWithOverrule($extConf, $conf);
         }

--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Common;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -498,7 +499,7 @@ abstract class Document
             // Try to load a file from the url
             if (GeneralUtility::isValidUrl($location)) {
                 // Load extension configuration
-                $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']);
+                $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
                 // Set user-agent to identify self when fetching XML data.
                 if (!empty($extConf['useragent'])) {
                     @ini_set('user_agent', $extConf['useragent']);
@@ -526,7 +527,7 @@ abstract class Document
                         $contentAsJsonArray = json_decode($content, true);
                         if ($contentAsJsonArray !== null) {
                             // Load plugin configuration.
-                            $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+                            $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
                             IiifHelper::setUrlReader(IiifUrlReader::getInstance());
                             IiifHelper::setMaxThumbnailHeight($conf['iiifThumbnailHeight']);
                             IiifHelper::setMaxThumbnailWidth($conf['iiifThumbnailWidth']);
@@ -555,7 +556,7 @@ abstract class Document
                 self::$registry[Helper::digest($instance->location)] = $instance;
             }
             // Load extension configuration
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             // Save registry to session if caching is enabled.
             if (!empty($extConf['caching'])) {
                 Helper::saveToSession(self::$registry, get_class($instance));
@@ -661,7 +662,7 @@ abstract class Document
         // ... physical structure ...
         $this->_getPhysicalStructure();
         // ... and extension configuration.
-        $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
         $fileGrpsFulltext = GeneralUtility::trimExplode(',', $extConf['fileGrpFulltext']);
         if (!empty($this->physicalStructureInfo[$id])) {
             while ($fileGrpFulltext = array_shift($fileGrpsFulltext)) {
@@ -894,7 +895,7 @@ abstract class Document
         // Load XML / JSON-LD file.
         if (\TYPO3\CMS\Core\Utility\GeneralUtility::isValidUrl($location)) {
             // Load extension configuration
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             // Set user-agent to identify self when fetching XML / JSON-LD data.
             if (!empty($extConf['useragent'])) {
                 @ini_set('user_agent', $extConf['useragent']);
@@ -1028,7 +1029,7 @@ abstract class Document
             return false;
         }
         // Load plugin configuration.
-        $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+        $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_dlf_structures');

--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -13,6 +13,7 @@
 namespace Kitodo\Dlf\Common;
 
 use Flow\JSONPath\JSONPath;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Ubl\Iiif\Presentation\Common\Model\Resources\AnnotationContainerInterface;
@@ -229,7 +230,7 @@ final class IiifManifest extends Document
     {
         if (!$this->useGrpsLoaded) {
             // Get configured USE attributes.
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             if (!empty($extConf['fileGrpImages'])) {
                 $this->useGrps['fileGrpImages'] = GeneralUtility::trimExplode(',', $extConf['fileGrpImages']);
             }
@@ -261,7 +262,7 @@ final class IiifManifest extends Document
             if ($this->iiif == null || !($this->iiif instanceof ManifestInterface)) {
                 return null;
             }
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             $iiifId = $this->iiif->getId();
             $physSeq[0] = $iiifId;
             $this->physicalStructureInfo[$physSeq[0]]['id'] = $iiifId;
@@ -799,7 +800,7 @@ final class IiifManifest extends Document
             // Load physical structure ...
             $this->_getPhysicalStructure();
             // ... and extension configuration.
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             $fileGrpsFulltext = GeneralUtility::trimExplode(',', $extConf['fileGrpFulltext']);
             if (!empty($this->physicalStructureInfo[$id])) {
                 while ($fileGrpFulltext = array_shift($fileGrpsFulltext)) {
@@ -867,7 +868,7 @@ final class IiifManifest extends Document
     {
         $fileResource = GeneralUtility::getUrl($location);
         if ($fileResource !== false) {
-            $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             IiifHelper::setUrlReader(IiifUrlReader::getInstance());
             IiifHelper::setMaxThumbnailHeight($conf['iiifThumbnailHeight']);
             IiifHelper::setMaxThumbnailWidth($conf['iiifThumbnailWidth']);
@@ -930,7 +931,7 @@ final class IiifManifest extends Document
                     $this->hasFulltext = true;
                     return;
                 }
-                $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+                $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
                 if ($extConf['indexAnnotations'] == 1 && !empty($canvas->getPossibleTextAnnotationContainers(Motivation::PAINTING))) {
                     foreach ($canvas->getPossibleTextAnnotationContainers(Motivation::PAINTING) as $annotationContainer) {
                         if (($textAnnotations = $annotationContainer->getTextAnnotations(Motivation::PAINTING)) != null) {
@@ -986,7 +987,7 @@ final class IiifManifest extends Document
      */
     public function __wakeup()
     {
-        $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+        $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
         IiifHelper::setUrlReader(IiifUrlReader::getInstance());
         IiifHelper::setMaxThumbnailHeight($conf['iiifThumbnailHeight']);
         IiifHelper::setMaxThumbnailWidth($conf['iiifThumbnailWidth']);

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Common;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -435,7 +436,7 @@ class Indexer
             && $fulltext = $doc->getRawText($physicalUnit['id'])
         ) {
             // Read extension configuration.
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             // Create new Solr document.
             $updateQuery = self::$solr->service->createUpdate();
             $solrDoc = $updateQuery->createDocument();

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Common;
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -169,7 +170,7 @@ final class MetsDocument extends Document
         $fileLocation = $this->getFileLocation($id);
         if ($fileMimeType === 'application/vnd.kitodo.iiif') {
             $fileLocation = (strrpos($fileLocation, 'info.json') === strlen($fileLocation) - 9) ? $fileLocation : (strrpos($fileLocation, '/') === strlen($fileLocation) ? $fileLocation . 'info.json' : $fileLocation . '/info.json');
-            $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             IiifHelper::setUrlReader(IiifUrlReader::getInstance());
             IiifHelper::setMaxThumbnailHeight($conf['iiifThumbnailHeight']);
             IiifHelper::setMaxThumbnailWidth($conf['iiifThumbnailWidth']);
@@ -273,7 +274,7 @@ final class MetsDocument extends Document
             $attributes[$attribute] = (string) $value;
         }
         // Load plugin configuration.
-        $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
         // Extract identity information.
         $details = [];
         $details['id'] = $attributes['ID'];
@@ -846,7 +847,7 @@ final class MetsDocument extends Document
     {
         if (!$this->fileGrpsLoaded) {
             // Get configured USE attributes.
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             $useGrps = GeneralUtility::trimExplode(',', $extConf['fileGrpImages']);
             if (!empty($extConf['fileGrpThumbs'])) {
                 $useGrps = array_merge($useGrps, GeneralUtility::trimExplode(',', $extConf['fileGrpThumbs']));
@@ -1010,7 +1011,7 @@ final class MetsDocument extends Document
                 return $this->thumbnail;
             }
             // Load extension configuration.
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             if (empty($extConf['fileGrpThumbs'])) {
                 Helper::devLog('No fileGrp for thumbnails specified', DEVLOG_SEVERITY_WARNING);
                 $this->thumbnailLoaded = true;

--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -13,6 +13,7 @@
 namespace Kitodo\Dlf\Common;
 
 use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -314,7 +315,7 @@ class Solr
         if (empty($this->config)) {
             $config = [];
             // Extract extension configuration.
-            $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::$extKey]);
+            $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             // Derive Solr scheme
             $config['scheme'] = empty($conf['solrHttps']) ? 'http' : 'https';
             // Derive Solr host name.

--- a/Classes/Hooks/ConfigurationForm.php
+++ b/Classes/Hooks/ConfigurationForm.php
@@ -14,6 +14,7 @@ namespace Kitodo\Dlf\Hooks;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -207,6 +208,6 @@ class ConfigurationForm
         // Load localization file.
         $GLOBALS['LANG']->includeLLFile('EXT:dlf/Resources/Private/Language/FlashMessages.xml');
         // Get current configuration.
-        $this->conf = array_merge((array) unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']), (array) \TYPO3\CMS\Core\Utility\GeneralUtility::_POST('data'));
+        $this->conf = array_merge(GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('dlf'), (array) \TYPO3\CMS\Core\Utility\GeneralUtility::_POST('data'));
     }
 }

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -16,6 +16,7 @@ use Kitodo\Dlf\Common\Document;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Indexer;
 use Kitodo\Dlf\Common\Solr;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -328,7 +329,7 @@ class DataHandler
             && $table == 'tx_dlf_solrcores'
         ) {
             // Is core deletion allowed in extension configuration?
-            $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['dlf']);
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('dlf');
             if (!empty($extConf['solrAllowCoreDelete'])) {
                 // Delete core from Apache Solr as well.
                 $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     "ext-libxml": "*",
     "ext-openssl": "*",
     "ext-simplexml": "*",
-    "typo3/cms-core": "~8.7.32|~9.5.26",
-    "typo3/cms-tstemplate": "~8.7.32|~9.5.26",
+    "typo3/cms-core": "~9.5.26",
+    "typo3/cms-tstemplate": "~9.5.26",
     "ubl/php-iiif-prezi-reader": "0.3.0",
     "solarium/solarium": "^4.2|^5.2"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,12 +13,12 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Kitodo.Presentation',
     'description' => 'Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.',
-    'version' => '3.2.0',
+    'version' => '3.3.0',
     'category' => 'misc',
     'constraints' => [
         'depends' => [
             'php' => '7.3.0-7.4.99',
-            'typo3' => '8.7.0-9.5.99'
+            'typo3' => '9.5.0-9.5.99'
         ],
         'conflicts' => [],
         'suggests' => []

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -23,12 +23,7 @@ if (\TYPO3_MODE === 'BE') {
             'name' => 'tools_dlfNewTenantModule',
             'icon' => 'EXT:dlf/Resources/Public/Icons/Extension.svg',
             'labels' => 'LLL:EXT:dlf/Resources/Private/Language/NewTenant.xml',
-            /**
-             * 'navigationComponentId' => 'typo3-pagetree' is marked deprecated
-             * in TYPO3 9. Use 'TYPO3/CMS/Backend/PageTree/PageTreeElement'
-             * instead. Keeping old setting for compatibility with TYPO3 8.7.
-             */
-            'navigationComponentId' => 'typo3-pagetree'
+            'navigationComponentId' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement'
         ]
     );
 }


### PR DESCRIPTION
This fixes two minor deprecation warning and starts dropping TYPO3 8.7 support.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Deprecation-82254-DeprecateGLOBALSTYPO3_CONF_VARSEXTextConf.html

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Feature-82426-NewNavigationModuleRegistrationEgPageTree.html