### PR TITLE
Refactoring the fluid template of the navigation plugin.

### DIFF
--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -25,7 +25,6 @@ class NavigationController extends AbstractController
     public function mainAction()
     {
         $requestData = GeneralUtility::_GPmerged('tx_dlf');
-        unset($requestData['__referrer'], $requestData['__trustedProperties']);
 
         if (empty($requestData['page'])) {
             $requestData['page'] = 1;
@@ -64,15 +63,9 @@ class NavigationController extends AbstractController
         $pageSteps = $this->settings['pageStep'] * ($requestData['double'] + 1);
 
         $this->view->assign('page', $requestData['page']);
-        $this->view->assign('docId', $this->doc->uid);
-        $this->view->assign('pageId', $GLOBALS['TSFE']->id);
         $this->view->assign('pageSteps', $pageSteps);
         $this->view->assign('double', $requestData['double']);
         $this->view->assign('numPages', $this->doc->numPages);
-
-        // TODO: Check if f:link.action can be used in template Navigation->main
-        $this->view->assign('pageToList', $this->settings['targetPid']);
-        $this->view->assign('forceAbsoluteUrl', !empty($this->conf['settings.forceAbsoluteUrl']) ? 1 : 0);
 
         $pageOptions = [];
         for ($i = 1; $i <= $this->doc->numPages; $i++) {
@@ -81,5 +74,10 @@ class NavigationController extends AbstractController
         $this->view->assign('uniqueId', uniqid(Helper::getUnqualifiedClassName(get_class($this)) . '-'));
         $this->view->assign('pageOptions', $pageOptions);
 
+        // prepare feature array for fluid
+        foreach (explode(',', $this->settings['features']) as $key => $value) {
+            $features[$value] = true;
+        }
+        $this->view->assign('features', $features);
     }
 }

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -75,6 +75,7 @@ class NavigationController extends AbstractController
         $this->view->assign('pageOptions', $pageOptions);
 
         // prepare feature array for fluid
+        $features = [];
         foreach (explode(',', $this->settings['features']) as $key => $value) {
             $features[$value] = true;
         }

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -76,8 +76,8 @@ class NavigationController extends AbstractController
 
         // prepare feature array for fluid
         $features = [];
-        foreach (explode(',', $this->settings['features']) as $key => $value) {
-            $features[$value] = true;
+        foreach (explode(',', $this->settings['features']) as $feature) {
+            $features[$feature] = true;
         }
         $this->view->assign('features', $features);
     }

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -152,10 +152,9 @@ class TableOfContentsController extends AbstractController
     public function mainAction()
     {
         $requestData = GeneralUtility::_GPmerged('tx_dlf');
-        unset($requestData['__referrer'], $requestData['__trustedProperties']);
 
         // Check for typoscript configuration to prevent fatal error.
-        if (empty($this->conf['settings.menuConf.'])) {
+        if (empty($this->settings['menuConf'])) {
             $this->logger->warning('Incomplete plugin configuration');
         }
 

--- a/Configuration/Flexforms/Navigation.xml
+++ b/Configuration/Flexforms/Navigation.xml
@@ -40,9 +40,68 @@
                             </config>
                         </TCEforms>
                     </settings.pages>
+                    <settings.features>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectMultipleSideBySide</renderType>
+                                <items>
+                                    <numIndex index="0">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.doublepage</numIndex>
+                                        <numIndex index="1">doublepage</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageFirst</numIndex>
+                                        <numIndex index="1">pageFirst</numIndex>
+                                    </numIndex>
+                                    <numIndex index="2">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageBack</numIndex>
+                                        <numIndex index="1">pageBack</numIndex>
+                                    </numIndex>
+                                    <numIndex index="3">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageStepBack</numIndex>
+                                        <numIndex index="1">pageStepBack</numIndex>
+                                    </numIndex>
+                                    <numIndex index="4">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageselect</numIndex>
+                                        <numIndex index="1">pageselect</numIndex>
+                                    </numIndex>
+                                    <numIndex index="5">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageForward</numIndex>
+                                        <numIndex index="1">pageForward</numIndex>
+                                    </numIndex>
+                                    <numIndex index="6">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageStepForward</numIndex>
+                                        <numIndex index="1">pageStepForward</numIndex>
+                                    </numIndex>
+                                    <numIndex index="7">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageLast</numIndex>
+                                        <numIndex index="1">pageLast</numIndex>
+                                    </numIndex>
+                                    <numIndex index="7">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.listview</numIndex>
+                                        <numIndex index="1">listview</numIndex>
+                                    </numIndex>
+                                    <numIndex index="8">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.zoom</numIndex>
+                                        <numIndex index="1">zoom</numIndex>
+                                    </numIndex>
+                                    <numIndex index="9">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.rotation</numIndex>
+                                        <numIndex index="1">rotation</numIndex>
+                                    </numIndex>
+                                </items>
+                                <default>doublepage,pageFirst,pageBack,pageStepBack,pageselect,pageForward,pageStepForward,pageLast,listview,zoom,rotation</default>
+                                <minitems>1</minitems>
+                            </config>
+                        </TCEforms>
+                    </settings.features>
                     <settings.pageStep>
                         <TCEforms>
                             <exclude>1</exclude>
+                            <displayCond>FIELD:settings.features:IN:pagestep</displayCond>
                             <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.pageStep</label>
                             <config>
                                 <type>input</type>
@@ -54,6 +113,7 @@
                     <settings.targetPid>
                         <TCEforms>
                             <exclude>1</exclude>
+                            <displayCond>FIELD:settings.features:IN:listview</displayCond>
                             <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:flexform.targetPidListView</label>
                             <config>
                                 <type>group</type>
@@ -71,21 +131,6 @@
                             </config>
                         </TCEforms>
                     </settings.targetPid>
-                    <settings.templateFile>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:flexform.templateFile</label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>file_reference</internal_type>
-                                <allowed>tmpl,tpl,html,htm,txt</allowed>
-                                <size>1</size>
-                                <maxitems>1</maxitems>
-                                <minitems>0</minitems>
-                                <disable_controls>upload</disable_controls>
-                            </config>
-                        </TCEforms>
-                    </settings.templateFile>
                 </el>
             </ROOT>
         </sDEF>

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -25,10 +25,31 @@ pages
 ^^^^^
 Startingpoint of this plugin. This is the Kitodo.Presentation data folder.
 
-templateFile
-^^^^^^^^^^^^
-The used template file of this plugin.
+Fluid Template Configuration
+----------------------------
 
+As of Kitodo.Presentation 4.0 the Fluid rendering engine is used. The former
+marker templates for plugins are not supported anymore.
+
+Now, all HTML markup is done in Fluid. To use different templates, you have
+to overload the templates by the common TYPO3 way.
+
+The following TypoScript defines addition paths inside a "example" extenion::
+
+   plugin.tx_dlf {
+      view {
+         templateRootPaths {
+            10 = EXT:example/Resources/Private/Plugins/Kitodo/Templates
+         }
+         partialRootPaths {
+            10 = EXT:example/Resources/Private/Plugins/Kitodo/Partials
+         }
+      }
+   }
+
+In this example, you place the customized fluid template into this file::
+
+   EXT:example/Resources/Private/Plugins/Kitodo/Partials/Navigation/Main.html
 
 
 Audioplayer
@@ -69,14 +90,6 @@ Properties
        :ref:`t3tsref:data-type-string`
    :Default:
         tx-dlf-audio
-
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-        AudioPlayer.tmpl
-
 
 
 excludeOther
@@ -160,13 +173,6 @@ Basket
        :ref:`t3tsref:data-type-page-id`
    :Default:
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Basket.tmpl
-
 
 Calendar
 ---------
@@ -239,12 +245,6 @@ now.
    :Default:
        1
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Calendar.tmpl
 
 Collection
 ----------
@@ -306,13 +306,6 @@ The collection plugin shows one collection, all collections or selected collecti
    :Data Type:
        :ref:`t3tsref:data-type-page-id`
    :Default:
-
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Collection.tmpl
 
 
 Feeds
@@ -452,13 +445,6 @@ List View
        :ref:`t3tsref:data-type-page-id`
    :Default:
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       ListView.tmpl
-
 
 Metadata
 --------
@@ -529,13 +515,6 @@ Metadata
    :Default:
        `#`
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Metadata.tmpl
-
 Navigation
 ----------
 
@@ -558,6 +537,15 @@ Navigation
    :Default:
 
  - :Property:
+       features
+   :Data Type:
+       :ref:`t3tsref:data-type-string`
+   :Default:
+      By default all features are activated. The selection is stored as comma separated list.
+
+       doublepage,pageFirst,pageBack,pageStepBack,pageselect,pageForward,pageStepForward,pageLast,listview,zoom,rotation
+
+ - :Property:
        pageStep
    :Data Type:
        :ref:`t3tsref:data-type-integer`
@@ -570,12 +558,6 @@ Navigation
        :ref:`t3tsref:data-type-page-id`
    :Default:
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Navigation.tmpl
 
 OAI-PMH
 -------
@@ -674,13 +656,6 @@ Page Grid
        :ref:`t3tsref:data-type-page-id`
    :Default:
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       PageGrid.tmpl
-
 Page View
 ---------
 
@@ -756,13 +731,6 @@ Page View
    :Data Type:
        :ref:`t3tsref:data-type-page-id`
    :Default:
-
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       PageView.tmpl
 
 Search
 ------
@@ -881,14 +849,6 @@ Search
        :ref:`t3tsref:data-type-page-id`
    :Default:
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Search.tmpl
-
-
 Statistics
 ----------
 
@@ -970,14 +930,6 @@ Table Of Contents
        :ref:`t3tsref:data-type-page-id`
    :Default:
 
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       TableOfContents.tmpl
-
-
 Toolbox
 -------
 
@@ -1028,14 +980,6 @@ Toolbox
        :ref:`t3tsref:data-type-list`
    :Default:
        MIN,DEFAULT,MAX
-
- - :Property:
-       templateFile_
-   :Data Type:
-       :ref:`t3tsref:data-type-resource`
-   :Default:
-       Toolbox.tmpl
-
 
 Fulltext Tool
 ^^^^^^^^^^^^^

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.0">
-	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2021-11-08T09:49:54Z">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2021-11-09T21:57:06Z">
 		<header>
 			<generator>LFEditor</generator>
 		</header>
@@ -244,6 +244,54 @@
 			<trans-unit id="plugins.navigation.description" approved="yes">
 				<source><![CDATA[Navigation Plugin for Kitodo.Presentation]]></source>
 				<target><![CDATA[Navigation Plugin für Kitodo.Presentation]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features" approved="yes">
+				<source><![CDATA[Show selected navigation features]]></source>
+				<target><![CDATA[Zeige ausgewählte Navigations-Funktionen]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.doublepage" approved="yes">
+				<source><![CDATA[Buttons for double page mode and recto/verso adjustment]]></source>
+				<target><![CDATA[Buttons für Doppelseitenansicht und Recto/Verso-Korrektur]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.listview" approved="yes">
+				<source><![CDATA[Link to page with listview plugin]]></source>
+				<target><![CDATA[Link zur Listenansicht]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageBack" approved="yes">
+				<source><![CDATA[One page back]]></source>
+				<target><![CDATA[Eine Seite zurück]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageFirst" approved="yes">
+				<source><![CDATA[First page]]></source>
+				<target><![CDATA[Erste Seite]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageForward" approved="yes">
+				<source><![CDATA[One page forward]]></source>
+				<target><![CDATA[Eine Seite vor]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageLast" approved="yes">
+				<source><![CDATA[Last page]]></source>
+				<target><![CDATA[Letzte Seite]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageStepBack" approved="yes">
+				<source><![CDATA[Rewind X pages]]></source>
+				<target><![CDATA[X Seiten zurück]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageStepForward" approved="yes">
+				<source><![CDATA[Forward X pages]]></source>
+				<target><![CDATA[X Seiten vor]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageselect" approved="yes">
+				<source><![CDATA[Page navigation menu]]></source>
+				<target><![CDATA[Seitennavigation]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.rotation" approved="yes">
+				<source><![CDATA[Buttons for rotate image left, right and reset]]></source>
+				<target><![CDATA[Rotations-Buttons: links, rechts und zurück]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.zoom" approved="yes">
+				<source><![CDATA[Buttons for zoom-in, zoom-out and full screen]]></source>
+				<target><![CDATA[Zoom-Buttons und Vollbild-Modus]]></target>
 			</trans-unit>
 			<trans-unit id="plugins.navigation.flexform.pageStep" approved="yes">
 				<source><![CDATA[How many pages should be skipped by "fast-forward" and "rewind" buttons?]]></source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -161,6 +161,42 @@
 			<trans-unit id="plugins.navigation.flexform.pageStep">
 				<source><![CDATA[How many pages should be skipped by "fast-forward" and "rewind" buttons?]]></source>
 			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features">
+				<source><![CDATA[Show selected navigation features]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageStepBack">
+				<source><![CDATA[Rewind X pages]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageStepForward">
+				<source><![CDATA[Forward X pages]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageForward">
+				<source><![CDATA[One page forward]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageBack">
+				<source><![CDATA[One page back]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageFirst">
+				<source><![CDATA[First page]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageLast">
+				<source><![CDATA[Last page]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.rotation">
+				<source><![CDATA[Buttons for rotate image left, right and reset]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.zoom">
+				<source><![CDATA[Buttons for zoom-in, zoom-out and full screen]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.doublepage">
+				<source><![CDATA[Buttons for double page mode and recto/verso adjustment]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.pageselect">
+				<source><![CDATA[Page navigation menu]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.listview">
+				<source><![CDATA[Link to page with listview plugin]]></source>
+			</trans-unit>
 			<trans-unit id="plugins.navigation.title">
 				<source><![CDATA[Kitodo: Navigation]]></source>
 			</trans-unit>

--- a/Resources/Private/Partials/TableOfContents/Children.html
+++ b/Resources/Private/Partials/TableOfContents/Children.html
@@ -33,39 +33,40 @@
         </f:defaultCase>
     </f:switch>
 
-        <f:if condition="{child.doNotLinkIt}">
-            <f:then>
-                <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
-            </f:then>
-            <f:else>
+    <f:if condition="{child.doNotLinkIt}">
+        <f:then>
+            <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+        </f:then>
+        <f:else>
+            <f:link.action
+                action="main"
+                pageUid="{settings.targetPid}"
+                additionalParams="{f:if(condition:'{child.id}', then:'{\'tx_dlf[id]\':child.id, \'tx_dlf[page]\':child.page}', else: '{\'tx_dlf[page]\':child.page}')}"
+                addQueryString="1"
+                title="{f:if(condition:'{child.type}', then: '{child.type}', else: '{child.orderlabel}')}">
+                    <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+            </f:link.action>
+        </f:else>
+    </f:if>
+
+    <f:if condition="{settings.basketButton} && {settings.targetBasket}">
+        <span class="tx-dlf-basket-button">
                 <f:link.action
+                    pageUid="{settings.targetBasket}"
                     action="main"
-                    pageUid="{settings.targetPid}"
-                    additionalParams="{f:if(condition:'{child.id}', then:'{\'tx_dlf[id]\':child.id, \'tx_dlf[page]\':child.page}', else: '{\'tx_dlf[page]\':child.page}')}"
-                    addQueryString="1"
-                    title="{f:if(condition:'{child.type}', then: '{child.type}', else: '{child.orderlabel}')}">
-                        <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+                    controller="Basket"
+                    additionalParams="{'tx_dlf[addToBasket]':'toc', 'tx_dlf[logId]':child.basketButton.logId, 'tx_dlf[startpage]':child.basketButton.startpage}"
+                    addQueryString="1">
+                        <f:translate key="AddToBasket" />
                 </f:link.action>
-            </f:else>
-        </f:if>
+        </span>
+    </f:if>
 
-        <f:if condition="{settings.basketButton} && {settings.targetBasket}">
-            <span class="tx-dlf-basket-button">
-                    <f:link.action
-                        pageUid="{settings.targetBasket}"
-                        action="main"
-                        controller="Basket"
-                        additionalParams="{'tx_dlf[addToBasket]':'toc', 'tx_dlf[logId]':child.basketButton.logId, 'tx_dlf[startpage]':child.basketButton.startpage}"
-                        addQueryString="1">
-                            <f:translate key="AddToBasket" />
-                    </f:link.action>
-            </span>
-        </f:if>
+    <f:if condition="{child._SUB_MENU} && ({child.ITEM_STATE} == 'ACTIFSUB' || {child.ITEM_STATE} == 'CURIFSUB')">
+        <ul>
+            <f:render partial="TableOfContents/Children" arguments="{children: child._SUB_MENU}"/>
+        </ul>
+    </f:if>
 
-        <f:if condition="{child._SUB_MENU} && ({child.ITEM_STATE} == 'ACTIFSUB' || {child.ITEM_STATE} == 'CURIFSUB')">
-            <ul>
-                <f:render partial="TableOfContents/Children" arguments="{children: child._SUB_MENU}"/>
-            </ul>
-        </f:if>
     </li>
 </f:for>

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -10,47 +10,58 @@
 -->
 </f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+
+<f:comment>Render all navigation features in the given order.</f:comment>
+<f:for each="{features}" key="feature" as="enabled">
+    <f:if condition="{feature}">
+        <f:render section="render.{feature}" arguments="{_all}"/>
+    </f:if>
+</f:for>
+
+<f:comment>One section for each feature.</f:comment>
+<f:section name="render.doublepage">
     <f:if condition="{numPages} > 0">
         <f:then>
-            <div class="tx-dlf-navigation-double">
-                <f:if condition="{double}">
-                    <f:then>
+            <f:if condition="{double}">
+                <f:then>
+                    <div class="tx-dlf-navigation-double">
                         <f:link.action addQueryString="1" additionalParams="{'tx_dlf[double]':'0'}">
                             <f:translate key="doublePageOn"/>
                         </f:link.action>
-                    </f:then>
-                    <f:else>
-                        <f:link.action addQueryString="1" additionalParams="{'tx_dlf[double]':'1'}">
-                            <f:translate key="doublePageOn"/>
-                        </f:link.action>
-                    </f:else>
-                </f:if>
-            </div>
-            <div class="tx-dlf-navigation-double+">
-                <f:if condition="{double} && {page} < {numPages}">
-                    <f:then>
-                        <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{page + 1}'}">
-                            <f:translate key="doublePage+1"/>
-                        </f:link.action>
-                    </f:then>
-                    <f:else>
-                        <span title="{f:translate(key: 'doublePage+1') -> f:format.htmlspecialchars()}">
-                            <f:translate key="doublePage+1"/>
-                        </span>
-                    </f:else>
-                </f:if>
-            </div>
+                    </div>
+                    <div class="tx-dlf-navigation-double+">
+                        <f:if condition="{double} && ({page} < {numPages})">
+                            <f:then>
+                                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{page + 1}'}">
+                                    <f:translate key="doublePage+1"/>
+                                </f:link.action>
+                            </f:then>
+                            <f:else>
+                                <span title="{f:translate(key: 'doublePage+1')}">
+                                    <f:translate key="doublePage+1"/>
+                                </span>
+                            </f:else>
+                        </f:if>
+                    </div>
+                </f:then>
+                <f:else>
+                    <f:link.action addQueryString="1" additionalParams="{'tx_dlf[double]':'1'}">
+                        <f:translate key="doublePageOn"/>
+                    </f:link.action>
+                </f:else>
+            </f:if>
         </f:then>
         <f:else>
-            <span title="{f:translate(key: 'doublePageOn') -> f:format.htmlspecialchars()}">
-                <f:translate key="doublePageOn"/>
-            </span>
-            <span title="{f:translate(key: 'doublePage+1') -> f:format.htmlspecialchars()}">
-                <f:translate key="doublePage+1"/>
-            </span>
+            <div class="tx-dlf-navigation-double">
+                <span title="{f:translate(key: 'doublePageOn')}">
+                    <f:translate key="doublePageOn"/>
+                </span>
+            </div>
         </f:else>
     </f:if>
+</f:section>
 
+<f:section name="render.pageFirst">
     <div class="tx-dlf-navigation-first">
         <f:if condition="{page} > 1">
             <f:then>
@@ -59,13 +70,15 @@
                 </f:link.action>
             </f:then>
             <f:else>
-                <span title="{f:translate(key: 'firstPage') -> f:format.htmlspecialchars()}">
+                <span title="{f:translate(key: 'firstPage')}">
                     <f:translate key="firstPage"/>
                 </span>
             </f:else>
         </f:if>
     </div>
+</f:section>
 
+<f:section name="render.pageBack">
     <div class="tx-dlf-navigation-back">
         <f:if condition="{page} > {pageSteps}">
             <f:then>
@@ -74,13 +87,16 @@
                 </f:link.action>
             </f:then>
             <f:else>
-                <span title="{f:translate(key: 'backXPages', arguments: '{0: pageSteps}') -> f:format.htmlspecialchars()}">
+                <span title="{f:translate(key: 'backXPages', arguments: '{0: pageSteps}')}">
                     <f:translate key="backXPages" arguments="{0: '{pageSteps}'}"/>
                 </span>
             </f:else>
         </f:if>
     </div>
-    <div class="tx-dlf-navigation-prev-1">
+</f:section>
+
+<f:section name="render.pageStepBack">
+    <div class="tx-dlf-navigation-prev">
         <f:if condition="{page} > {double + 1}">
             <f:then>
                 <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{page - 1 + double}'}">
@@ -88,21 +104,30 @@
                 </f:link.action>
             </f:then>
             <f:else>
-                <span title="{f:translate(key: 'prevPage') -> f:format.htmlspecialchars()}">
+                <span title="{f:translate(key: 'prevPage')}">
                     <f:translate key="prevPage"/>
                 </span>
             </f:else>
         </f:if>
     </div>
+</f:section>
+
+<f:section name="render.pageselect">
     <div class="tx-dlf-navigation-pageselect">
-        <f:form action="" method="POST" fieldNamePrefix="tx_dlf" addQueryString="1" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" absolute="{forceAbsoluteUrl}">
+        <f:form method="get" fieldNamePrefix="tx_dlf" addQueryString="1" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}">
             <label for="{uniqueId}">
                 <f:translate key="selectPage"/>
             </label>
-            <f:form.select id="{uniqueId}" name="page" options="{pageOptions}" value="{page}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
+            <f:form.select id="{uniqueId}" name="page"
+                options="{pageOptions}"
+                value="{page}"
+                additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
             </f:form.select>
         </f:form>
     </div>
+</f:section>
+
+<f:section name="render.pageForward">
     <div class="tx-dlf-navigation-next">
         <f:if condition="{page} < {numPages}">
             <f:then>
@@ -111,26 +136,32 @@
                 </f:link.action>
             </f:then>
             <f:else>
-                <span title="{f:translate(key: 'nextPage') -> f:format.htmlspecialchars()}">
+                <span title="{f:translate(key: 'nextPage')}">
                     <f:translate key="nextPage"/>
                 </span>
             </f:else>
         </f:if>
     </div>
-    <div class="tx-dlf-navigation-fwd">
-        <f:if condition="{page} <= {numPages - pageSteps}">
-            <f:then>
-                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{page + pageSteps}'}">
-                    <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
-                </f:link.action>
-            </f:then>
-            <f:else>
-                <span title="{f:translate(key: 'forwardXPages', arguments: '{0: pageSteps}') -> f:format.htmlspecialchars()}">
-                    <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
-                </span>
-            </f:else>
-        </f:if>
-    </div>
+</f:section>
+
+<f:section name="render.pageStepForward">
+        <div class="tx-dlf-navigation-fwd">
+            <f:if condition="{page} <= {numPages - pageSteps}">
+                <f:then>
+                    <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{page + pageSteps}'}">
+                        <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
+                    </f:link.action>
+                </f:then>
+                <f:else>
+                    <span title="{f:translate(key: 'forwardXPages', arguments: '{0: pageSteps}')}">
+                        <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
+                    </span>
+                </f:else>
+            </f:if>
+        </div>
+</f:section>
+
+<f:section name="render.pageLast">
     <div class="tx-dlf-navigation-last">
         <f:if condition="{page} < {numPages}">
             <f:then>
@@ -139,47 +170,55 @@
                 </f:link.action>
             </f:then>
             <f:else>
-                <span title="{f:translate(key: 'lastPage') -> f:format.htmlspecialchars()}">
+                <span title="{f:translate(key: 'lastPage'}">
                     <f:translate key="lastPage"/>
                 </span>
             </f:else>
         </f:if>
     </div>
-    <div class="tx-dlf-navigation-listview">
-        <f:link.typolink parameter="{pageToList}" absolute="{forceAbsoluteUrl}" title="{f:translate(key: 'linkToList') -> f:format.htmlspecialchars()}">
-            <f:translate key="linkToList"/>
-        </f:link.typolink>
-    </div>
+</f:section>
+
+<f:section name="render.listview">
+        <div class="tx-dlf-navigation-listview">
+            <f:link.page pageUid="{settings.targetPid}">
+                <f:translate key="linkToList"/>
+            </f:link.page>
+        </div>
+</f:section>
+
+<f:section name="render.zoom">
     <div class="tx-dlf-navigation-zoom-in">
-        <span title="{f:translate(key: 'zoomIn') -> f:format.htmlspecialchars()}">
+        <a href="#" title="{f:translate(key: 'zoomIn')}" onclick="tx_dlf_viewer.map.zoomIn();">
             <f:translate key="zoomIn"/>
-        </span>
+        </a>
     </div>
     <div class="tx-dlf-navigation-zoom-out">
-        <span title="{f:translate(key: 'zoomOut') -> f:format.htmlspecialchars()}">
+        <a href="#" title="{f:translate(key: 'zoomOut')}" onclick="tx_dlf_viewer.map.zoomOut();">
             <f:translate key="zoomOut"/>
-        </span>
+        </a>
     </div>
     <div class="tx-dlf-navigation-fullscreen">
-        <span title="{f:translate(key: 'zoomFullscreen') -> f:format.htmlspecialchars()}">
+        <a href="#" title="{f:translate(key: 'zoomFullscreen')}">
             <f:translate key="zoomFullscreen"/>
-        </span>
+        </a>
     </div>
+</f:section>
+
+<f:section name="render.rotation">
     <div class="tx-dlf-navigation-rotate-left">
-        <span title="{f:translate(key: 'rotateLeft') -> f:format.htmlspecialchars()}">
+        <a href="#" title="{f:translate(key: 'rotateLeft')}" onclick="tx_dlf_viewer.map.rotateLeft();">
             <f:translate key="rotateLeft"/>
-        </span>
+        </a>
     </div>
     <div class="tx-dlf-navigation-rotate-right">
-        <span title="{f:translate(key: 'rotateRight') -> f:format.htmlspecialchars()}">
+        <a href="#" title="{f:translate(key: 'rotateRight')}" onclick="tx_dlf_viewer.map.rotateRight();">
             <f:translate key="rotateRight"/>
-        </span>
+        </a>
     </div>
     <div class="tx-dlf-navigation-rotate-reset">
-        <span title="{f:translate(key: 'rotateReset') -> f:format.htmlspecialchars()}">
+        <a href="#" title="{f:translate(key: 'rotateReset')}" onclick="tx_dlf_viewer.map.resetRotation();">
             <f:translate key="rotateReset"/>
-        </span>
+        </a>
     </div>
-
-
+</f:section>
 </html>


### PR DESCRIPTION

* make all navigation features selectable by flexform
* make the order of features sortable by flexform
* some cleanups

This makes live easier (or even possible) for usage of the navigation plugin in [slub_digitalcollections](https://github.com/slub/slub_digitalcollections) or other customization extensions.