### PR TITLE
Quick Fix: Wait for `tx_dlf_viewer` when highlighting word

### DIFF
--- a/Resources/Public/Javascript/PageView/SearchInDocument.js
+++ b/Resources/Public/Javascript/PageView/SearchInDocument.js
@@ -259,7 +259,7 @@ function addImageHighlight(data) {
     data['documents'].forEach(function (element, i) {
         if(element['page'] === page) {
             if (element['highlight'].length > 0) {
-                if(tx_dlf_viewer.map != null) {
+                if (typeof tx_dlf_viewer !== 'undefined' && tx_dlf_viewer.map != null) { // eslint-disable-line camelcase
                     tx_dlf_viewer.displayHighlightWord(encodeURIComponent(getHighlights(element['highlight'])));
                 } else {
                     setTimeout(addImageHighlight, 500, data);


### PR DESCRIPTION
When clicking on a result in the in-document search (`SearchInDocumentTool`), I get the following following console error:

    Uncaught ReferenceError: tx_dlf_viewer is not defined
        addImageHighlight https://ddev-kitodo-presentation.ddev.site/typo3temp/assets/compressed/merged-eb6368222cc28ec61f1f1ba34ea295cc.js?1634203496:4401
        [...]

Link to reproduce: https://ddev-kitodo-presentation.ddev.site/workview?tx_dlf[id]=1&tx_dlf[highlight_word]=Zukunft

This happens because in order to highlight the search term (via `tx_dlf[highlight_word]` parameter), `addImageHighlight()` tries to access `tx_dlf_viewer`, but at that point `tx_dlf_viewer` isn't initialized yet (see `PageView::addViewerJS()`).

Since the code already has some mechanism to wait for the OL map being initialized, I just extend that to also check whether `tx_dlf_viewer` has already been set.