### PR TITLE
Check for extension configuration before access.

### DIFF
--- a/Classes/Common/AbstractModule.php
+++ b/Classes/Common/AbstractModule.php
@@ -132,7 +132,10 @@ abstract class AbstractModule extends \TYPO3\CMS\Backend\Module\BaseScriptClass
     public function __construct()
     {
         $GLOBALS['LANG']->includeLLFile('EXT:' . $this->extKey . '/Resources/Private/Language/' . Helper::getUnqualifiedClassName(get_class($this)) . '.xml');
-        $this->conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
+        // Read extension configuration.
+        if (isset($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey]) && is_array($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey])) {
+            $this->conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
+        }
         $this->data = GeneralUtility::_GPmerged($this->prefixId);
     }
 }

--- a/Classes/Common/AbstractModule.php
+++ b/Classes/Common/AbstractModule.php
@@ -133,7 +133,7 @@ abstract class AbstractModule extends \TYPO3\CMS\Backend\Module\BaseScriptClass
     {
         $GLOBALS['LANG']->includeLLFile('EXT:' . $this->extKey . '/Resources/Private/Language/' . Helper::getUnqualifiedClassName(get_class($this)) . '.xml');
         // Read extension configuration.
-        if (isset($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey]) && is_array($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey])) {
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey]) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey])) {
             $this->conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
         }
         $this->data = GeneralUtility::_GPmerged($this->prefixId);

--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -113,7 +113,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
             $conf = Helper::mergeRecursiveWithOverrule($generalConf, $conf);
         }
         // Read extension configuration.
-        if (isset($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey]) && is_array($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey])) {
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey]) && is_array($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey])) {
             $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
             if (is_array($extConf)) {
                 $conf = Helper::mergeRecursiveWithOverrule($extConf, $conf);

--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -113,14 +113,11 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
             $conf = Helper::mergeRecursiveWithOverrule($generalConf, $conf);
         }
         // Read extension configuration.
-        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
-        if (is_array($extConf)) {
-            $conf = Helper::mergeRecursiveWithOverrule($extConf, $conf);
-        }
-        // Read TYPO3_CONF_VARS configuration.
-        $varsConf = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][$this->extKey];
-        if (is_array($varsConf)) {
-            $conf = Helper::mergeRecursiveWithOverrule($varsConf, $conf);
+        if (isset($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey]) && is_array($‪GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extKey])) {
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get($this->extKey);
+            if (is_array($extConf)) {
+                $conf = Helper::mergeRecursiveWithOverrule($extConf, $conf);
+            }
         }
         $this->conf = $conf;
         // Set default plugin variables.


### PR DESCRIPTION
From TYPO3 10.4 a protected method `ExtensionConfiguration::hasConfiguration()` is introduced to check the availability of the extnension configuration before access. Anyway, an excep
tion is thrown if the configuration is not present.

Bis patch will check like the `hasConfiguration()` method before `get()`.

The deprecation note #82254 tells us that the array $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'] is deprecated and has been _replaced_ by $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']. So there is no need to access this array after `ExtensionConfiguration::get()` as we have already done it.

This will fix #613.