### PR TITLE
Set owner correctly on (re-) indexing documents.

### DIFF
--- a/Classes/Common/Document.php
+++ b/Classes/Common/Document.php
@@ -1130,7 +1130,7 @@ abstract class Document
 
         // Get UID for owner.
         if (empty($owner)) {
-            $owner = empty($metadata['owner'][0]) ? $metadata['owner'][0] : 'default';
+            $owner = $metadata['owner'][0] ? : 'default';
         }
         if (!MathUtility::canBeInterpretedAsInteger($owner)) {
             $result = $queryBuilder

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -629,9 +629,11 @@ final class MetsDocument extends Document
 
                 $allResults = $result->fetchAll();
 
-                foreach ($allResults as $resArray) {
-                    if (!in_array($resArray['index_name'], $metadata['collection'])) {
-                        $metadata['collection'][] = $resArray['index_name'];
+                if (is_array($allResults)) {
+                    foreach ($allResults as $resArray) {
+                        if (!in_array($resArray['index_name'], $metadata['collection'])) {
+                            $metadata['collection'][] = $resArray['index_name'];
+                        }
                     }
                 }
 
@@ -647,11 +649,15 @@ final class MetsDocument extends Document
                         $queryBuilder->expr()->eq('tx_dlf_documents.pid', intval($cPid)),
                         $queryBuilder->expr()->eq('tx_dlf_documents.uid', intval($this->uid))
                     )
+                    ->setMaxResults(1)
                     ->execute();
 
-                $resArray = $result->fetch();
-
-                $metadata['owner'][0] = $resArray['owner'];
+                if ($resArray = $result->fetch()) {
+                    // Only overwrite owner with found value, if not already set.
+                    if (empty($metadata['owner'][0]) && isset($resArray['owner'])) {
+                        $metadata['owner'][0] = $resArray['owner'];
+                    }
+                }
             }
             // Extract metadata only from first supported dmdSec.
             $hasSupportedMetadata = true;


### PR DESCRIPTION
This fixes #751.

The priority is the owner found in METS file over the already set owner in the database. The solution before made the priority the other way round (database always wins) which makes it impossible "messed up" installations. With almost all other fields, the METS file always overwrites values in the database on reindexing.