### PR TITLE
Rise the number of snippets for text hightlighting.

### DIFF
--- a/Classes/Plugin/Eid/SearchInDocument.php
+++ b/Classes/Plugin/Eid/SearchInDocument.php
@@ -77,7 +77,7 @@ class SearchInDocument
             // return the coordinates of highlighted search as absolute coordinates
             $solrRequest->addParam('hl.ocr.absoluteHighlights', 'on');
             // max amount of snippets for a single page
-            $solrRequest->addParam('hl.snippets', 20);
+            $solrRequest->addParam('hl.snippets', 40);
             // we store the fulltext on page level and can disable this option
             $solrRequest->addParam('hl.ocr.trackPages', 'off');
 


### PR DESCRIPTION
The search in document plugin is used for text highlighting. In some
edge cases the amount of text snippets is to low. Not all words gets
highlighted than.

This rise the number of text snippets to 40.