### PR TITLE
Catch another case we get unwanted error messages in log file.

### DIFF
--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -74,8 +74,9 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
 
                 $type = 'undefined';
 
-                // It happens that $queryParams is an empty array.
-                if (empty($queryParams)) {
+                // It happens that $queryParams is an empty array or does not contain a key 'tx_dlf'
+                // in case of other contexts. In this case we have to return here to avoid log messages.
+                if (empty($queryParams) || !isset($queryParams[$this->prefixId])) {
                     return $type;
                 }
 


### PR DESCRIPTION
The log errors are like the following:

```
Tue, 12 Oct 2021 18:43:34 +0000 [ERROR] request="94d2a03342b88" component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Argument 1 passed to Kitodo\Dlf\ExpressionLanguage\DocumentTypeFunctionProvider::loadDocument() must be of the type array, null given, called in /var/www/extensions/dlf/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php on line 83 - {"expression":"getDocumentType(2) === 'ephemera' or getDocumentType(2) === 'newspaper'","exception":{}}
Tue, 12 Oct 2021 18:43:34 +0000 [ERROR] request="94d2a03342b88" component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Argument 1 passed to Kitodo\Dlf\ExpressionLanguage\DocumentTypeFunctionProvider::loadDocument() must be of the type array, null given, called in /var/www/extensions/dlf/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php on line 83 - {"expression":"getDocumentType(2) === 'year'","exception":{}}
Tue, 12 Oct 2021 18:43:34 +0000 [ERROR] request="94d2a03342b88" component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Argument 1 passed to Kitodo\Dlf\ExpressionLanguage\DocumentTypeFunctionProvider::loadDocument() must be of the type array, null given, called in /var/www/extensions/dlf/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php on line 83 - {"expression":"getDocumentType(2) === 'issue'","exception":{}}
Tue, 12 Oct 2021 18:44:22 +0000 [ERROR] request="03204b91b7463" component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Argument 1 passed to Kitodo\Dlf\ExpressionLanguage\DocumentTypeFunctionProvider::loadDocument() must be of the type array, null given, called in /var/www/extensions/dlf/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php on line 83 - {"expression":"getDocumentType(2) === 'ephemera' or getDocumentType(2) === 'newspaper'","exception":{}}
Tue, 12 Oct 2021 18:44:22 +0000 [ERROR] request="03204b91b7463" component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Argument 1 passed to Kitodo\Dlf\ExpressionLanguage\DocumentTypeFunctionProvider::loadDocument() must be of the type array, null given, called in /var/www/extensions/dlf/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php on line 83 - {"expression":"getDocumentType(2) === 'year'","exception":{}}
Tue, 12 Oct 2021 18:44:22 +0000 [ERROR] request="03204b91b7463" component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Argument 1 passed to Kitodo\Dlf\ExpressionLanguage\DocumentTypeFunctionProvider::loadDocument() must be of the type array, null given, called in /var/www/extensions/dlf/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php on line 83 - {"expression":"getDocumentType(2) === 'issue'","exception":{}}
```
This happens on browsing the TYPO3 backend (!). The `$queryParams` is set and an array. But it doesn't contain the `tx_dlf` key.