### PR TITLE
Add lazy loading to document model

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -82,7 +82,7 @@ class BaseCommand extends Command
             $frameworkConfiguration['persistence']['storagePid'] = MathUtility::forceIntegerInRange((int) $storagePid, 0);
             $configurationManager->setConfiguration($frameworkConfiguration);
 
-            // TODO: When we drop support for TYPO3@9, we needn't/shouldn't use ObjectManager anymore
+            // TODO: When we drop support for TYPO3v9, we needn't/shouldn't use ObjectManager anymore
             $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
             $this->collectionRepository = $objectManager->get(CollectionRepository::class);

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -1078,7 +1078,7 @@ class Helper
      * This transforms the structure used in `Classes.php` to that used in
      * `ext_typoscript_setup.txt`. See commit 5e6110fb for a similar approach.
      *
-     * @deprecated Remove once we drop support for TYPO3@9
+     * @deprecated Remove once we drop support for TYPO3v9
      *
      * @access public
      */

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -101,7 +101,7 @@ class Indexer
             // Handle multi-volume documents.
             if ($parentId = $document->getPartof()) {
                 // initialize documentRepository
-                // TODO: When we drop support for TYPO3@9, we needn't/shouldn't use ObjectManager anymore
+                // TODO: When we drop support for TYPO3v9, we needn't/shouldn't use ObjectManager anymore
                 $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
                 $documentRepository = $objectManager->get(DocumentRepository::class);
                 // get parent document

--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Domain\Model;
 
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
@@ -153,6 +154,7 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Kitodo\Dlf\Domain\Model\Collection>
+     * @Extbase\ORM\Lazy
      */
     protected $collections = null;
 
@@ -168,6 +170,7 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
     /**
      * @var \Kitodo\Dlf\Domain\Model\Library
+     * @Extbase\ORM\Lazy
      */
     protected $owner;
 

--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -72,7 +72,7 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
     {
         Helper::polyfillExtbaseClassesForTYPO3v9();
 
-        // TODO: When we drop support for TYPO3@9, we needn't/shouldn't use ObjectManager anymore
+        // TODO: When we drop support for TYPO3v9, we needn't/shouldn't use ObjectManager anymore
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $configurationManager = $objectManager->get(ConfigurationManager::class);
         $frameworkConfiguration = $configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -40,9 +40,5 @@ return [
     ],
     \Kitodo\Dlf\Domain\Model\Token::class => [
         'tableName' => 'tx_dlf_tokens',
-    ],
-    // This mapping is only required in TYPO3v9. It usually comes from the core.
-    TYPO3\CMS\Extbase\Domain\Model\FileReference::class => [
-        'tableName' => 'sys_file_reference',
     ]
 ];

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -41,4 +41,8 @@ return [
     \Kitodo\Dlf\Domain\Model\Token::class => [
         'tableName' => 'tx_dlf_tokens',
     ],
+    // This mapping is only required in TYPO3v9. It usually comes from the core.
+    TYPO3\CMS\Extbase\Domain\Model\FileReference::class => [
+        'tableName' => 'sys_file_reference',
+    ]
 ];


### PR DESCRIPTION
The documentTypeSwitch has a strange behavior with TYPO3v9.
Sometimes the class mapping array is empty. That's why we set
the class mapping with `Helper::polyfillExtbaseClassesForTYPO3v9()`.

Even worse is the missing of the mapping for the sys_file_reference
table. This is required by `tx_dlf_collections.thumbnail` field.

This can be fixed by lazy loading the collections relation from the document class.