### PR TITLE
Change Search Forms from POST to GET

### DIFF
--- a/Documentation/Administrator/Index.rst
+++ b/Documentation/Administrator/Index.rst
@@ -35,7 +35,7 @@ Please run the following commands in your webroot where the TYPO3 :file:`compose
 
    .. code-block:: shell
 
-      composer require kitodo/presentation:^3.2
+      composer require kitodo/presentation:^3.3
 
 #. Install and Activate the Extension
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -79,7 +79,7 @@ You may notice from time to time, the viewer page stays empty even though you
 pass the :code:`tx_dlf[id]` parameter.
 
 This happens, if someone called the viewer page without any parameters or with parameters
-without a valid cHash. In this case, TYPO3 saves the page to it's cache. If you call the
+without a valid cHash. In this case, TYPO3 saves the page to its cache. If you call the
 viewer page again with any parameter and without a cHash, the cached page is
 delivered.
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -75,7 +75,7 @@ This configuration is written to *typo3conf/LocalConfiguration.php*::
 Avoid empty Workview
 ~~~~~~~~~~~~~~~~~~~~
 
-You may notice from time to time, the viewer page keeps empty even though you
+You may notice from time to time, the viewer page stays empty even though you
 pass the :code:`tx_dlf[id]` parameter.
 
 This happens, if someone called the viewer page without any parameters or with parameters

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -36,10 +36,17 @@ After this step, the require tx_dlf_formats records are created on the root page
 TYPO3 Configuration
 ===================
 
-The navigation plugin provides a page selection dropdown input field. The
+Disable caching in certain situations
+-------------------------------------
+
+Navigation Plugin
+~~~~~~~~~~~~~~~~~
+
+The *navigation plugin* provides a page selection dropdown input field. The
 resulting action url cannot contain a valid cHash value.
 
-The default behaviour of TYPO3 is to call the pageNotFound handler and/or to show an exception:
+The default behaviour of TYPO3 is to call the pageNotFound handler and/or
+to show an exception:
 
 .. figure:: ../Images/Configuration/typo3_pagenotfoundonchasherror.png
    :width: 820px
@@ -47,11 +54,10 @@ The default behaviour of TYPO3 is to call the pageNotFound handler and/or to sho
 
    TYPO3 Error-Message "Reason: Request parameters could not be validated (&cHash empty)"
 
-This is not the desired behaviour. You should configure in
-:file:`ADMIN TOOLS -> Settings -> Configure Installation-Wide Options`
-:file:`$TYPO3_CONF_VARS['FE']['pageNotFoundOnCHashError']=0` to show the requested page
-instead. The caching will be disabled in this case. This was the default
-behaviour before TYPO3 6.x.
+This is not the desired behaviour. You should disable
+:code:`$TYPO3_CONF_VARS['FE']['pageNotFoundOnCHashError'] = 0` to show the
+requested page instead. The caching will be disabled in this case. This was
+the default behaviour before TYPO3 6.x.
 
 .. figure:: ../Images/Configuration/New\ TYPO3\ site\ \[TYPO3\ CMS\ 9.5.26\ .png
    :width: 820px
@@ -59,12 +65,40 @@ behaviour before TYPO3 6.x.
 
    TYPO3 Configuration of pageNotFoundOnCHashError in Settings Module
 
-This configuration is written to typo3conf/LocalConfiguration.php::
+This configuration is written to *typo3conf/LocalConfiguration.php*::
 
     'FE' => [
             'pageNotFoundOnCHashError' => '0',
-            'pageNotFound_handling' => '',
         ],
+
+
+Avoid empty Workview
+~~~~~~~~~~~~~~~~~~~~
+
+You may notice from time to time, the viewer page keeps empty even though you
+pass the :code:`tx_dlf[id]` parameter.
+
+This happens, if someone called the viewer page without any parameters or with parameters
+without a valid cHash. In this case, TYPO3 saves the page to it's cache. If you call the
+viewer page again with any parameter and without a cHash, the cached page is
+delivered.
+
+With the search plugin or the searchInDocument tool this may disable the search functionality.
+
+To avoid this, you must configure :code:`tx_dlf[id]` to require a cHash. Of
+course this is impossible to achieve so the system will process the page uncached.
+
+Add this setting to your *typo3conf/LocalConfiguration.php*::
+
+    'FE' => [
+        'cacheHash' => [
+            'requireCacheHashPresenceParameters' => [
+                'tx_dlf[id]',
+            ],
+        ],
+    ]
+
+Tip: Use the admin backend module: Settings -> Configure Installation-Wide Options
 
 
 TypoScript Basic Configuration

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,6 +1,6 @@
 [general]
 project = Kitodo.Presentation
-release = 3.2.0
+release = 3.3
 copyright = since 2017 by Kitodo Release Management Team
 
 [html_theme_options]

--- a/Resources/Private/Templates/Search.tmpl
+++ b/Resources/Private/Templates/Search.tmpl
@@ -8,7 +8,7 @@
  * LICENSE.txt file that was distributed with this source code.
 -->
 <!-- ###TEMPLATE### -->
-<form class="tx-dlf-search-form" action="###ACTION_URL###" method="post" enctype="multipart/form-data"><div>
+<form class="tx-dlf-search-form" action="###ACTION_URL###" method="get" enctype="multipart/form-data"><div>
     <label for="tx-dlf-search-query">###LABEL_QUERY###</label>
     <!-- Never change the @id of this input field! Otherwise search suggestions won't work! -->
     <input type="text" id="tx-dlf-search-query" name="###FIELD_QUERY###" value="###QUERY###" />

--- a/Resources/Private/Templates/SearchInDocumentTool.tmpl
+++ b/Resources/Private/Templates/SearchInDocumentTool.tmpl
@@ -8,9 +8,9 @@
  * LICENSE.txt file that was distributed with this source code.
 -->
 <!-- ###TEMPLATE### -->
-<form class="tx-dlf-search-form" id="tx-dlf-search-in-document-form" action="###ACTION_URL###" method="post" enctype="multipart/form-data">
+<form class="tx-dlf-search-form" id="tx-dlf-search-in-document-form" action="###ACTION_URL###" method="get" enctype="multipart/form-data">
   <div>
-    <label for="tx-dlf-search-query">###LABEL_QUERY###</label>
+    <label for="tx-dlf-search-in-document-query">###LABEL_QUERY###</label>
     <!-- Never change the @id of this input field! Otherwise search won't work! -->
     <input type="text" id="tx-dlf-search-in-document-query" placeholder="###LABEL_SEARCH_IN_DOCUMENT###" name="###LABEL_QUERY_URL###" />
     <input type="submit" id="tx-dlf-search-in-document-button" value="###LABEL_SUBMIT###" onclick="resetStart();" />


### PR DESCRIPTION
Search with HTTP POST may fail with TYPO3 9.5.

This is always the case, if the target page is cached by mistake. This
can easily happen, if a search engine or anyone else calls the target
page with some GET parameter but of course without a valid
cHash-parameter.

In this case, TYPO3 9.5 safes the page to cache including the wrong
parameters.

A search sending the parameters by POST will receive the cached page
though the parameter 'tx_dlf[id]' is passed which should disable
caching.

This is a know bug (comparable with [1]) and can be worked around by
sending the search parameters by HTTP GET.

[1] https://forge.typo3.org/issues/88631