### PR TITLE
Fix check for empty resumption token

### DIFF
--- a/Classes/Plugin/OaiPmh.php
+++ b/Classes/Plugin/OaiPmh.php
@@ -440,7 +440,7 @@ class OaiPmh extends \Kitodo\Dlf\Common\AbstractPlugin
 
         $allResults = $result->fetchAll();
 
-        if (count($allResults) > 1) {
+        if (count($allResults) < 1) {
             // No resumption token found or resumption token expired.
             return $this->error('badResumptionToken');
         }


### PR DESCRIPTION
The array $allResults cannot contain more than one element because of the database query done above.

The comparison to check for a bad result is wrong at this point. If no resumption token is found, count will return 0.

This will fix #638 