### PR TITLE
Allow setting of Solr core name on creating solrcore records.

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -97,7 +97,7 @@ class DataHandler implements LoggerAwareInterface
                     // Field post-processing for table "tx_dlf_solrcores".
                 case 'tx_dlf_solrcores':
                     // Create new Solr core.
-                    $fieldArray['index_name'] = Solr::createCore();
+                    $fieldArray['index_name'] = Solr::createCore($fieldArray['index_name']);
                     if (empty($fieldArray['index_name'])) {
                         $this->logger->error('Could not create new Apache Solr core');
                     }

--- a/Configuration/TCA/tx_dlf_solrcores.php
+++ b/Configuration/TCA/tx_dlf_solrcores.php
@@ -47,7 +47,7 @@ return [
                 'type' => 'input',
                 'size' => 30,
                 'max' => 255,
-                'eval' => 'alphanum,nospace,required,unique',
+                'eval' => 'alphanum,nospace,unique',
                 'default' => '',
                 'fieldInformation' => [
                     'solrCoreStatus' => [


### PR DESCRIPTION
We allowed to edit the index_name field recently. It stayed a required
field but anything you typed in was ignored and the next possible
index_name was set (e.g. "dlfCore1").

With this change, it is possible to create cores with the given name.
Something like "mySolrcore" is possible now.

Additionally, the field is not "required" anymore. So it may be empty.
In this case, the automatic behavior is kept. A index_name is set and a
Solr core created.