### PR TITLE
Add classes for highlight of SOLR search results

### DIFF
--- a/Classes/Common/SolrSearchResult/Highlight.php
+++ b/Classes/Common/SolrSearchResult/Highlight.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common\SolrSearchResult;
+
+/**
+ * Highlight class for the 'dlf' extension. It keeps highlight for found search phrase.
+ *
+ * @author Beatrycze Volk <beatrycze.volk@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class Highlight {
+
+    /**
+     * The identifier in form 'w_h_x_y'
+     *
+     * @var string
+     * @access private
+     */
+    private $id;
+
+    /**
+     * The parent region's identifier
+     *
+     * @var int
+     * @access private
+     */
+    private $parentRegionId;
+
+    /**
+     * The horizontal beginning position of found highlight
+     *
+     * @var int
+     * @access private
+     */
+    private $xBeginPosition;
+
+    /**
+     * The horizontal ending position of found highlight
+     *
+     * @var int
+     * @access private
+     */
+    private $xEndPosition;
+
+    /**
+     * The vertical beginning position of found highlight
+     *
+     * @var int
+     * @access private
+     */
+    private $yBeginPosition;
+
+    /**
+     * The vertical ending position of found highlight
+     *
+     * @var int
+     * @access private
+     */
+    private $yEndPosition;
+
+    /**
+     * The width of found highlight
+     *
+     * @var int
+     * @access private
+     */
+    private $width;
+
+    /**
+     * The height of found highlight
+     *
+     * @var int
+     * @access private
+     */
+    private $height;
+
+    /**
+     * The constructor for highlight.
+     *
+     * @access public
+     *
+     * @param array $highlight: Array of found highlight properties
+     *
+     * @return void
+     */
+    public function __construct($highlight) {
+        $this->parentRegionId = $highlight['parentRegionIdx'];
+        $this->xBeginPosition = $highlight['ulx'];
+        $this->xEndPosition = $highlight['lrx'];
+        $this->yBeginPosition = $highlight['uly'];
+        $this->yEndPosition = $highlight['lry'];
+        $this->width = $highlight['lrx'] - $highlight['ulx'];
+        $this->height = $highlight['lry'] - $highlight['uly'];
+        $this->id = $this->width . '_' . $this->height . '_' . $this->xBeginPosition . '_' . $this->yBeginPosition;
+    }
+
+    /**
+     * Get the highlight's identifier.
+     *
+     * @access public
+     *
+     * @return string The highlight's identifier
+     */
+    public function getId() {
+        return $this->id;
+    }
+
+    /**
+     * Get the highlight's horizontal beginning position.
+     *
+     * @access public
+     *
+     * @return int The highlight's horizontal beginning position
+     */
+    public function getXBeginPosition() {
+        return $this->xBeginPosition;
+    }
+
+    /**
+     * Get the highlight's horizontal ending position.
+     *
+     * @access public
+     *
+     * @return int The highlight's horizontal ending position
+     */
+    public function getXEndPosition() {
+        return $this->xEndPosition;
+    }
+
+    /**
+     * Get the highlight's vertical beginning position.
+     *
+     * @access public
+     *
+     * @return int The highlight's vertical beginning position
+     */
+    public function getYBeginPosition() {
+        return $this->yBeginPosition;
+    }
+
+    /**
+     * Get the highlight's vertical ending position.
+     *
+     * @access public
+     *
+     * @return int The highlight's vertical ending position
+     */
+    public function getYEndPosition() {
+        return $this->yEndPosition;
+    }
+
+    /**
+     * Get the highlight's width.
+     *
+     * @access public
+     *
+     * @return int The highlight's width
+     */
+    public function getWidth() {
+        return $this->width;
+    }
+
+    /**
+     * Get the highlight's height.
+     *
+     * @access public
+     *
+     * @return int The highlight's height
+     */
+    public function getHeight() {
+        return $this->height;
+    }
+}

--- a/Classes/Common/SolrSearchResult/Highlight.php
+++ b/Classes/Common/SolrSearchResult/Highlight.php
@@ -20,7 +20,8 @@ namespace Kitodo\Dlf\Common\SolrSearchResult;
  * @subpackage dlf
  * @access public
  */
-class Highlight {
+class Highlight
+{
 
     /**
      * The identifier in form 'w_h_x_y'
@@ -95,7 +96,8 @@ class Highlight {
      *
      * @return void
      */
-    public function __construct($highlight) {
+    public function __construct($highlight)
+    {
         $this->parentRegionId = $highlight['parentRegionIdx'];
         $this->xBeginPosition = $highlight['ulx'];
         $this->xEndPosition = $highlight['lrx'];
@@ -113,7 +115,8 @@ class Highlight {
      *
      * @return string The highlight's identifier
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -124,7 +127,8 @@ class Highlight {
      *
      * @return int The highlight's horizontal beginning position
      */
-    public function getXBeginPosition() {
+    public function getXBeginPosition()
+    {
         return $this->xBeginPosition;
     }
 
@@ -135,7 +139,8 @@ class Highlight {
      *
      * @return int The highlight's horizontal ending position
      */
-    public function getXEndPosition() {
+    public function getXEndPosition()
+    {
         return $this->xEndPosition;
     }
 
@@ -146,7 +151,8 @@ class Highlight {
      *
      * @return int The highlight's vertical beginning position
      */
-    public function getYBeginPosition() {
+    public function getYBeginPosition()
+    {
         return $this->yBeginPosition;
     }
 
@@ -157,7 +163,8 @@ class Highlight {
      *
      * @return int The highlight's vertical ending position
      */
-    public function getYEndPosition() {
+    public function getYEndPosition()
+    {
         return $this->yEndPosition;
     }
 
@@ -168,7 +175,8 @@ class Highlight {
      *
      * @return int The highlight's width
      */
-    public function getWidth() {
+    public function getWidth()
+    {
         return $this->width;
     }
 
@@ -179,7 +187,8 @@ class Highlight {
      *
      * @return int The highlight's height
      */
-    public function getHeight() {
+    public function getHeight()
+    {
         return $this->height;
     }
 }

--- a/Classes/Common/SolrSearchResult/Page.php
+++ b/Classes/Common/SolrSearchResult/Page.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common\SolrSearchResult;
+
+/**
+ * Page class for the 'dlf' extension. It keeps page in which search phrase was found.
+ *
+ * @author Beatrycze Volk <beatrycze.volk@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class Page {
+
+    /**
+     * The identifier of the page
+     *
+     * @var int
+     * @access private
+     */
+    private $id;
+
+    /**
+     * The name of the page
+     *
+     * @var string
+     * @access private
+     */
+    private $name;
+
+    /**
+     * The width of found page
+     *
+     * @var int
+     * @access private
+     */
+    private $width;
+
+    /**
+     * The height of found page
+     *
+     * @var int
+     * @access private
+     */
+    private $height;
+
+    /**
+     * The constructor for region.
+     *
+     * @access public
+     *
+     * @param int $id: Id of found page properties
+     * @param array $page: Array of found page properties
+     *
+     * @return void
+     */
+    public function __construct($id, $page) {
+        $this->id = $id;
+        $this->name = $page['id'];
+        $this->width = $page['width'];
+        $this->height = $page['height'];
+    }
+
+    /**
+     * Get the page's identifier.
+     *
+     * @access public
+     *
+     * @return int The page's identifier
+     */
+    public function getId() {
+        return $this->id;
+    }
+
+    /**
+     * Get the page's name.
+     *
+     * @access public
+     *
+     * @return string The page's name
+     */
+    public function getName() {
+        return $this->name;
+    }
+
+    /**
+     * Get the page's width.
+     *
+     * @access public
+     *
+     * @return int The page's width
+     */
+    public function getWidth() {
+        return $this->width;
+    }
+
+    /**
+     * Get the page's height.
+     *
+     * @access public
+     *
+     * @return int The page's height
+     */
+    public function getHeight() {
+        return $this->height;
+    }
+}

--- a/Classes/Common/SolrSearchResult/Page.php
+++ b/Classes/Common/SolrSearchResult/Page.php
@@ -20,7 +20,8 @@ namespace Kitodo\Dlf\Common\SolrSearchResult;
  * @subpackage dlf
  * @access public
  */
-class Page {
+class Page
+{
 
     /**
      * The identifier of the page
@@ -64,7 +65,8 @@ class Page {
      *
      * @return void
      */
-    public function __construct($id, $page) {
+    public function __construct($id, $page)
+    {
         $this->id = $id;
         $this->name = $page['id'];
         $this->width = $page['width'];
@@ -78,7 +80,8 @@ class Page {
      *
      * @return int The page's identifier
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -89,7 +92,8 @@ class Page {
      *
      * @return string The page's name
      */
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
@@ -100,7 +104,8 @@ class Page {
      *
      * @return int The page's width
      */
-    public function getWidth() {
+    public function getWidth()
+    {
         return $this->width;
     }
 
@@ -111,7 +116,8 @@ class Page {
      *
      * @return int The page's height
      */
-    public function getHeight() {
+    public function getHeight()
+    {
         return $this->height;
     }
 }

--- a/Classes/Common/SolrSearchResult/Region.php
+++ b/Classes/Common/SolrSearchResult/Region.php
@@ -20,7 +20,8 @@ namespace Kitodo\Dlf\Common\SolrSearchResult;
  * @subpackage dlf
  * @access public
  */
-class Region {
+class Region
+{
 
     /**
      * The identifier of the region
@@ -104,7 +105,8 @@ class Region {
      *
      * @return void
      */
-    public function __construct($id, $region) {
+    public function __construct($id, $region)
+    {
         $this->id = $id;
         $this->pageId = $region['pageIdx'];
         $this->xBeginPosition = $region['ulx'];
@@ -123,7 +125,8 @@ class Region {
      *
      * @return int The region's identifier
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -134,7 +137,8 @@ class Region {
      *
      * @return int The region's page identifier
      */
-    public function getPageId() {
+    public function getPageId()
+    {
         return $this->pageId;
     }
 
@@ -145,7 +149,8 @@ class Region {
      *
      * @return int The region's horizontal beginning position
      */
-    public function getXBeginPosition() {
+    public function getXBeginPosition()
+    {
         return $this->xBeginPosition;
     }
 
@@ -156,7 +161,8 @@ class Region {
      *
      * @return int The region's horizontal ending position
      */
-    public function getXEndPosition() {
+    public function getXEndPosition()
+    {
         return $this->xEndPosition;
     }
 
@@ -167,7 +173,8 @@ class Region {
      *
      * @return int The region's vertical beginning position
      */
-    public function getYBeginPosition() {
+    public function getYBeginPosition()
+    {
         return $this->yBeginPosition;
     }
 
@@ -178,7 +185,8 @@ class Region {
      *
      * @return int The region's vertical ending position
      */
-    public function getYEndPosition() {
+    public function getYEndPosition()
+    {
         return $this->yEndPosition;
     }
 
@@ -189,7 +197,8 @@ class Region {
      *
      * @return int The region's width
      */
-    public function getWidth() {
+    public function getWidth()
+    {
         return $this->width;
     }
 
@@ -200,7 +209,8 @@ class Region {
      *
      * @return int The region's height
      */
-    public function getHeight() {
+    public function getHeight()
+    {
         return $this->height;
     }
 
@@ -211,7 +221,8 @@ class Region {
      *
      * @return string The region's text
      */
-    public function getText() {
+    public function getText()
+    {
         return $this->text;
     }
 }

--- a/Classes/Common/SolrSearchResult/Region.php
+++ b/Classes/Common/SolrSearchResult/Region.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common\SolrSearchResult;
+
+/**
+ * Region class for the 'dlf' extension. It keeps region in which search phrase was found.
+ *
+ * @author Beatrycze Volk <beatrycze.volk@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class Region {
+
+    /**
+     * The identifier of the region
+     *
+     * @var int
+     * @access private
+     */
+    private $id;
+
+    /**
+     * The identifier of the page in which text was found
+     *
+     * @var int
+     * @access private
+     */
+    private $pageId;
+
+    /**
+     * The horizontal beginning position of found region
+     *
+     * @var int
+     * @access private
+     */
+    private $xBeginPosition;
+
+    /**
+     * The horizontal ending position of found region
+     *
+     * @var int
+     * @access private
+     */
+    private $xEndPosition;
+
+    /**
+     * The vertical beginning position of found region
+     *
+     * @var int
+     * @access private
+     */
+    private $yBeginPosition;
+
+    /**
+     * The vertical ending position of found region
+     *
+     * @var int
+     * @access private
+     */
+    private $yEndPosition;
+
+    /**
+     * The width of found region
+     *
+     * @var int
+     * @access private
+     */
+    private $width;
+
+    /**
+     * The height of found region
+     *
+     * @var int
+     * @access private
+     */
+    private $height;
+
+    /**
+     * The text of found region
+     *
+     * @var string
+     * @access private
+     */
+    private $text;
+
+    /**
+     * The constructor for region.
+     *
+     * @access public
+     *
+     * @param int $id: Id of found region properties
+     * @param array $region: Array of found region properties
+     *
+     * @return void
+     */
+    public function __construct($id, $region) {
+        $this->id = $id;
+        $this->pageId = $region['pageIdx'];
+        $this->xBeginPosition = $region['ulx'];
+        $this->xEndPosition = $region['lrx'];
+        $this->yBeginPosition = $region['uly'];
+        $this->yEndPosition = $region['lry'];
+        $this->width = $region['lrx'] - $region['ulx'];
+        $this->height = $region['lry'] - $region['uly'];
+        $this->text = $region['text'];
+    }
+
+    /**
+     * Get the region's identifier.
+     *
+     * @access public
+     *
+     * @return int The region's identifier
+     */
+    public function getId() {
+        return $this->id;
+    }
+
+    /**
+     * Get the region's page identifier.
+     *
+     * @access public
+     *
+     * @return int The region's page identifier
+     */
+    public function getPageId() {
+        return $this->pageId;
+    }
+
+    /**
+     * Get the region's horizontal beginning position.
+     *
+     * @access public
+     *
+     * @return int The region's horizontal beginning position
+     */
+    public function getXBeginPosition() {
+        return $this->xBeginPosition;
+    }
+
+    /**
+     * Get the region's horizontal ending position.
+     *
+     * @access public
+     *
+     * @return int The region's horizontal ending position
+     */
+    public function getXEndPosition() {
+        return $this->xEndPosition;
+    }
+
+    /**
+     * Get the region's vertical beginning position.
+     *
+     * @access public
+     *
+     * @return int The region's vertical beginning position
+     */
+    public function getYBeginPosition() {
+        return $this->yBeginPosition;
+    }
+
+    /**
+     * Get the region's vertical ending position.
+     *
+     * @access public
+     *
+     * @return int The region's vertical ending position
+     */
+    public function getYEndPosition() {
+        return $this->yEndPosition;
+    }
+
+    /**
+     * Get the region's width.
+     *
+     * @access public
+     *
+     * @return int The region's width
+     */
+    public function getWidth() {
+        return $this->width;
+    }
+
+    /**
+     * Get the region's height.
+     *
+     * @access public
+     *
+     * @return int The region's height
+     */
+    public function getHeight() {
+        return $this->height;
+    }
+
+    /**
+     * Get the region's text.
+     *
+     * @access public
+     *
+     * @return string The region's text
+     */
+    public function getText() {
+        return $this->text;
+    }
+}

--- a/Classes/Common/SolrSearchResult/ResultDocument.php
+++ b/Classes/Common/SolrSearchResult/ResultDocument.php
@@ -24,7 +24,8 @@ use Kitodo\Dlf\Common\SolrSearchResult\Region;
  * @subpackage dlf
  * @access public
  */
-class ResultDocument {
+class ResultDocument
+{
 
     /**
      * The identifier
@@ -101,7 +102,8 @@ class ResultDocument {
      *
      * @return void
      */
-    public function __construct($record, $highlighting, $fields) {
+    public function __construct($record, $highlighting, $fields)
+    {
         $this->id = $record[$fields['id']];
         $this->uid = $record[$fields['uid']];
         $this->page = $record[$fields['page']];
@@ -122,7 +124,8 @@ class ResultDocument {
      *
      * @return string The result's record identifier
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -133,7 +136,8 @@ class ResultDocument {
      *
      * @return string|null The result's record unified identifier
      */
-    public function getUid() {
+    public function getUid()
+    {
         return $this->uid;
     }
 
@@ -144,7 +148,8 @@ class ResultDocument {
      *
      * @return int The result's record page
      */
-    public function getPage() {
+    public function getPage()
+    {
         return $this->page;
     }
 
@@ -155,7 +160,8 @@ class ResultDocument {
      *
      * @return string All result's record snippets imploded to one string
      */
-    public function getSnippets() {
+    public function getSnippets()
+    {
         return $this->snippets;
     }
 
@@ -166,7 +172,8 @@ class ResultDocument {
      *
      * @return array(Page) All result's pages which contain search phrase
      */
-    public function getPages() {
+    public function getPages()
+    {
         return $this->pages;
     }
 
@@ -177,7 +184,8 @@ class ResultDocument {
      *
      * @return array(Region) All result's regions which contain search phrase
      */
-    public function getRegions() {
+    public function getRegions()
+    {
         return $this->regions;
     }
 
@@ -188,7 +196,8 @@ class ResultDocument {
      *
      * @return array(Highlight) All result's highlights of search phrase
      */
-    public function getHighlights() {
+    public function getHighlights()
+    {
         return $this->highlights;
     }
 
@@ -199,7 +208,8 @@ class ResultDocument {
      *
      * @return array(string) All result's highlights of search phrase
      */
-    public function getHighlightsIds() {
+    public function getHighlightsIds()
+    {
         $highlightsIds = [];
         foreach ($this->highlights as $highlight) {
             array_push($highlightsIds, $highlight->getId());
@@ -215,7 +225,8 @@ class ResultDocument {
      *
      * @return void
      */
-    private function parseSnippets() {
+    private function parseSnippets()
+    {
         $snippetArray = $this->getArrayByIndex('text');
 
         $this->snippets = !empty($snippetArray) ? implode(' [...] ', $snippetArray) : '';
@@ -229,7 +240,8 @@ class ResultDocument {
      *
      * @return void
      */
-    private function parsePages() {
+    private function parsePages()
+    {
         $pageArray = $this->getArrayByIndex('pages');
 
         $i = 0;
@@ -249,7 +261,8 @@ class ResultDocument {
      *
      * @return void
      */
-    private function parseRegions() {
+    private function parseRegions()
+    {
         $regionArray = $this->getArrayByIndex('regions');
 
         $i = 0;
@@ -269,7 +282,8 @@ class ResultDocument {
      *
      * @return void
      */
-    private function parseHighlights() {
+    private function parseHighlights()
+    {
         $highlightArray = $this->getArrayByIndex('highlights');
 
         foreach ($highlightArray as $highlights) {
@@ -290,7 +304,8 @@ class ResultDocument {
      *
      * @return array
      */
-    private function getArrayByIndex($index) {
+    private function getArrayByIndex($index)
+    {
         $objectArray = [];
         foreach ($this->snippetsForRecord as $snippet) {
             array_push($objectArray, $snippet[$index]);

--- a/Classes/Common/SolrSearchResult/ResultDocument.php
+++ b/Classes/Common/SolrSearchResult/ResultDocument.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common\SolrSearchResult;
+
+use Kitodo\Dlf\Common\SolrSearchResult\Highlight;
+use Kitodo\Dlf\Common\SolrSearchResult\Page;
+use Kitodo\Dlf\Common\SolrSearchResult\Region;
+
+/**
+ * ResultDocument class for the 'dlf' extension. It keeps te result of the search in the SOLR index.
+ *
+ * @author Beatrycze Volk <beatrycze.volk@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ */
+class ResultDocument {
+
+    /**
+     * The identifier
+     *
+     * @var string
+     * @access private
+     */
+    private $id;
+
+    /**
+     * The unified identifier
+     *
+     * @var string|null
+     * @access private
+     */
+    private $uid;
+
+    /**
+     * The page on which result was found
+     *
+     * @var int
+     * @access private
+     */
+    private $page;
+
+    /**
+     * All snippets imploded to one string
+     *
+     * @var string
+     * @access private
+     */
+    private $snippets;
+
+    /**
+     * All pages in which search phrase was found
+     *
+     * @var array(Page)
+     * @access private
+     */
+    private $pages = [];
+
+    /**
+     * All regions in which search phrase was found
+     *
+     * @var array(Region)
+     * @access private
+     */
+    private $regions = [];
+
+    /**
+     * All highlights of search phrase
+     *
+     * @var array(Highlight)
+     * @access private
+     */
+    private $highlights = [];
+
+    /**
+     * The snippets for given record
+     *
+     * @var array
+     * @access private
+     */
+    private $snippetsForRecord = [];
+
+    /**
+     * The constructor for result.
+     *
+     * @access public
+     *
+     * @param array $record: Array of found document record
+     * @param array $highlighting: Array of found highlight elements
+     * @param array $fields: Array of fields used for search
+     *
+     * @return void
+     */
+    public function __construct($record, $highlighting, $fields) {
+        $this->id = $record[$fields['id']];
+        $this->uid = $record[$fields['uid']];
+        $this->page = $record[$fields['page']];
+
+        $highlightingForRecord = $highlighting[$record[$fields['id']]][$fields['fulltext']];
+        $this->snippetsForRecord = is_array($highlightingForRecord['snippets']) ? $highlightingForRecord['snippets'] : [];
+
+        $this->parseSnippets();
+        $this->parsePages();
+        $this->parseRegions();
+        $this->parseHighlights();
+    }
+
+    /**
+     * Get the result's record identifier.
+     *
+     * @access public
+     *
+     * @return string The result's record identifier
+     */
+    public function getId() {
+        return $this->id;
+    }
+
+    /**
+     * Get the result's record unified identifier.
+     *
+     * @access public
+     *
+     * @return string|null The result's record unified identifier
+     */
+    public function getUid() {
+        return $this->uid;
+    }
+
+    /**
+     * Get the result's record page.
+     *
+     * @access public
+     *
+     * @return int The result's record page
+     */
+    public function getPage() {
+        return $this->page;
+    }
+
+    /**
+     * Get all result's record snippets imploded to one string.
+     *
+     * @access public
+     *
+     * @return string All result's record snippets imploded to one string
+     */
+    public function getSnippets() {
+        return $this->snippets;
+    }
+
+    /**
+     * Get all result's pages which contain search phrase.
+     *
+     * @access public
+     *
+     * @return array(Page) All result's pages which contain search phrase
+     */
+    public function getPages() {
+        return $this->pages;
+    }
+
+    /**
+     * Get all result's regions which contain search phrase.
+     *
+     * @access public
+     *
+     * @return array(Region) All result's regions which contain search phrase
+     */
+    public function getRegions() {
+        return $this->regions;
+    }
+
+    /**
+     * Get all result's highlights of search phrase.
+     *
+     * @access public
+     *
+     * @return array(Highlight) All result's highlights of search phrase
+     */
+    public function getHighlights() {
+        return $this->highlights;
+    }
+
+    /**
+     * Get all result's highlights' ids of search phrase.
+     *
+     * @access public
+     *
+     * @return array(string) All result's highlights of search phrase
+     */
+    public function getHighlightsIds() {
+        $highlightsIds = [];
+        foreach ($this->highlights as $highlight) {
+            array_push($highlightsIds, $highlight->getId());
+        }
+        return $highlightsIds;
+    }
+
+    /**
+     * Parse snippets array to string for displaying purpose.
+     * Snippets are stored in 'text' field of 'snippets' object.
+     *
+     * @access private
+     *
+     * @return void
+     */
+    private function parseSnippets() {
+        $snippetArray = $this->getArrayByIndex('text');
+
+        $this->snippets = !empty($snippetArray) ? implode(' [...] ', $snippetArray) : '';
+    }
+
+    /**
+     * Parse pages array to array of Page objects.
+     * Pages are stored in 'pages' field of 'snippets' object.
+     *
+     * @access private
+     *
+     * @return void
+     */
+    private function parsePages() {
+        $pageArray = $this->getArrayByIndex('pages');
+
+        $i = 0;
+        foreach ($pageArray as $pages) {
+            foreach ($pages as $page) {
+                array_push($this->pages, new Page($i, $page));
+                $i++;
+            }
+        }
+    }
+
+    /**
+     * Parse regions array to array of Region objects.
+     * Regions are stored in 'regions' field of 'snippets' object.
+     *
+     * @access private
+     *
+     * @return void
+     */
+    private function parseRegions() {
+        $regionArray = $this->getArrayByIndex('regions');
+
+        $i = 0;
+        foreach ($regionArray as $regions) {
+            foreach ($regions as $region) {
+                array_push($this->regions, new Region($i, $region));
+                $i++;
+            }
+        }
+    }
+
+    /**
+     * Parse highlights array to array of Highlight objects.
+     * Highlights are stored in 'highlights' field of 'snippets' object.
+     *
+     * @access private
+     *
+     * @return void
+     */
+    private function parseHighlights() {
+        $highlightArray = $this->getArrayByIndex('highlights');
+
+        foreach ($highlightArray as $highlights) {
+            foreach ($highlights as $highlight) {
+                foreach ($highlight as $hl) {
+                    array_push($this->highlights, new Highlight($hl));
+                }
+            }
+        }
+    }
+
+    /**
+     * Get array for given index.
+     *
+     * @access private
+     *
+     * @param string $index: Name of field for which array is going be created
+     *
+     * @return array
+     */
+    private function getArrayByIndex($index) {
+        $objectArray = [];
+        foreach ($this->snippetsForRecord as $snippet) {
+            array_push($objectArray, $snippet[$index]);
+        }
+        return $objectArray;
+    }
+}


### PR DESCRIPTION
It is preparation PR for introducing OCR SOLR Highlighting Plugin. It contains classes which are going be used for parsing and displaying the results of SOLR search. They are responding to the JSON response returned from the index.

Related to #587