### PR TITLE
Speedup PageViewProxy

### DIFF
--- a/Classes/Common/StdOutStream.php
+++ b/Classes/Common/StdOutStream.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Common;
+
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
+use TYPO3\CMS\Core\Http\SelfEmittableStreamInterface;
+
+/**
+ * Stream decorator to allow printing a stream to standard output in chunks.
+ */
+class StdOutStream implements StreamInterface, SelfEmittableStreamInterface
+{
+    use StreamDecoratorTrait;
+
+    public function emit()
+    {
+        // Disable output buffering
+        ob_end_flush();
+
+        // Stream content in chunks of 8KB
+        while (!$this->stream->eof()) {
+            echo $this->stream->read(8 * 1024);
+        }
+    }
+}

--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -15,6 +15,7 @@ namespace Kitodo\Dlf\Plugin\Eid;
 use Kitodo\Dlf\Common\Helper;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\Response;
@@ -35,9 +36,15 @@ class PageViewProxy
      */
     protected $requestFactory;
 
+    /**
+     * @var mixed
+     */
+    protected $extConf;
+
     public function __construct()
     {
         $this->requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+        $this->extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('dlf');
     }
 
     protected function overwriteHeaders(array $headers)
@@ -73,10 +80,15 @@ class PageViewProxy
 
         try {
             $response = $this->requestFactory->request($url, 'GET', [
+                'headers' => [
+                    'User-Agent' => $this->extConf['useragent'] ?? 'Kitodo.Presentation Proxy',
+                ],
+
                 // For performance, don't download content up-front. Rather, we'll
                 // download and upload simultaneously.
                 // https://docs.guzzlephp.org/en/6.5/request-options.html#stream
                 'stream' => true,
+
                 // Don't throw exceptions when a non-success status code is
                 // received. We handle these manually.
                 'http_errors' => false,

--- a/Classes/Plugin/Eid/PageViewProxy.php
+++ b/Classes/Plugin/Eid/PageViewProxy.php
@@ -25,6 +25,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * eID image proxy for plugin 'Page View' of the 'dlf' extension
  *
+ * Supported query parameters:
+ * - `url` (mandatory): The URL to be proxied
+ * - `uHash` (mandatory): HMAC of the URL
+ *
  * @author Alexander Bigga <alexander.bigga@slub-dresden.de>
  * @package TYPO3
  * @subpackage dlf
@@ -58,13 +62,15 @@ class PageViewProxy
      */
     public function main(ServerRequestInterface $request)
     {
-        $url = (string) $request->getQueryParams()['url'];
+        $queryParams = $request->getQueryParams();
+
+        $url = (string) ($queryParams['url'] ?? '');
         if (!Helper::isValidHttpUrl($url)) {
             return new JsonResponse(['message' => 'Did not receive a valid URL.'], 400);
         }
 
         // get and verify the uHash
-        $uHash = (string) $request->getQueryParams()['uHash'];
+        $uHash = (string) ($queryParams['uHash'] ?? '');
         if (!hash_equals(GeneralUtility::hmac($url, 'PageViewProxy'), $uHash)) {
             return new JsonResponse(['message' => 'No valid uHash passed!'], 401);
         }


### PR DESCRIPTION
This PR optimizes the PageViewProxy. While we may still want to switch to a proper image proxy eventually (I suppose), this could at least improve the current situation.

The speedup will be roughly to the amount that it takes for the proxy to connect to and download the data from the target. So this may help whenever the target is slow to respond, or the connection between proxy and target is slow. 

Sample URLs:
- Original image (on my setup, this has a TTFB of ~650ms)
  https://pic.sub.uni-hamburg.de/PPN1012341925_18871104/2000/0/00000001.tif (from [Zeitungsportal](https://www.deutsche-digitale-bibliothek.de/newspaper/item/3K75DNS4VPZ56Y6YLVNLJJWITTHCEWLP?fromDay=1&fromMonth=1&fromYear=1887&toDay=31&toMonth=12&toYear=1887&hit=1&issuepage=1))
- Proxied URL
  https://ddev-kitodo-presentation.ddev.site/?eID=tx_dlf_pageview_proxy&url=https%3A%2F%2Fpic.sub.uni-hamburg.de%2FPPN1012341925_18871104%2F2000%2F0%2F00000001.tif

There are two main changes:
- The previous version called `GeneralUtility::getUrl()` twice, once for headers and once for data. This is replaced with just once request (though I also use GuzzleHttp directly). This should help for cases with high TTFB, where even a HEAD request may be slow.
- Previously, the proxy would first download all content and only then start to send it to its client. This is replaced with a streaming approach, where data is fetched/sent in chunks. This should help for cases with low throughput between target and proxy.