### PR TITLE
dev-extbase-fluid: Some fixes to OAI-PMH interface

### DIFF
--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -782,6 +782,9 @@ class OaiPmhController extends AbstractController
         $expireDateTime->add(new \DateInterval('PT' . $this->settings['expired'] . 'S'));
         $resumptionTokenInfo['expired'] = $expireDateTime;
 
-        $this->view->assign('resumptionToken', $resumptionTokenInfo);
+        $omitResumptionToken = $currentCursor === 0 && $numShownDocuments >= $documentListSet['metadata']['completeListSize'];
+        if (!$omitResumptionToken) {
+            $this->view->assign('resumptionToken', $resumptionTokenInfo);
+        }
     }
 }

--- a/Classes/Domain/Repository/CollectionRepository.php
+++ b/Classes/Domain/Repository/CollectionRepository.php
@@ -123,7 +123,7 @@ class CollectionRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
             )
             ->from('tx_dlf_collections')
             ->where(
-                $queryBuilder->expr()->eq('tx_dlf_collections.pid', intval($settings['pages'])),
+                $queryBuilder->expr()->eq('tx_dlf_collections.pid', intval($settings['storagePid'])),
                 $queryBuilder->expr()->eq('tx_dlf_collections.oai_name',
                     $queryBuilder->expr()->literal($set)),
                 $where,

--- a/Resources/Private/Templates/OaiPmh/Main.xml
+++ b/Resources/Private/Templates/OaiPmh/Main.xml
@@ -16,7 +16,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate><f:format.date format="Y-m-d\TH:i:s\Z">now</f:format.date></responseDate>
-    <request{f:if(condition: i.isFirst, then: ' {key}="{value}"', else: ' {key}="{value}"') -> f:for(each:'{parameters}', as:'value', key:'key', iteration:'i')}><f:uri.page absolute="1" /></request>
+    <f:comment>As per the specification, don't show arguments on badVerb or badArgument.</f:comment>
+    {f:if(condition: '{error} == "badVerb" || {error} == "badArgument"', then: '{}', else: '{parameters}') -> f:variable(name: 'shownParameters')}
+    <request{f:if(condition: i.isFirst, then: ' {key}="{value}"', else: ' {key}="{value}"') -> f:for(each:'{shownParameters}', as:'value', key:'key', iteration:'i')}><f:uri.page absolute="1" /></request>
     <f:if condition="{error}">
         <f:then>
             <error code="{error}">
@@ -122,7 +124,9 @@
                         </f:else>
                     </f:if>
                 </f:for>
-                <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>
+                <f:if condition="{resumptionToken.token}">
+                    <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>
+                </f:if>
             </ListIdentifiers>
         </f:then>
     </f:if>
@@ -158,7 +162,10 @@
                         </f:if>
                     </record>
                 </f:for>
-                <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>            </ListRecords>
+                <f:if condition="{resumptionToken.token}">
+                    <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>
+                </f:if>
+            </ListRecords>
         </f:then>
     </f:if>
 </f:section>

--- a/Resources/Private/Templates/OaiPmh/Main.xml
+++ b/Resources/Private/Templates/OaiPmh/Main.xml
@@ -124,9 +124,7 @@
                         </f:else>
                     </f:if>
                 </f:for>
-                <f:if condition="{resumptionToken.token}">
-                    <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>
-                </f:if>
+                <f:render section="resumptionToken" arguments="{resumptionToken: resumptionToken}" />
             </ListIdentifiers>
         </f:then>
     </f:if>
@@ -162,9 +160,7 @@
                         </f:if>
                     </record>
                 </f:for>
-                <f:if condition="{resumptionToken.token}">
-                    <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>
-                </f:if>
+                <f:render section="resumptionToken" arguments="{resumptionToken: resumptionToken}" />
             </ListRecords>
         </f:then>
     </f:if>
@@ -242,4 +238,17 @@
         </f:case>
         <f:defaultCase><error code="badVerb"><f:translate key="oaipmh.badVerb" /></error></f:defaultCase>
     </f:switch>
+</f:section>
+
+<f:section name="resumptionToken">
+    <f:if condition="{resumptionToken}">
+        <f:if condition="{resumptionToken.token}">
+            <f:then>
+                <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" expirationDate="<f:format.date format="Y-m-d\TH:i:s\Z">{resumptionToken.expired}</f:format.date>">{resumptionToken.token}</resumptionToken>
+            </f:then>
+            <f:else>
+                <resumptionToken cursor="{resumptionToken.cursor}" completeListSize="{resumptionToken.completeListSize}" />
+            </f:else>
+        </f:if>
+    </f:if>
 </f:section>

--- a/Resources/Public/Stylesheets/OaiPmh.xsl
+++ b/Resources/Public/Stylesheets/OaiPmh.xsl
@@ -381,7 +381,7 @@ p.intro {
         <p>There are more results.</p>
     </xsl:if>
     <table class="values">
-        <tr><td class="key">Submitted Records</td>
+        <tr><td class="key">Cursor</td>
         <td class="value"><xsl:value-of select="@cursor"/></td></tr>
         <tr><td class="key">Total Records</td>
         <td class="value"><xsl:value-of select="@completeListSize"/></td></tr>


### PR DESCRIPTION
This fixes some issues that I noticed while writing tests (#756).

---

- Fix listing records and identifiers (set $resultSet['elements'])
- Fix XML error when embedding METS documents (there has been an excess angle bracket)
- Don't include <resumptionToken> tag when there's no token
- Fix value of cursor attribute in <resumptionToken>
- Don't show request parameters when there's a badVerb or badArgument
- Restore fallback "earliestDatestamp" when no document is found