### PR TITLE
Extend Document class

### DIFF
--- a/Classes/Command/HarvestCommand.php
+++ b/Classes/Command/HarvestCommand.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Connection;
 use Kitodo\Dlf\Command\BaseCommand;
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Phpoaipmh\Endpoint;
 use Phpoaipmh\Exception\BaseoaipmhException;
 

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use Kitodo\Dlf\Command\BaseCommand;
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 
 /**
  * CLI Command for indexing single documents into database and Solr.

--- a/Classes/Command/ReindexCommand.php
+++ b/Classes/Command/ReindexCommand.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use Kitodo\Dlf\Command\BaseCommand;
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 
 /**
  * CLI Command for re-indexing collections into database and Solr.

--- a/Classes/Common/AbstractPlugin.php
+++ b/Classes/Common/AbstractPlugin.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Common;
 
+use Kitodo\Dlf\Common\Document\Document;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -43,7 +44,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin 
     /**
      * This holds the current document
      *
-     * @var \Kitodo\Dlf\Common\Document
+     * @var \Kitodo\Dlf\Common\Document\Document
      * @access protected
      */
     protected $doc;
@@ -146,7 +147,7 @@ abstract class AbstractPlugin extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin 
         ) {
             // Should we exclude documents from other pages than $this->conf['pages']?
             $pid = (!empty($this->conf['excludeOther']) ? intval($this->conf['pages']) : 0);
-            // Get instance of \Kitodo\Dlf\Common\Document.
+            // Get instance of \Kitodo\Dlf\Common\Document\Document.
             $this->doc = Document::getInstance($this->piVars['id'], $pid);
             if (!$this->doc->ready) {
                 // Destroy the incomplete object.

--- a/Classes/Common/Document/Document.php
+++ b/Classes/Common/Document/Document.php
@@ -328,69 +328,6 @@ abstract class Document
     }
 
     /**
-     * This ensures that the recordId, if existent, is retrieved from the document
-     *
-     * @access protected
-     *
-     * @abstract
-     *
-     * @param int $pid: ID of the configuration page with the recordId config
-     *
-     */
-    protected abstract function establishRecordId($pid);
-
-    /**
-     * Source document PHP object which is represented by a Document instance
-     *
-     * @access protected
-     *
-     * @abstract
-     *
-     * @return \SimpleXMLElement|IiifResourceInterface An PHP object representation of
-     * the current document. SimpleXMLElement for METS, IiifResourceInterface for IIIF
-     */
-    protected abstract function getDocument();
-
-    /**
-     * This gets the location of a downloadable file for a physical page or track
-     *
-     * @access public
-     *
-     * @abstract
-     *
-     * @param string $id: The @ID attribute of the file node (METS) or the @id property of the IIIF resource
-     *
-     * @return string    The file's location as URL
-     */
-    public abstract function getDownloadLocation($id);
-
-    /**
-     * This gets the location of a file representing a physical page or track
-     *
-     * @access public
-     *
-     * @abstract
-     *
-     * @param string $id: The @ID attribute of the file node (METS) or the @id property of the IIIF resource
-     *
-     * @return string The file's location as URL
-     */
-    public abstract function getFileLocation($id);
-
-    /**
-     * This gets the MIME type of a file representing a physical page or track
-     *
-     * @access public
-     *
-     * @abstract
-     *
-     * @param string $id: The @ID attribute of the file node
-     *
-     * @return string The file's MIME type
-     */
-    public abstract function getFileMimeType($id);
-
-    /**
      * This is a singleton class, thus an instance must be created by this method
      *
      * @access public
@@ -548,19 +485,16 @@ abstract class Document
     }
 
     /**
-     * This gets details about a logical structure element
+     * Source document PHP object which is represented by a Document instance
      *
-     * @access public
+     * @access protected
      *
      * @abstract
      *
-     * @param string $id: The @ID attribute of the logical structure node (METS) or
-     * the @id property of the Manifest / Range (IIIF)
-     * @param bool $recursive: Whether to include the child elements / resources
-     *
-     * @return array Array of the element's id, label, type and physical page indexes/mptr link
+     * @return \SimpleXMLElement|IiifResourceInterface An PHP object representation of
+     * the current document. SimpleXMLElement for METS, IiifResourceInterface for IIIF
      */
-    public abstract function getLogicalStructure($id, $recursive = false);
+    protected abstract function getDocument();
 
     /**
      * This extracts all the metadata for a logical structure node
@@ -577,6 +511,60 @@ abstract class Document
      * @return array The logical structure node's / the IIIF resource's parsed metadata array
      */
     public abstract function getMetadata($id, $cPid = 0);
+
+    /**
+     * This gets the location of a downloadable file for a physical page or track
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id: The @ID attribute of the file node (METS) or the @id property of the IIIF resource
+     *
+     * @return string    The file's location as URL
+     */
+    public abstract function getDownloadLocation($id);
+
+    /**
+     * This gets the location of a file representing a physical page or track
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id: The @ID attribute of the file node (METS) or the @id property of the IIIF resource
+     *
+     * @return string The file's location as URL
+     */
+    public abstract function getFileLocation($id);
+
+    /**
+     * This gets the MIME type of a file representing a physical page or track
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id: The @ID attribute of the file node
+     *
+     * @return string The file's MIME type
+     */
+    public abstract function getFileMimeType($id);
+
+    /**
+     * This gets details about a logical structure element
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id: The @ID attribute of the logical structure node (METS) or
+     * the @id property of the Manifest / Range (IIIF)
+     * @param bool $recursive: Whether to include the child elements / resources
+     *
+     * @return array Array of the element's id, label, type and physical page indexes/mptr link
+     */
+    public abstract function getLogicalStructure($id, $recursive = false);
 
     /**
      * This returns the first corresponding physical page number of a given logical page label
@@ -673,7 +661,7 @@ abstract class Document
      *
      * @return array The logical structure node's / resource's parsed metadata array
      */
-    public function getTitledata($cPid = 0)
+    public function getTitleData($cPid = 0)
     {
         $titledata = $this->getMetadata($this->_getToplevelId(), $cPid);
         // Add information from METS structural map to titledata array.
@@ -696,33 +684,6 @@ abstract class Document
     }
 
     /**
-     * Traverse a logical (sub-) structure tree to find the structure with the requested logical id and return it's depth.
-     *
-     * @access protected
-     *
-     * @param array $structure: logical structure array
-     * @param int $depth: current tree depth
-     * @param string $logId: ID of the logical structure whose depth is requested
-     *
-     * @return int|bool: false if structure with $logId is not a child of this substructure,
-     * or the actual depth.
-     */
-    protected function getTreeDepth($structure, $depth, $logId)
-    {
-        foreach ($structure as $element) {
-            if ($element['id'] == $logId) {
-                return $depth;
-            } elseif (array_key_exists('children', $element)) {
-                $foundInChildren = $this->getTreeDepth($element['children'], $depth + 1, $logId);
-                if ($foundInChildren !== false) {
-                    return $foundInChildren;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
      * Get the tree depth of a logical structure element within the table of content
      *
      * @access public
@@ -733,109 +694,6 @@ abstract class Document
     public function getStructureDepth($logId)
     {
         return $this->getTreeDepth($this->_getTableOfContents(), 1, $logId);
-    }
-
-    /**
-     * This sets some basic class properties
-     *
-     * @access protected
-     *
-     * @abstract
-     *
-     * @return void
-     */
-    protected abstract function init();
-
-    /**
-     * Reuse any document object that might have been already loaded to determine wether document is METS or IIIF
-     *
-     * @access protected
-     *
-     * @abstract
-     *
-     * @param \SimpleXMLElement|IiifResourceInterface $preloadedDocument: any instance that has already been loaded
-     *
-     * @return bool true if $preloadedDocument can actually be reused, false if it has to be loaded again
-     */
-    protected abstract function setPreloadedDocument($preloadedDocument);
-
-    /**
-     * METS/IIIF specific part of loading a location
-     *
-     * @access protected
-     *
-     * @abstract
-     *
-     * @param string $location: The URL of the file to load
-     *
-     * @return bool true on success or false on failure
-     */
-    protected abstract function loadLocation($location);
-
-    /**
-     * Load XML file / IIIF resource from URL
-     *
-     * @access protected
-     *
-     * @param string $location: The URL of the file to load
-     *
-     * @return bool true on success or false on failure
-     */
-    protected function load($location)
-    {
-        // Load XML / JSON-LD file.
-        if (GeneralUtility::isValidUrl($location)) {
-            // Load extension configuration
-            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
-            // Set user-agent to identify self when fetching XML / JSON-LD data.
-            if (!empty($extConf['useragent'])) {
-                @ini_set('user_agent', $extConf['useragent']);
-            }
-            // the actual loading is format specific
-            return $this->loadLocation($location);
-        } else {
-            $this->logger->error('Invalid file location "' . $location . '" for document loading');
-        }
-        return false;
-    }
-
-    /**
-     * Register all available data formats
-     *
-     * @access protected
-     *
-     * @return void
-     */
-    protected function loadFormats()
-    {
-        if (!$this->formatsLoaded) {
-            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-                ->getQueryBuilderForTable('tx_dlf_formats');
-
-            // Get available data formats from database.
-            $result = $queryBuilder
-                ->select(
-                    'tx_dlf_formats.type AS type',
-                    'tx_dlf_formats.root AS root',
-                    'tx_dlf_formats.namespace AS namespace',
-                    'tx_dlf_formats.class AS class'
-                )
-                ->from('tx_dlf_formats')
-                ->where(
-                    $queryBuilder->expr()->eq('tx_dlf_formats.pid', 0)
-                )
-                ->execute();
-
-            while ($resArray = $result->fetch()) {
-                // Update format registry.
-                $this->formats[$resArray['type']] = [
-                    'rootElement' => $resArray['root'],
-                    'namespaceURI' => $resArray['namespace'],
-                    'class' => $resArray['class']
-                ];
-            }
-            $this->formatsLoaded = true;
-        }
     }
 
     /**
@@ -905,7 +763,7 @@ abstract class Document
             $this->uid = uniqid('NEW');
         }
         // Get metadata array.
-        $metadata = $this->getTitledata($pid);
+        $metadata = $this->getTitleData($pid);
         // Check for record identifier.
         if (empty($metadata['record_id'][0])) {
             $this->logger->error('No record identifier found to avoid duplication');
@@ -1187,6 +1045,18 @@ abstract class Document
     }
 
     /**
+     * This ensures that the recordId, if existent, is retrieved from the document
+     *
+     * @access protected
+     *
+     * @abstract
+     *
+     * @param int $pid: ID of the configuration page with the recordId config
+     *
+     */
+    protected abstract function establishRecordId($pid);
+
+    /**
      * Get the ID of the parent document if the current document has one. Also save a parent document
      * to the database and the Solr index if their $pid and the current $pid differ.
      * Currently only applies to METS documents.
@@ -1198,6 +1068,136 @@ abstract class Document
      * @return int The parent document's id.
      */
     protected abstract function getParentDocumentUidForSaving($pid, $core, $owner);
+
+    /**
+     * This sets some basic class properties
+     *
+     * @access protected
+     *
+     * @abstract
+     *
+     * @return void
+     */
+    protected abstract function init();
+
+    /**
+     * METS/IIIF specific part of loading a location
+     *
+     * @access protected
+     *
+     * @abstract
+     *
+     * @param string $location: The URL of the file to load
+     *
+     * @return bool true on success or false on failure
+     */
+    protected abstract function loadLocation($location);
+
+    /**
+     * Reuse any document object that might have been already loaded to determine wether document is METS or IIIF
+     *
+     * @access protected
+     *
+     * @abstract
+     *
+     * @param \SimpleXMLElement|IiifResourceInterface $preloadedDocument: any instance that has already been loaded
+     *
+     * @return bool true if $preloadedDocument can actually be reused, false if it has to be loaded again
+     */
+    protected abstract function setPreloadedDocument($preloadedDocument);
+
+    /**
+     * Load XML file / IIIF resource from URL
+     *
+     * @access protected
+     *
+     * @param string $location: The URL of the file to load
+     *
+     * @return bool true on success or false on failure
+     */
+    protected function load($location)
+    {
+        // Load XML / JSON-LD file.
+        if (GeneralUtility::isValidUrl($location)) {
+            // Load extension configuration
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
+            // Set user-agent to identify self when fetching XML / JSON-LD data.
+            if (!empty($extConf['useragent'])) {
+                @ini_set('user_agent', $extConf['useragent']);
+            }
+            // the actual loading is format specific
+            return $this->loadLocation($location);
+        } else {
+            $this->logger->error('Invalid file location "' . $location . '" for document loading');
+        }
+        return false;
+    }
+
+    /**
+     * Register all available data formats
+     *
+     * @access protected
+     *
+     * @return void
+     */
+    protected function loadFormats()
+    {
+        if (!$this->formatsLoaded) {
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getQueryBuilderForTable('tx_dlf_formats');
+
+            // Get available data formats from database.
+            $result = $queryBuilder
+                ->select(
+                    'tx_dlf_formats.type AS type',
+                    'tx_dlf_formats.root AS root',
+                    'tx_dlf_formats.namespace AS namespace',
+                    'tx_dlf_formats.class AS class'
+                )
+                ->from('tx_dlf_formats')
+                ->where(
+                    $queryBuilder->expr()->eq('tx_dlf_formats.pid', 0)
+                )
+                ->execute();
+
+            while ($resArray = $result->fetch()) {
+                // Update format registry.
+                $this->formats[$resArray['type']] = [
+                    'rootElement' => $resArray['root'],
+                    'namespaceURI' => $resArray['namespace'],
+                    'class' => $resArray['class']
+                ];
+            }
+            $this->formatsLoaded = true;
+        }
+    }
+
+    /**
+     * Traverse a logical (sub-) structure tree to find the structure with the requested logical id and return it's depth.
+     *
+     * @access protected
+     *
+     * @param array $structure: logical structure array
+     * @param int $depth: current tree depth
+     * @param string $logId: ID of the logical structure whose depth is requested
+     *
+     * @return int|bool: false if structure with $logId is not a child of this substructure,
+     * or the actual depth.
+     */
+    protected function getTreeDepth($structure, $depth, $logId)
+    {
+        foreach ($structure as $element) {
+            if ($element['id'] == $logId) {
+                return $depth;
+            } elseif (array_key_exists('children', $element)) {
+                $foundInChildren = $this->getTreeDepth($element['children'], $depth + 1, $logId);
+                if ($foundInChildren !== false) {
+                    return $foundInChildren;
+                }
+            }
+        }
+        return false;
+    }
 
     /**
      * This returns $this->cPid via __get()

--- a/Classes/Common/Document/Document.php
+++ b/Classes/Common/Document/Document.php
@@ -12,6 +12,8 @@
 
 namespace Kitodo\Dlf\Common\Document;
 
+use Kitodo\Dlf\Common\Helper;
+use Kitodo\Dlf\Common\Indexer;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;

--- a/Classes/Common/Document/FullTextDocument.php
+++ b/Classes/Common/Document/FullTextDocument.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common\Document;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Document class for the 'dlf' extension
+ *
+ * @author Beatrycze Volk <beatrycze.volk@slub-dresden.de>
+ * @package TYPO3
+ * @subpackage dlf
+ * @access public
+ * @property-read bool $hasFullText Are there any full text files available?
+ * @property array $rawTextArray array containing raw text
+ * @abstract
+ */
+abstract class FullTextDocument extends Document
+{
+    /**
+     * The extension key
+     *
+     * @var string
+     * @access public
+     */
+    public static $extKey = 'dlf';
+
+    /**
+     * Are there any fulltext files available? This also includes IIIF text annotations
+     * with motivation 'painting' if Kitodo.Presentation is configured to store text
+     * annotations as fulltext.
+     *
+     * @var bool
+     * @access protected
+     */
+    protected $hasFullText = false;
+
+    /**
+     * This holds the documents' raw text pages with their corresponding
+     * structMap//div's ID (METS) or Range / Manifest / Sequence ID (IIIF) as array key
+     *
+     * @var array
+     * @access protected
+     */
+    protected $rawTextArray = [];
+
+    /**
+     * This extracts the OCR full text for a physical structure node / IIIF Manifest / Canvas. Text might be
+     * given as ALTO for METS or as annotations or ALTO for IIIF resources.
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id: The @ID attribute of the physical structure node (METS) or the @id property
+     * of the Manifest / Range (IIIF)
+     *
+     * @return string The OCR full text
+     */
+    public abstract function getFullText($id);
+
+    /**
+     * Analyze the document if it contains any full text that needs to be indexed.
+     *
+     * @access protected
+     *
+     * @abstract
+     */
+    protected abstract function ensureHasFullTextIsSet();
+
+    /**
+     * This extracts the OCR full text for a physical structure node / IIIF Manifest / Canvas from an
+     * XML full text representation (currently only ALTO). For IIIF manifests, ALTO documents have
+     * to be given in the Canvas' / Manifest's "seeAlso" property.
+     *
+     * @param string $id: The @ID attribute of the physical structure node (METS) or the @id property
+     * of the Manifest / Range (IIIF)
+     *
+     * @return string The OCR full text
+     */
+    protected function getFullTextFromXml($id)
+    {
+        $fullText = '';
+        // Load available text formats, ...
+        $this->loadFormats();
+        // ... physical structure ...
+        $this->_getPhysicalStructure();
+        // ... and extension configuration.
+        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
+        $fileGrpsFulltext = GeneralUtility::trimExplode(',', $extConf['fileGrpFulltext']);
+        if (!empty($this->physicalStructureInfo[$id])) {
+            while ($fileGrpFulltext = array_shift($fileGrpsFulltext)) {
+                if (!empty($this->physicalStructureInfo[$id]['files'][$fileGrpFulltext])) {
+                    // Get full text file.
+                    $fileContent = GeneralUtility::getUrl($this->getFileLocation($this->physicalStructureInfo[$id]['files'][$fileGrpFulltext]));
+                    if ($fileContent !== false) {
+                        $textFormat = $this->getTextFormat($fileContent);
+                    } else {
+                        $this->logger->warning('Couldn\'t load full text file for structure node @ID "' . $id . '"');
+                        return $fullText;
+                    }
+                    break;
+                }
+            }
+        } else {
+            $this->logger->warning('Invalid structure node @ID "' . $id . '"');
+            return $fullText;
+        }
+        // Is this text format supported?
+        // This part actually differs from previous version of indexed OCR
+        if (!empty($fileContent) && !empty($this->formats[$textFormat])) {
+            $textMiniOcr = '';
+            if (!empty($this->formats[$textFormat]['class'])) {
+                $class = $this->formats[$textFormat]['class'];
+                // Get the raw text from class.
+                if (
+                    class_exists($class)
+                    && ($obj = GeneralUtility::makeInstance($class)) instanceof FulltextInterface
+                ) {
+                    // Load XML from file.
+                    $ocrTextXml = Helper::getXmlFileAsString($fileContent);
+                    $textMiniOcr = $obj->getTextAsMiniOcr($ocrTextXml);
+                    $this->rawTextArray[$id] = $textMiniOcr;
+                } else {
+                    $this->logger->warning('Invalid class/method "' . $class . '->getRawText()" for text format "' . $textFormat . '"');
+                }
+            }
+            $fullText = $textMiniOcr;
+        } else {
+            $this->logger->warning('Unsupported text format "' . $textFormat . '" in physical node with @ID "' . $id . '"');
+        }
+        return $fullText;
+    }
+
+    /**
+     * Get format of the OCR full text
+     *
+     * @access private
+     *
+     * @param string $fileContent: content of the XML file
+     *
+     * @return string The format of the OCR full text
+     */
+    private function getTextFormat($fileContent)
+    {
+        // Get the root element's name as text format.
+        return strtoupper(Helper::getXmlFileAsString($fileContent)->getName());
+    }
+
+    /**
+     * This returns $this->hasFullText via __get()
+     *
+     * @access protected
+     *
+     * @return bool Are there any full text files available?
+     */
+    protected function _getHasFullText()
+    {
+        $this->ensureHasFullTextIsSet();
+        return $this->hasFullText;
+    }
+}

--- a/Classes/Common/Document/FullTextDocument.php
+++ b/Classes/Common/Document/FullTextDocument.php
@@ -12,6 +12,8 @@
 
 namespace Kitodo\Dlf\Common\Document;
 
+use Kitodo\Dlf\Common\FulltextInterface;
+use Kitodo\Dlf\Common\Helper;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 

--- a/Classes/Common/Document/IiifManifest.php
+++ b/Classes/Common/Document/IiifManifest.php
@@ -56,7 +56,7 @@ use Ubl\Iiif\Tools\IiifHelper;
  * @property-read string $toplevelId This holds the toplevel manifest's @id
  * @property-read mixed $uid This holds the UID or the URL of the document
  */
-final class IiifManifest extends Document
+final class IiifManifest extends FullTextDocument
 {
     /**
      * This holds the manifest file as string for serialization purposes
@@ -786,7 +786,7 @@ final class IiifManifest extends Document
 
     /**
      * {@inheritDoc}
-     * @see Document::getFullText()
+     * @see FullTextDocument::getFullText()
      */
     //TODO: rewrite it to get full OCR
     public function getFullText($id)

--- a/Classes/Common/Document/IiifManifest.php
+++ b/Classes/Common/Document/IiifManifest.php
@@ -10,7 +10,7 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
-namespace Kitodo\Dlf\Common;
+namespace Kitodo\Dlf\Common\Document;
 
 use Flow\JSONPath\JSONPath;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -39,7 +39,7 @@ use Ubl\Iiif\Tools\IiifHelper;
  * @subpackage dlf
  * @access public
  * @property int $cPid This holds the PID for the configuration
- * @property-read bool $hasFulltext Are there any fulltext files available?
+ * @property-read bool $hasFullTextSet Are there any fulltext files available?
  * @property-read string $location This holds the documents location
  * @property-read array $metadataArray This holds the documents' parsed metadata array
  * @property-read int $numPages The holds the total number of pages
@@ -87,7 +87,7 @@ final class IiifManifest extends Document
      * @var bool
      * @access protected
      */
-    protected $hasFulltextSet = false;
+    protected $hasFullTextSet = false;
 
     /**
      * This holds the original manifest's parsed metadata array with their corresponding
@@ -289,8 +289,8 @@ final class IiifManifest extends Document
                 if (!empty($iiifAlto)) {
                     $this->mimeTypes[$iiifAlto[0]] = 'application/alto+xml';
                     $this->physicalStructureInfo[$physSeq[0]]['files'][$fileUseFulltext[0]] = $iiifAlto[0];
-                    $this->hasFulltext = true;
-                    $this->hasFulltextSet = true;
+                    $this->hasFullText = true;
+                    $this->hasFullTextSet = true;
                 }
             }
             if (!empty($this->iiif->getDefaultCanvases())) {
@@ -321,8 +321,8 @@ final class IiifManifest extends Document
                         foreach ($canvas->getPossibleTextAnnotationContainers(Motivation::PAINTING) as $annotationContainer) {
                             $this->physicalStructureInfo[$elements[$canvasOrder]]['annotationContainers'][] = $annotationContainer->getId();
                             if ($extConf['indexAnnotations']) {
-                                $this->hasFulltext = true;
-                                $this->hasFulltextSet = true;
+                                $this->hasFullText = true;
+                                $this->hasFullTextSet = true;
                             }
                         }
                     }
@@ -334,8 +334,8 @@ final class IiifManifest extends Document
                         if (!empty($alto)) {
                             $this->mimeTypes[$alto[0]] = 'application/alto+xml';
                             $this->physicalStructureInfo[$elements[$canvasOrder]]['files'][$fileUseFulltext[0]] = $alto[0];
-                            $this->hasFulltext = true;
-                            $this->hasFulltextSet = true;
+                            $this->hasFullText = true;
+                            $this->hasFullTextSet = true;
                         }
                     }
                     if (!empty($fileUses)) {
@@ -797,7 +797,7 @@ final class IiifManifest extends Document
             return $this->rawTextArray[$id];
         }
         $this->ensureHasFulltextIsSet();
-        if ($this->hasFulltext) {
+        if ($this->hasFullText) {
             // Load physical structure ...
             $this->_getPhysicalStructure();
             // ... and extension configuration.
@@ -887,7 +887,7 @@ final class IiifManifest extends Document
 
     /**
      * {@inheritDoc}
-     * @see \Kitodo\Dlf\Common\Document::prepareMetadataArray()
+     * @see Document::prepareMetadataArray()
      */
     protected function prepareMetadataArray($cPid)
     {
@@ -920,7 +920,7 @@ final class IiifManifest extends Document
          *  https://digi.ub.uni-heidelberg.de/diglit/iiif/hirsch_hamburg1933_04_25/manifest.json links
          *  https://digi.ub.uni-heidelberg.de/diglit/iiif/hirsch_hamburg1933_04_25/list/0001.json
          */
-        if (!$this->hasFulltextSet && $this->iiif instanceof ManifestInterface) {
+        if (!$this->hasFullTextSet && $this->iiif instanceof ManifestInterface) {
             $manifest = $this->iiif;
             $canvases = $manifest->getDefaultCanvases();
             foreach ($canvases as $canvas) {
@@ -928,8 +928,8 @@ final class IiifManifest extends Document
                     !empty($canvas->getSeeAlsoUrlsForFormat("application/alto+xml")) ||
                     !empty($canvas->getSeeAlsoUrlsForProfile("http://www.loc.gov/standards/alto/"))
                 ) {
-                    $this->hasFulltextSet = true;
-                    $this->hasFulltext = true;
+                    $this->hasFullTextSet = true;
+                    $this->hasFullText = true;
                     return;
                 }
                 $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
@@ -942,8 +942,8 @@ final class IiifManifest extends Document
                                     $annotation->getBody()->getFormat() == "text/plain" &&
                                     $annotation->getBody()->getChars() != null
                                 ) {
-                                    $this->hasFulltextSet = true;
-                                    $this->hasFulltext = true;
+                                    $this->hasFullTextSet = true;
+                                    $this->hasFullText = true;
                                     return;
                                 }
                             }
@@ -951,13 +951,13 @@ final class IiifManifest extends Document
                     }
                 }
             }
-            $this->hasFulltextSet = true;
+            $this->hasFullTextSet = true;
         }
     }
 
     /**
      * {@inheritDoc}
-     * @see \Kitodo\Dlf\Common\Document::_getThumbnail()
+     * @see Document::_getThumbnail()
      */
     protected function _getThumbnail($forceReload = false)
     {
@@ -966,7 +966,7 @@ final class IiifManifest extends Document
 
     /**
      * {@inheritDoc}
-     * @see \Kitodo\Dlf\Common\Document::_getToplevelId()
+     * @see Document::_getToplevelId()
      */
     protected function _getToplevelId()
     {

--- a/Classes/Common/Document/MetsDocument.php
+++ b/Classes/Common/Document/MetsDocument.php
@@ -1005,7 +1005,7 @@ final class MetsDocument extends Document
                 return $this->thumbnail;
             }
             $strctId = $this->_getToplevelId();
-            $metadata = $this->getTitledata($cPid);
+            $metadata = $this->getTitleData($cPid);
 
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable('tx_dlf_structures');

--- a/Classes/Common/Document/MetsDocument.php
+++ b/Classes/Common/Document/MetsDocument.php
@@ -13,6 +13,8 @@
 namespace Kitodo\Dlf\Common\Document;
 
 use Kitodo\Dlf\Common\Helper;
+use Kitodo\Dlf\Common\IiifUrlReader;
+use Kitodo\Dlf\Common\MetadataInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
@@ -49,7 +51,7 @@ use Ubl\Iiif\Services\AbstractImageService;
  * @property-read string $toplevelId This holds the toplevel structure's @ID (METS) or the manifest's @id (IIIF)
  * @property-read mixed $uid This holds the UID or the URL of the document
  */
-final class MetsDocument extends Document
+final class MetsDocument extends FullTextDocument
 {
     /**
      * This holds the whole XML file as string for serialization purposes
@@ -727,9 +729,9 @@ final class MetsDocument extends Document
 
     /**
      * {@inheritDoc}
-     * @see FullTextDocument::ensureHasFulltextIsSet()
+     * @see FullTextDocument::ensureHasFullTextIsSet()
      */
-    protected function ensureHasFulltextIsSet()
+    protected function ensureHasFullTextIsSet()
     {
         // Are the fileGrps already loaded?
         if (!$this->fileGrpsLoaded) {

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Common;
 
+use Kitodo\Dlf\Common\Document\Document;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -85,7 +86,7 @@ class Indexer
      *
      * @access public
      *
-     * @param \Kitodo\Dlf\Common\Document &$doc: The document to add
+     * @param \Kitodo\Dlf\Common\Document\Document &$doc: The document to add
      * @param int $core: UID of the Solr core to use
      *
      * @return bool true on success or false on failure
@@ -123,7 +124,7 @@ class Indexer
                     }
                 }
                 // Index full text files if available.
-                if ($doc->hasFulltext) {
+                if ($doc->hasFullText) {
                     foreach ($doc->physicalStructure as $pageNumber => $xmlId) {
                         if ($success) {
                             $success = self::processPhysical($doc, $pageNumber, $doc->physicalStructureInfo[$xmlId]);
@@ -304,7 +305,7 @@ class Indexer
      *
      * @access protected
      *
-     * @param \Kitodo\Dlf\Common\Document &$doc: The METS document
+     * @param \Kitodo\Dlf\Common\Document\Document &$doc: The METS document
      * @param array $logicalUnit: Array of the logical unit to process
      *
      * @return bool true on success or false on failure
@@ -433,7 +434,7 @@ class Indexer
      *
      * @access protected
      *
-     * @param \Kitodo\Dlf\Common\Document &$doc: The METS document
+     * @param \Kitodo\Dlf\Common\Document\Document &$doc: The METS document
      * @param int $page: The page number
      * @param array $physicalUnit: Array of the physical unit to process
      *
@@ -441,7 +442,7 @@ class Indexer
      */
     protected static function processPhysical(Document &$doc, $page, array $physicalUnit)
     {
-        if ($doc->hasFulltext && $fullText = $doc->getFullText($physicalUnit['id'])) {
+        if ($doc->hasFullText && $fullText = $doc->getFullText($physicalUnit['id'])) {
             // Read extension configuration.
             $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey);
             // Create new Solr document.

--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\ExpressionLanguage;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\IiifManifest;
 use Psr\Log\LoggerAwareInterface;
@@ -110,7 +110,7 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
      *
      * @param array $piVars The current plugin variables containing a document identifier
      *
-     * @return \Kitodo\Dlf\Common\Document Instance of the current document
+     * @return \Kitodo\Dlf\Common\Document\Document Instance of the current document
      */
     protected function loadDocument(array $piVars)
     {

--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -13,8 +13,8 @@
 namespace Kitodo\Dlf\ExpressionLanguage;
 
 use Kitodo\Dlf\Common\Document\Document;
+use Kitodo\Dlf\Common\Document\IiifManifest;
 use Kitodo\Dlf\Common\Helper;
-use Kitodo\Dlf\Common\IiifManifest;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;

--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -87,7 +87,7 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
                 // Set PID for metadata definitions.
                 $doc->cPid = $cPid;
 
-                $metadata = $doc->getTitledata($cPid);
+                $metadata = $doc->getTitleData($cPid);
                 if (!empty($metadata['type'][0])) {
                     // Calendar plugin does not support IIIF (yet). Abort for all newspaper related types.
                     if (

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\Hooks;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Indexer;
 use Kitodo\Dlf\Common\Solr;

--- a/Classes/Hooks/UserFunc.php
+++ b/Classes/Hooks/UserFunc.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\Hooks;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\IiifManifest;
 use Psr\Log\LoggerAwareInterface;

--- a/Classes/Hooks/UserFunc.php
+++ b/Classes/Hooks/UserFunc.php
@@ -13,8 +13,8 @@
 namespace Kitodo\Dlf\Hooks;
 
 use Kitodo\Dlf\Common\Document\Document;
+use Kitodo\Dlf\Common\Document\IiifManifest;
 use Kitodo\Dlf\Common\Helper;
-use Kitodo\Dlf\Common\IiifManifest;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Classes/Plugin/Basket.php
+++ b/Classes/Plugin/Basket.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\Plugin;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\Helper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/Plugin/Calendar.php
+++ b/Classes/Plugin/Calendar.php
@@ -63,7 +63,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             return $content;
         }
 
-        $metadata = $this->doc->getTitledata();
+        $metadata = $this->doc->getTitleData();
         if (!empty($metadata['type'][0])) {
             $type = $metadata['type'][0];
         } else {
@@ -208,7 +208,7 @@ class Calendar extends \Kitodo\Dlf\Common\AbstractPlugin
             'forceAbsoluteUrl.' => ['scheme' => !empty($this->conf['forceAbsoluteUrl']) && !empty($this->conf['forceAbsoluteUrlHttps']) ? 'https' : 'http'],
             'additionalParams' => '&' . $this->prefixId . '[id]=' . urlencode($this->doc->uid),
         ];
-        $linkTitleData = $this->doc->getTitledata();
+        $linkTitleData = $this->doc->getTitleData();
         $linkTitle = !empty($linkTitleData['mets_orderlabel'][0]) ? $linkTitleData['mets_orderlabel'][0] : $linkTitleData['mets_label'][0];
         $yearLink = $this->cObj->typoLink($linkTitle, $linkConf);
         // Link to years overview.

--- a/Classes/Plugin/Feeds.php
+++ b/Classes/Plugin/Feeds.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\Plugin;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\Helper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -13,8 +13,8 @@
 namespace Kitodo\Dlf\Plugin;
 
 use Kitodo\Dlf\Common\Document\Document;
+use Kitodo\Dlf\Common\Document\IiifManifest;
 use Kitodo\Dlf\Common\Helper;
-use Kitodo\Dlf\Common\IiifManifest;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Ubl\Iiif\Context\IRI;

--- a/Classes/Plugin/Metadata.php
+++ b/Classes/Plugin/Metadata.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\Plugin;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\IiifManifest;
 use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -12,8 +12,8 @@
 
 namespace Kitodo\Dlf\Plugin;
 
+use Kitodo\Dlf\Common\Document\IiifManifest;
 use Kitodo\Dlf\Common\Helper;
-use Kitodo\Dlf\Common\IiifManifest;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;

--- a/Classes/Plugin/Search.php
+++ b/Classes/Plugin/Search.php
@@ -12,7 +12,7 @@
 
 namespace Kitodo\Dlf\Plugin;
 
-use Kitodo\Dlf\Common\Document;
+use Kitodo\Dlf\Common\Document\Document;
 use Kitodo\Dlf\Common\DocumentList;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Indexer;

--- a/Classes/Plugin/TableOfContents.php
+++ b/Classes/Plugin/TableOfContents.php
@@ -41,7 +41,7 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
      *
      * @access protected
      *
-     * @param array $entry: The entry's array from \Kitodo\Dlf\Common\Document->getLogicalStructure
+     * @param array $entry: The entry's array from \Kitodo\Dlf\Common\Document\Document->getLogicalStructure
      * @param bool $recursive: Whether to include the child entries
      *
      * @return array HMENU array for menu entry


### PR DESCRIPTION
This PR prepares adding of 3D model class which is going to extend Document class. 3D models don't have full text at all, so all methods related to full text are not needed for it.

- move document classes to the own package
- add abstract FullTextDocument class which extends Document class
- MetsDocument and IiifManifest classes extend now FullTextDocument
- reorder classes in Document class (first public abstract, then public / static public, then protected abstract, then protected and at the end magic methods)

For easier review is good to check first commit (moving code) and then second (reordering methods).