### PR TITLE
Allow new solr records even without Solr connected.

### DIFF
--- a/Classes/Common/Solr.php
+++ b/Classes/Common/Solr.php
@@ -132,6 +132,8 @@ class Solr implements LoggerAwareInterface
      */
     public static function createCore($core = '')
     {
+        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
+
         // Get next available core name if none given.
         if (empty($core)) {
             $core = 'dlfCore' . self::getNextCoreNumber();
@@ -163,7 +165,7 @@ class Solr implements LoggerAwareInterface
                     // Nothing to do here.
                 }
             } else {
-                $solr->logger->error('Apache Solr not available');
+                $logger->error('Apache Solr not available');
             }
         }
         return '';

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -100,8 +100,6 @@ class DataHandler implements LoggerAwareInterface
                     $fieldArray['index_name'] = Solr::createCore();
                     if (empty($fieldArray['index_name'])) {
                         $this->logger->error('Could not create new Apache Solr core');
-                        // Solr core could not be created, thus unset field array.
-                        $fieldArray = [];
                     }
                     break;
             }

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -49,7 +49,6 @@ return [
                 'max' => 255,
                 'eval' => 'alphanum,nospace,required,unique',
                 'default' => '',
-                'readOnly' => true,
                 'fieldInformation' => [
                     'solrCoreStatus' => [
                         'renderType' => 'solrCoreStatus',


### PR DESCRIPTION
On creating a new tx_dlf_solrcores record, the corresponding core is
created on the connected Solr automatically. This is nice for the first
setup.

If you change the Solr server, move Kitodo.Presentation to a new server
or do some fancy stuff like using an external readonly Solr for search
only, you have to manipulate the tx_dlf_solrcores records 'by hand'.

This patch gives the full freedom to TYPO3 admins to create records
independantly to an established Solr connection.

As long, as there is no connection, a red banner informs the user. If
the connection is etablished later and the corresponding core is
present, the core stats is shown. This is no new feature.