### PR TITLE
Fix check whether fulltext is present

### DIFF
--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -164,7 +164,7 @@ dlfViewer.prototype.addCustomControls = function() {
 
     // Adds fulltext behavior and download only if there is fulltext available and no double page
     // behavior is active
-    if (this.fulltexts[0] !== undefined && this.fulltexts[0].length !== 0 && this.fulltexts[0].url !== '' && this.images.length === 1) {
+    if (dlfUtils.isFulltextDescriptor(this.fulltexts[0]) && this.images.length === 1) {
         fulltextControl = new dlfViewerFullTextControl(this.map, this.images[0], this.fulltexts[0].url);
         fulltextDownloadControl = new dlfViewerFullTextDownloadControl(this.map, this.images[0], this.fulltexts[0].url);
     } else {
@@ -331,7 +331,7 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
         }
     }
 
-    if (this.fulltexts[0] !== undefined && this.fulltexts[0].length !== 0 && this.fulltexts[0].url !== '' && this.images.length > 0) {
+    if (dlfUtils.isFulltextDescriptor(this.fulltexts[0]) && this.images.length > 0) {
         var values = [],
             fulltextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[0].url, this.images[0]),
             fulltextDataImageTwo = undefined;
@@ -341,7 +341,7 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
         }
 
         // check if there is another image / fulltext to look for
-        if (this.images.length === 2 && this.fulltexts[1] !== undefined && this.fulltexts[1].length !== 0 && this.fulltexts[1].url !== '') {
+        if (this.images.length === 2 && dlfUtils.isFulltextDescriptor(this.fulltexts[1])) {
             var image = $.extend({}, this.images[1]);
             image.width = image.width + this.images[0].width;
             fulltextDataImageTwo = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[1].url, this.images[1], this.images[0].width);

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -331,7 +331,7 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
         }
     }
 
-    if (this.fulltexts[0] !== undefined && this.fulltexts[0].url !== '' && this.images.length > 0) {
+    if (this.fulltexts[0] !== undefined && this.fulltexts[0].length !== 0 && this.fulltexts[0].url !== '' && this.images.length > 0) {
         var values = [],
             fulltextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[0].url, this.images[0]),
             fulltextDataImageTwo = undefined;
@@ -341,7 +341,7 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
         }
 
         // check if there is another image / fulltext to look for
-        if (this.images.length === 2 & this.fulltexts[1] !== undefined && this.fulltexts[1].url !== '') {
+        if (this.images.length === 2 && this.fulltexts[1] !== undefined && this.fulltexts[1].length !== 0 && this.fulltexts[1].url !== '') {
             var image = $.extend({}, this.images[1]);
             image.width = image.width + this.images[0].width;
             fulltextDataImageTwo = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[1].url, this.images[1], this.images[0].width);

--- a/Resources/Public/Javascript/PageView/Utility.js
+++ b/Resources/Public/Javascript/PageView/Utility.js
@@ -756,6 +756,22 @@ dlfUtils.isCorsEnabled = function (imageObjs) {
 };
 
 /**
+ * Checks if {@link obj} is a valid object describing the location of a
+ * fulltext (@see PageView::getFulltext in PageView.php).
+ *
+ * @param {any} obj The object to test.
+ * @return {boolean}
+ */
+dlfUtils.isFulltextDescriptor = function (obj) {
+    return (
+        typeof obj === 'object'
+        && obj !== null
+        && 'url' in obj
+        && obj.url !== ''
+    );
+};
+
+/**
  * Functions checks if WebGL is enabled in the browser
  * @return {boolean}
  */


### PR DESCRIPTION
This PR fixes a condition that checks whether fulltext is present, and refactors the condition into a utility function to avoid code duplication.

## Issue

When opening a page that does not have fulltext using the v3.3 of Kitodo.Presentation, I get two console errors:

    XML Parsing Error: mismatched tag. Expected: </link>.
    [...]

    Uncaught Error: Invalid XML: [...]

## Reproduce

For example, install the kitodo/ddev-kitodo-presentation environment and open the following link:

> https://ddev-kitodo-presentation.ddev.site/workview?tx_dlf[id]=https%3A%2F%2Fdigital.slub-dresden.de%2Foai%3Fverb%3DGetRecord%26metadataPrefix%3Dmets%26identifier%3Doai%3Ade%3Aslub-dresden%3Adb%3Aid-1665101628

## Trace

- Currently, when there is no fulltext, Kitodo tries to load fulltext from URL `undefined`.
- `$.ajax` defaults to loading the current page.
- The response text is fed to the ALTO parser.
- Choke.