### PR TITLE
Fix double escaped slashes in format upgrade wizard.

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -296,9 +296,9 @@ class ext_update
     {
         $oldRecords = $this->oldFormatClasses();
         $newValues = [
-            'ALTO' => 'Kitodo\\\\Dlf\\\\Format\\\\Alto', // Those are effectively single backslashes
-            'MODS' => 'Kitodo\\\\Dlf\\\\Format\\\\Mods',
-            'TEIHDR' => 'Kitodo\\\\Dlf\\\\Format\\\\TeiHeader'
+            'ALTO' => 'Kitodo\\Dlf\\Format\\Alto', // Those are effectively single backslashes
+            'MODS' => 'Kitodo\\Dlf\\Format\\Mods',
+            'TEIHDR' => 'Kitodo\\Dlf\\Format\\TeiHeader'
         ];
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_dlf_formats');
 


### PR DESCRIPTION
In Kitodo.Presentation 2.x the `tx_dlf_formats`.`class` names have the format like `tx_dlf_alto`.

In Kitodo.Presentation 3.x the format of the namespace based classes is
like `Kitodo\Dlf\Format\Alto`.

An update wizard task is provided to convert these entries. But it adds
a double encoding of the slashes which does not work finally.

Wrong is `Kitodo\\Dlf\\Format\\Alto`.

This patch fixes this issue.