### PR TITLE
PageView Performance

### DIFF
--- a/Documentation/Features/PageView.rst
+++ b/Documentation/Features/PageView.rst
@@ -22,6 +22,7 @@ The viewer supports various image formats. Each of them should work in single pa
    *  https://digital.slub-dresden.de/data/kitodo/aufdesun_351357262/aufdesun_351357262_mets.xml
    *  `Single page view <https://ddev-kitodo-presentation.ddev.site/workview?tx_dlf[id]=https%3A%2F%2Fdigital.slub-dresden.de%2Fdata%2Fkitodo%2Faufdesun_351357262%2Faufdesun_351357262_mets.xml&tx_dlf[page]=4>`__
    *  `Single page view with word highlighting <https://ddev-kitodo-presentation.ddev.site/workview?tx_dlf[id]=https%3A%2F%2Fdigital.slub-dresden.de%2Fdata%2Fkitodo%2Faufdesun_351357262%2Faufdesun_351357262_mets.xml&tx_dlf[page]=4&tx_dlf[highlight_word]=Dresden>`__
+   *  `Double page view with word highlighting <https://ddev-kitodo-presentation.ddev.site/workview?tx_dlf[id]=https%3A%2F%2Fdigital.slub-dresden.de%2Fdata%2Fkitodo%2Faufdesun_351357262%2Faufdesun_351357262_mets.xml&tx_dlf[page]=4&tx_dlf[double]=1&tx_dlf[highlight_word]=Dresden>`__
 
 *  IIIF Image API
 
@@ -67,7 +68,13 @@ In the *Digital Collections* template, activate the tool by clicking the slider 
 Full Text
 ---------
 
-In the *Digital Collections* template, click the reading-glass icon.
+In the *Digital Collections* template, the following full text features are available:
+
+*  Click the reading-glass icon on the left to toggle the fulltext overlay.
+   When hovering a text line on the image, the corresponding part should be highlighted in the overlay.
+
+*  When showing an indexed document, click the search icon on the right to toggle in-document search.
+   Search results should be highlighted on the page.
 
 Overview Map and Zoom Buttons
 -----------------------------

--- a/Documentation/Features/PageView.rst
+++ b/Documentation/Features/PageView.rst
@@ -76,6 +76,8 @@ In the *Digital Collections* template, the following full text features are avai
 *  When showing an indexed document, click the search icon on the right to toggle in-document search.
    Search results should be highlighted on the page.
 
+*  In single page mode, click the download link and select "Fulltext page (TXT)" to download the raw text.
+
 Overview Map and Zoom Buttons
 -----------------------------
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -373,6 +373,10 @@
 				<source><![CDATA[Full text]]></source>
 				<target><![CDATA[Volltext]]></target>
 			</trans-unit>
+			<trans-unit id="tools.fulltext.loading" approved="yes">
+				<source><![CDATA[Loading full text...]]></source>
+				<target><![CDATA[Volltext wird geladen...]]></target>
+			</trans-unit>
 			<trans-unit id="tools.fulltext.not-available" approved="yes">
 				<source><![CDATA[No full text available]]></source>
 				<target><![CDATA[Keine Volltexte vorhanden]]></target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -188,6 +188,9 @@
 			<trans-unit id="tools.fulltext">
 				<source><![CDATA[Full text]]></source>
 			</trans-unit>
+			<trans-unit id="tools.fulltext.loading">
+				<source><![CDATA[Loading full text...]]></source>
+			</trans-unit>
 			<trans-unit id="tools.fulltext.not-available">
 				<source><![CDATA[No full text available]]></source>
 			</trans-unit>

--- a/Resources/Private/Templates/Toolbox/Main.html
+++ b/Resources/Private/Templates/Toolbox/Main.html
@@ -83,6 +83,7 @@
                         <f:then>
                             <a class="select switchoff" id="tx-dlf-tools-fulltext" title=""
                                 data-dic="fulltext:{f:translate(key: 'tools.fulltext')}
+                                        ;fulltext-loading:{f:translate(key: 'tools.fulltext.loading')}
                                         ;fulltext-on:{f:translate(key: 'tools.fulltext.on')}
                                         ;fulltext-off:{f:translate(key: 'tools.fulltext.off')}
                                         ;activate-full-text-initially:{activateFullTextInitially}

--- a/Resources/Public/Javascript/PageView/AltoParser.js
+++ b/Resources/Public/Javascript/PageView/AltoParser.js
@@ -9,6 +9,14 @@
  */
 
 /**
+ * @typedef {ol.Feature & {
+ *  getStringFeatures: () => any[];
+ *  getTextblocks: () => any[];
+ *  getTextlines: () => any[];
+ * }} FullTextFeature
+ */
+
+/**
  * @constructor
  * @param {Object=} opt_imageObj
  * @param {number=} opt_width
@@ -105,7 +113,7 @@ dlfAltoParser.prototype.parseAltoFeature_ = function(node) {
 
 /**
  * @param {XMLDocument|string} document
- * @return {Array.<ol.Feature>}
+ * @return {Array.<FullTextFeature>}
  */
 dlfAltoParser.prototype.parseFeatures = function(document) {
     var parsedDoc = this.parseXML_(document),

--- a/Resources/Public/Javascript/PageView/FullTextUtility.js
+++ b/Resources/Public/Javascript/PageView/FullTextUtility.js
@@ -47,16 +47,25 @@ dlfFullTextUtils.isFeatureEqual = function(element, feature){
  * @return {FullTextFeature | undefined}
  * @static
  */
-dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset){
-    // fetch data from server
-    var request = $.ajax({
-        url,
-        async: false
+dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset) {
+    var result = new $.Deferred();
+
+    $.ajax({ url }).done(function (data, status, jqXHR) {
+        try {
+            var fulltext = dlfFullTextUtils.parseAltoData(image, optOffset, jqXHR);
+
+            if (fulltext === undefined) {
+                result.reject();
+            } else {
+                result.resolve(fulltext);
+            }
+        } catch (e) {
+            console.error(e);
+            result.reject();
+        }
     });
 
-    var offset = dlfUtils.exists(optOffset) ? optOffset : undefined;
-
-    return dlfFullTextUtils.parseAltoData(image, offset, request);
+    return result;
 };
 
 /**

--- a/Resources/Public/Javascript/PageView/FullTextUtility.js
+++ b/Resources/Public/Javascript/PageView/FullTextUtility.js
@@ -44,7 +44,7 @@ dlfFullTextUtils.isFeatureEqual = function(element, feature){
  * @param {string} url
  * @param {Object} image
  * @param {number=} optOffset
- * @return {ol.Feature|undefined}
+ * @return {FullTextFeature | undefined}
  * @static
  */
 dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset){
@@ -64,7 +64,7 @@ dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset){
  * @param {Object} image
  * @param {number=} offset
  * @param {Object} request
- * @return {ol.Feature|undefined}
+ * @return {FullTextFeature | undefined}
  * @static
  */
 dlfFullTextUtils.parseAltoData = function(image, offset, request){

--- a/Resources/Public/Javascript/PageView/FullTextUtility.js
+++ b/Resources/Public/Javascript/PageView/FullTextUtility.js
@@ -60,7 +60,7 @@ dlfFullTextUtils.fetchFullTextDataFromServer = function(url, image, optOffset) {
                 result.resolve(fulltext);
             }
         } catch (e) {
-            console.error(e);
+            console.error(e); // eslint-disable-line no-console
             result.reject();
         }
     });

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -73,10 +73,9 @@ dlfFulltextSegments.prototype.coordinateToFeature = function (coordinate) {
  * Encapsulates especially the fulltext behavior
  * @constructor
  * @param {ol.Map} map
- * @param {Object} image
- * @param {string} fulltextUrl
+ * @param {FullTextFeature} fulltextData
  */
-var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
+var dlfViewerFullTextControl = function(map, fulltextData) {
 
     /**
      * @private
@@ -85,16 +84,10 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
     this.map = map;
 
     /**
-     * @type {Object}
+     * @type {FullTextFeature}
      * @private
      */
-    this.image = image;
-
-    /**
-     * @type {string}
-     * @private
-     */
-    this.url = fulltextUrl;
+    this.fulltextData_ = fulltextData;
 
     /**
      * @type {Object}
@@ -120,12 +113,6 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
      * @private
      */
     this.fullTextScrollElement = this.dic['full-text-scroll-element'];
-
-    /**
-     * @type {ol.Feature|undefined}
-     * @private
-     */
-    this.fulltextData_ = undefined;
 
     /**
      * @type {Object}
@@ -423,27 +410,22 @@ dlfViewerFullTextControl.prototype.activate = function() {
 
     var controlEl = $('#tx-dlf-tools-fulltext');
 
-    // if the activate method is called for the first time fetch
-    // fulltext data from server
-    if (this.fulltextData_ === undefined)  {
-        this.fulltextData_ = dlfFullTextUtils.fetchFullTextDataFromServer(this.url, this.image);
+    // if the activate method is called for the first time, render fulltext data
+    if (this.lastRenderedFeatures_ === undefined)  {
+        // add features to fulltext layer
+        const textblockFeatures = this.fulltextData_.getTextblocks();
+        this.layers_.textblock.getSource().addFeatures(textblockFeatures);
+        this.textblocks_.populate(textblockFeatures);
 
-        if (this.fulltextData_ !== undefined) {
-            // add features to fulltext layer
-            const textblockFeatures = this.fulltextData_.getTextblocks();
-            this.layers_.textblock.getSource().addFeatures(textblockFeatures);
-            this.textblocks_.populate(textblockFeatures);
+        const textlineFeatures = this.fulltextData_.getTextlines();
+        this.layers_.textline.getSource().addFeatures(textlineFeatures);
+        this.textlines_.populate(textlineFeatures);
 
-            const textlineFeatures = this.fulltextData_.getTextlines();
-            this.layers_.textline.getSource().addFeatures(textlineFeatures);
-            this.textlines_.populate(textlineFeatures);
-
-            // add first feature of textBlockFeatures to map
-            if (this.fulltextData_.getTextblocks().length > 0) {
-                this.layers_.select.getSource().addFeature(this.fulltextData_.getTextblocks()[0]);
-                this.selectedFeature_ = this.fulltextData_.getTextblocks()[0];
-                this.showFulltext(this.fulltextData_.getTextblocks());
-            }
+        // add first feature of textBlockFeatures to map
+        if (this.fulltextData_.getTextblocks().length > 0) {
+            this.layers_.select.getSource().addFeature(this.fulltextData_.getTextblocks()[0]);
+            this.selectedFeature_ = this.fulltextData_.getTextblocks()[0];
+            this.showFulltext(this.fulltextData_.getTextblocks());
         }
     }
 

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -531,6 +531,18 @@ dlfViewerFullTextControl.prototype.enableFulltextSelect = function() {
 };
 
 /**
+ * Template elements to be used via cloneNode when rendering fulltext.
+ */
+var dlfTmplFulltext = {
+    word: document.createElement('span'),
+    textline: document.createElement('span'),
+    space: document.createElement('span'),
+};
+
+dlfTmplFulltext.textline.className = "textline";
+dlfTmplFulltext.space.className = "sp";
+
+/**
  * Show full text
  *
  * @param {Array.<ol.Feature>|undefined} features
@@ -538,13 +550,17 @@ dlfViewerFullTextControl.prototype.enableFulltextSelect = function() {
 dlfViewerFullTextControl.prototype.showFulltext = function(features) {
 
     if (features !== undefined) {
-        $('#tx-dlf-fulltextselection').children().remove();
-        for (var feature of features) {
-            var textLines = feature.get('textlines');
-            for (var textLine of textLines) {
-                this.appendTextLineSpan(textLine);
+        var target = document.getElementById('tx-dlf-fulltextselection');
+        if (target !== null) {
+            target.innerHTML = "";
+            for (var feature of features) {
+                var textLines = feature.get('textlines');
+                for (var textLine of textLines) {
+                    var textLineSpan = this.getTextLineSpan(textLine);
+                    target.append(textLineSpan);
+                }
+                target.append(document.createElement('br'), document.createElement('br'));
             }
-            $('#tx-dlf-fulltextselection').append('<br /><br />');
         }
     }
 };
@@ -554,16 +570,19 @@ dlfViewerFullTextControl.prototype.showFulltext = function(features) {
  *
  * @param {Object} textLine
  */
-dlfViewerFullTextControl.prototype.appendTextLineSpan = function(textLine) {
-    var textLineSpan = $('<span class="textline" id="' + textLine.getId() + '">');
+dlfViewerFullTextControl.prototype.getTextLineSpan = function(textLine) {
+    var textLineSpan = dlfTmplFulltext.textline.cloneNode();
+    textLineSpan.id = textLine.getId();
+
     var content = textLine.get('content');
 
     for (var item of content) {
         textLineSpan.append(this.getItemForTextLineSpan(item));
     }
 
-    textLineSpan.append('<span class="sp"> </span>');
-    $('#tx-dlf-fulltextselection').append(textLineSpan);
+    textLineSpan.append(dlfTmplFulltext.space.cloneNode());
+
+    return textLineSpan;
 };
 
 /**
@@ -572,14 +591,14 @@ dlfViewerFullTextControl.prototype.appendTextLineSpan = function(textLine) {
  *
  * @param {Object} item
  *
- * @return {string}
+ * @return {HTMLElement}
  */
 dlfViewerFullTextControl.prototype.getItemForTextLineSpan = function(item) {
-    var span = '';
-    if (item.get('type') === 'string') {
-        span = $('<span class="' + item.get('type') + '" id="' + item.getId() + '"/>');
-    } else {
-        span = $('<span class="' + item.get('type') + '"/>');
+    var type = item.get('type');
+    var span = dlfTmplFulltext.word.cloneNode();
+    span.className = type;
+    if (type === 'string') {
+        span.id = item.getId();
     }
 
     var spanText = item.get('fulltext');
@@ -587,8 +606,9 @@ dlfViewerFullTextControl.prototype.getItemForTextLineSpan = function(item) {
     for (const [i, spanTextLine] of spanTextLines.entries()) {
         span.append(document.createTextNode(spanTextLine));
         if (i < spanTextLines.length - 1) {
-            span.append($('<br />'));
+            span.append(document.createElement('br'));
         }
     }
+
     return span;
 };

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -35,7 +35,7 @@ var dlfFulltextSegments = function () {
      * @private
      */
     this.segments_ = [];
-}
+};
 
 /**
  * Add {@link features} to the list of segments.
@@ -47,7 +47,7 @@ dlfFulltextSegments.prototype.populate = function (features) {
         var feature = features[i];
 
         this.segments_.push({
-            feature: feature,
+            feature,
             extent: feature.getGeometry().getExtent()
         });
     }
@@ -243,7 +243,7 @@ dlfViewerFullTextControl.prototype.loadFulltextData = function (fulltextData) {
         this.selectedFeature_ = textblockFeatures[0];
         this.showFulltext(textblockFeatures);
     }
-}
+};
 
 /**
  * Add active / deactive behavior in case of click on control depending if the full text should be activated initially.

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -73,21 +73,14 @@ dlfFulltextSegments.prototype.coordinateToFeature = function (coordinate) {
  * Encapsulates especially the fulltext behavior
  * @constructor
  * @param {ol.Map} map
- * @param {FullTextFeature} fulltextData
  */
-var dlfViewerFullTextControl = function(map, fulltextData) {
+var dlfViewerFullTextControl = function(map) {
 
     /**
      * @private
      * @type {ol.Map}
      */
     this.map = map;
-
-    /**
-     * @type {FullTextFeature}
-     * @private
-     */
-    this.fulltextData_ = fulltextData;
 
     /**
      * @type {Object}
@@ -97,6 +90,7 @@ var dlfViewerFullTextControl = function(map, fulltextData) {
         dlfUtils.parseDataDic($('#tx-dlf-tools-fulltext')) :
         {
             'fulltext':'Fulltext',
+            'fulltext-loading':'Loading full text...',
             'fulltext-on':'Activate Fulltext',
             'fulltext-off':'Deactivate Fulltext',
             'activate-full-text-initially':'0',
@@ -225,8 +219,31 @@ var dlfViewerFullTextControl = function(map, fulltextData) {
         this)
     };
 
+    $('#tx-dlf-fulltextselection').text(this.dic['fulltext-loading']);
+
     this.changeActiveBehaviour();
 };
+
+/**
+ * @param {FullTextFeature} fulltextData
+ */
+dlfViewerFullTextControl.prototype.loadFulltextData = function (fulltextData) {
+    // add features to fulltext layer
+    const textblockFeatures = fulltextData.getTextblocks();
+    this.layers_.textblock.getSource().addFeatures(textblockFeatures);
+    this.textblocks_.populate(textblockFeatures);
+
+    const textlineFeatures = fulltextData.getTextlines();
+    this.layers_.textline.getSource().addFeatures(textlineFeatures);
+    this.textlines_.populate(textlineFeatures);
+
+    // add first feature of textBlockFeatures to map
+    if (textblockFeatures.length > 0) {
+        this.layers_.select.getSource().addFeature(textblockFeatures[0]);
+        this.selectedFeature_ = textblockFeatures[0];
+        this.showFulltext(textblockFeatures);
+    }
+}
 
 /**
  * Add active / deactive behavior in case of click on control depending if the full text should be activated initially.
@@ -409,25 +426,6 @@ dlfViewerFullTextControl.prototype.scrollToText = function(element, fullTextScro
 dlfViewerFullTextControl.prototype.activate = function() {
 
     var controlEl = $('#tx-dlf-tools-fulltext');
-
-    // if the activate method is called for the first time, render fulltext data
-    if (this.lastRenderedFeatures_ === undefined)  {
-        // add features to fulltext layer
-        const textblockFeatures = this.fulltextData_.getTextblocks();
-        this.layers_.textblock.getSource().addFeatures(textblockFeatures);
-        this.textblocks_.populate(textblockFeatures);
-
-        const textlineFeatures = this.fulltextData_.getTextlines();
-        this.layers_.textline.getSource().addFeatures(textlineFeatures);
-        this.textlines_.populate(textlineFeatures);
-
-        // add first feature of textBlockFeatures to map
-        if (this.fulltextData_.getTextblocks().length > 0) {
-            this.layers_.select.getSource().addFeature(this.fulltextData_.getTextblocks()[0]);
-            this.selectedFeature_ = this.fulltextData_.getTextblocks()[0];
-            this.showFulltext(this.fulltextData_.getTextblocks());
-        }
-    }
 
     // now activate the fulltext overlay and map behavior
     this.enableFulltextSelect();

--- a/Resources/Public/Javascript/PageView/FulltextControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextControl.js
@@ -161,6 +161,12 @@ var dlfViewerFullTextControl = function(map, image, fulltextUrl) {
     this.selectedFeature_ = undefined;
 
     /**
+     * @type {ol.Feature[] | undefined}
+     * @private
+     */
+    this.lastRenderedFeatures_ = undefined;
+
+    /**
      * @type {dlfFulltextSegments}
      * @private
      */
@@ -548,20 +554,30 @@ dlfTmplFulltext.space.className = "sp";
  * @param {Array.<ol.Feature>|undefined} features
  */
 dlfViewerFullTextControl.prototype.showFulltext = function(features) {
+    if (features === undefined) {
+        return;
+    }
 
-    if (features !== undefined) {
-        var target = document.getElementById('tx-dlf-fulltextselection');
-        if (target !== null) {
-            target.innerHTML = "";
-            for (var feature of features) {
-                var textLines = feature.get('textlines');
-                for (var textLine of textLines) {
-                    var textLineSpan = this.getTextLineSpan(textLine);
-                    target.append(textLineSpan);
-                }
-                target.append(document.createElement('br'), document.createElement('br'));
+    // Don't rerender when it's the same features as last time
+    if (this.lastRenderedFeatures_ !== undefined
+        && dlfUtils.arrayEqualsByIdentity(features, this.lastRenderedFeatures_)
+    ) {
+        return;
+    }
+
+    var target = document.getElementById('tx-dlf-fulltextselection');
+    if (target !== null) {
+        target.innerHTML = "";
+        for (var feature of features) {
+            var textLines = feature.get('textlines');
+            for (var textLine of textLines) {
+                var textLineSpan = this.getTextLineSpan(textLine);
+                target.append(textLineSpan);
             }
+            target.append(document.createElement('br'), document.createElement('br'));
         }
+
+        this.lastRenderedFeatures_ = features;
     }
 };
 

--- a/Resources/Public/Javascript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextDownloadControl.js
@@ -1,4 +1,4 @@
-var dlfViewerFullTextDownloadControl = function(map, image, fullTextUrl) {
+var dlfViewerFullTextDownloadControl = function(map, fulltextData) {
 
     /**
      * @private
@@ -7,16 +7,10 @@ var dlfViewerFullTextDownloadControl = function(map, image, fullTextUrl) {
     this.map = map;
 
     /**
-     * @type {Object}
+     * @type {FullTextFeature}
      * @private
      */
-    this.image = image;
-
-    /**
-     * @type {string}
-     * @private
-     */
-    this.url = fullTextUrl;
+    this.fulltextData_ = fulltextData;
 
     // add active / deactive behavior in case of click on control
     var element = $('#tx-dlf-tools-fulltextdownload');
@@ -54,17 +48,14 @@ dlfViewerFullTextDownloadControl.prototype.downloadFullTextFile = function() {
  * Activate Fulltext Features
  */
 dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function() {
-    var fullTextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.url, this.image);
-    var features = fullTextData.getTextblocks();
+    var features = this.fulltextData_.getTextblocks();
     var fileContent = '';
-    if (features !== undefined) {
-        for (var feature of features) {
-            var textLines = feature.get('textlines');
-            for (var textLine of textLines) {
-                fileContent = fileContent.concat(this.appendTextLine(textLine));
-            }
-            fileContent = fileContent.concat('\n\n');
+    for (var feature of features) {
+        var textLines = feature.get('textlines');
+        for (var textLine of textLines) {
+            fileContent = fileContent.concat(this.appendTextLine(textLine));
         }
+        fileContent = fileContent.concat('\n\n');
     }
 
     return fileContent;

--- a/Resources/Public/Javascript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/Javascript/PageView/FulltextDownloadControl.js
@@ -7,14 +7,16 @@ var dlfViewerFullTextDownloadControl = function(map, fulltextData) {
     this.map = map;
 
     /**
-     * @type {FullTextFeature}
+     * @type {FullTextFeature | undefined}
      * @private
      */
-    this.fulltextData_ = fulltextData;
+    this.fulltextData_ = undefined;
 
     // add active / deactive behavior in case of click on control
-    var element = $('#tx-dlf-tools-fulltextdownload');
-    if (element.length > 0){
+    this.element_ = $('#tx-dlf-tools-fulltextdownload');
+    if (this.element_.length > 0){
+        this.element_.addClass('disabled');
+
         var downloadFullText = $.proxy(function(event) {
             event.preventDefault();
 
@@ -22,33 +24,47 @@ var dlfViewerFullTextDownloadControl = function(map, fulltextData) {
         }, this);
 
 
-        element.on('click', downloadFullText);
-        element.on('touchstart', downloadFullText);
+        this.element_.on('click', downloadFullText);
+        this.element_.on('touchstart', downloadFullText);
     }
+};
+
+/**
+ * Set fulltext data to be used when clicking the button.
+ *
+ * @param {FullTextFeature} fulltextData
+ */
+dlfViewerFullTextDownloadControl.prototype.setFulltextData = function (fulltextData) {
+    this.fulltextData_ = fulltextData;
+    this.element_.removeClass('disabled');
 };
 
 /**
  * Method fetches the fulltext data from the server
  */
 dlfViewerFullTextDownloadControl.prototype.downloadFullTextFile = function() {
-    var clickedElement = $('#tx-dlf-tools-fulltextdownload');
+    if (this.fulltextData_) {
+        var clickedElement = $('#tx-dlf-tools-fulltextdownload');
 
-    var element = $('<a/>');
-    element.attr('id', 'downloadFile');
-    element.attr('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(this.createFullTextFile()));
-    element.attr('download', 'fulltext.txt');
+        var element = $('<a/>');
+        element.attr('id', 'downloadFile');
+        element.attr('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(this.createFullTextFile(this.fulltextData_)));
+        element.attr('download', 'fulltext.txt');
 
-    element.insertAfter(clickedElement);
+        element.insertAfter(clickedElement);
 
-    $('#downloadFile').get(0).click();
-    $('#downloadFile').remove();
+        $('#downloadFile').get(0).click();
+        $('#downloadFile').remove();
+    }
 };
 
 /**
  * Activate Fulltext Features
+ *
+ * @param {FullTextFeature} fulltextData
  */
-dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function() {
-    var features = this.fulltextData_.getTextblocks();
+dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fulltextData) {
+    var features = fulltextData.getTextblocks();
     var fileContent = '';
     for (var feature of features) {
         var textLines = feature.get('textlines');

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -164,6 +164,15 @@ var dlfViewer = function(settings){
 };
 
 /**
+ * Get number of shown pages. Typically 1 (single page) or 2 (double page mode).
+ *
+ * @returns {number}
+ */
+dlfViewer.prototype.countPages = function () {
+    return this.imageUrls.length;
+};
+
+/**
  * Methods inits and binds the custom controls to the dlfViewer. Right now that are the
  * fulltext and the image manipulation control
  *
@@ -328,11 +337,11 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
         this.map.addLayer(this.highlightLayer);
     }
 
+    // clear in case of old displays
+    this.highlightLayer.getSource().clear();
+
     // check if highlight by coords should be activate
     if (this.highlightFields.length > 0) {
-        // clear in case of old displays
-        this.highlightLayer.getSource().clear();
-
         // create features and scale it down
         for (var i = 0; i < this.highlightFields.length; i++) {
 

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -188,8 +188,12 @@ dlfViewer.prototype.addCustomControls = function() {
     // Adds fulltext behavior and download only if there is fulltext available and no double page
     // behavior is active
     if (dlfUtils.isFulltextDescriptor(this.fulltexts[0]) && this.images.length === 1) {
-        fulltextControl = new dlfViewerFullTextControl(this.map, this.images[0], this.fulltexts[0].url);
-        fulltextDownloadControl = new dlfViewerFullTextDownloadControl(this.map, this.images[0], this.fulltexts[0].url);
+        var fulltextData = dlfFullTextUtils.fetchFullTextDataFromServer(this.fulltexts[0].url, this.images[0]);
+
+        if (fulltextData !== undefined) {
+            fulltextControl = new dlfViewerFullTextControl(this.map, fulltextData);
+            fulltextDownloadControl = new dlfViewerFullTextDownloadControl(this.map, fulltextData);
+        }
     } else {
         $('#tx-dlf-tools-fulltext').remove();
     }

--- a/Resources/Public/Javascript/PageView/PageView.js
+++ b/Resources/Public/Javascript/PageView/PageView.js
@@ -9,12 +9,26 @@
  */
 
 /**
+ * @typedef {{
+ *  url: string;
+ *  mimetype: string;
+ * }} ResourceLocator
+ *
+ * @typedef {ResourceLocator} ImageDesc
+ *
+ * @typedef {ResourceLocator} FulltextDesc
+ *
+ * @typedef {{
+ *  div: string;
+ *  images?: ImageDesc[] | [];
+ *  fulltexts?: FulltextDesc[] | [];
+ *  controls?: ('OverviewMap' | 'ZoomPanel')[];
+ * }} DlfViewerConfig
+ */
+
+/**
  * @TODO Trigger resize map event after fullscreen is toggled
- * @param {Object} settings
- *      {string=} div
- *      {Array.<?>} images
- *      {Array.<?>} fulltexts
- *      {Array.<?>} controls
+ * @param {DlfViewerConfig} settings
  * @constructor
  */
 var dlfViewer = function(settings){
@@ -35,7 +49,7 @@ var dlfViewer = function(settings){
 
     /**
      * Contains image information (e.g. URL, width, height)
-     * @type {Array.<string>}
+     * @type {DlfViewerConfig['images']}
      * @private
      */
     this.imageUrls = dlfUtils.exists(settings.images) ? settings.images : [];
@@ -472,7 +486,7 @@ dlfViewer.prototype.init = function(controlNames) {
 /**
  * Generate the OpenLayers layer objects for given image sources. Returns a promise / jQuery deferred object.
  *
- * @param {Array.<{url: *, mimetype: *}>} imageSourceObjs
+ * @param {ImageDesc[]} imageSourceObjs
  * @return {jQuery.Deferred.<function(Array.<ol.layer.Layer>)>}
  * @private
  */

--- a/Resources/Public/Javascript/PageView/SearchInDocument.js
+++ b/Resources/Public/Javascript/PageView/SearchInDocument.js
@@ -285,18 +285,22 @@ function getCurrentPage() {
 function addImageHighlight(data) {
     var page = getCurrentPage();
 
-    data['documents'].forEach(function (element, i) {
-        if(element['page'] === page) {
-            if (element['highlight'].length > 0) {
-                if (typeof tx_dlf_viewer !== 'undefined' && tx_dlf_viewer.map != null) { // eslint-disable-line camelcase
-                    tx_dlf_viewer.displayHighlightWord(encodeURIComponent(getHighlights(element['highlight'])));
-                } else {
-                    setTimeout(addImageHighlight, 500, data);
+    if (typeof tx_dlf_viewer !== 'undefined' && tx_dlf_viewer.map != null) { // eslint-disable-line camelcase
+        var highlights = [];
+
+        data['documents'].forEach(function (element, i) {
+            if(page <= element['page'] && element['page'] < page + tx_dlf_viewer.countPages()) {
+                if (element['highlight'].length > 0) {
+                    highlights.push(getHighlights(element['highlight']));
                 }
+                addHighlightEffect(element['highlight']);
             }
-            addHighlightEffect(element['highlight']);
-        }
-    });
+        });
+
+        tx_dlf_viewer.displayHighlightWord(encodeURIComponent(highlights.join(';')));
+    } else {
+        setTimeout(addImageHighlight, 500, data);
+    }
 }
 
 /**

--- a/Resources/Public/Javascript/PageView/SearchInDocument.js
+++ b/Resources/Public/Javascript/PageView/SearchInDocument.js
@@ -289,7 +289,7 @@ function addImageHighlight(data) {
         var highlights = [];
 
         data['documents'].forEach(function (element, i) {
-            if(page <= element['page'] && element['page'] < page + tx_dlf_viewer.countPages()) {
+            if(page <= element['page'] && element['page'] < page + tx_dlf_viewer.countPages()) { // eslint-disable-line camelcase
                 if (element['highlight'].length > 0) {
                     highlights.push(getHighlights(element['highlight']));
                 }
@@ -297,7 +297,7 @@ function addImageHighlight(data) {
             }
         });
 
-        tx_dlf_viewer.displayHighlightWord(encodeURIComponent(highlights.join(';')));
+        tx_dlf_viewer.displayHighlightWord(encodeURIComponent(highlights.join(';'))); // eslint-disable-line camelcase
     } else {
         setTimeout(addImageHighlight, 500, data);
     }

--- a/Resources/Public/Javascript/PageView/Utility.js
+++ b/Resources/Public/Javascript/PageView/Utility.js
@@ -45,6 +45,28 @@ dlfUtils.CUSTOM_MIMETYPE = {
 dlfUtils.RUNNING_INDEX = 99999999;
 
 /**
+ * Check if arrays {@link lhs} and {@link rhs} contain exactly the same elements (compared via `===`).
+ *
+ * @template {T}
+ * @param {T[]} lhs
+ * @param {T[]} rhs
+ * @returns {boolean}
+ */
+dlfUtils.arrayEqualsByIdentity = function (lhs, rhs) {
+    if (lhs.length !== rhs.length) {
+        return false;
+    }
+
+    for (let i = 0; i < lhs.length; i++) {
+        if (lhs[i] !== rhs[i]) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+/**
  * Clone OpenLayers layer for dlfViewer (only properties used there are
  * considered).
  *

--- a/Resources/Public/Javascript/PageView/Utility.js
+++ b/Resources/Public/Javascript/PageView/Utility.js
@@ -316,7 +316,7 @@ dlfUtils.fetchStaticImageData = function (imageSourceObj) {
         image.onload = function () {
             var imageDataObj = {
                 src: this.src,
-                mimetype: mimetype,
+                mimetype,
                 width: this.width,
                 height: this.height
             };

--- a/Resources/Public/Javascript/PageView/Utility.js
+++ b/Resources/Public/Javascript/PageView/Utility.js
@@ -199,7 +199,7 @@ dlfUtils.exists = function (val) {
 /**
  * Fetch image data for given image sources.
  *
- * @param {Array.<{url: *, mimetype: *}>} imageSourceObjs
+ * @param {ImageDesc[]} imageSourceObjs
  * @return {JQueryStatic.Deferred}
  */
 dlfUtils.fetchImageData = function (imageSourceObjs) {
@@ -257,7 +257,7 @@ dlfUtils.fetchImageData = function (imageSourceObjs) {
 /**
  * Fetches the image data for static images source.
  *
- * @param {{url: *, mimetype: *}} imageSourceObj
+ * @param {ImageDesc} imageSourceObj
  * @return {JQueryStatic.Deferred}
  */
 dlfUtils.fetchStaticImageData = function (imageSourceObj) {
@@ -323,7 +323,7 @@ dlfUtils.getIIIFResource = function getIIIFResource(imageSourceObj) {
 /**
  * Fetches the image data for iip images source.
  *
- * @param {{url: *, mimetype: *}} imageSourceObj
+ * @param {ImageDesc} imageSourceObj
  * @return {JQueryStatic.Deferred}
  */
 dlfUtils.fetchIIPData = function (imageSourceObj) {
@@ -351,7 +351,7 @@ dlfUtils.fetchIIPData = function (imageSourceObj) {
 /**
  * Fetch image data for zoomify source.
  *
- * @param {{url: *, mimetype: *}} imageSourceObj
+ * @param {ImageDesc} imageSourceObj
  * @return {JQueryStatic.Deferred}
  */
 dlfUtils.fetchZoomifyData = function (imageSourceObj) {
@@ -443,7 +443,7 @@ dlfUtils.isNullEmptyUndefinedOrNoNumber = function (val) {
  * fulltext (@see PageView::getFulltext in PageView.php).
  *
  * @param {any} obj The object to test.
- * @return {boolean}
+ * @return {obj is FulltextDesc}
  */
 dlfUtils.isFulltextDescriptor = function (obj) {
     return (


### PR DESCRIPTION
This PR improves PageView performance and fixes two small issues in word highlighting.

- Highlighting: Also highlight words on second page in double-page mode, and clear highlight on subsequent searches.
- Don't load static images twice (with the exception of non-CORS or mixed content)
- Don't load and parse fulltext files twice (previously both in FulltextConrol and in FulltextDownloadControl)
- Replace OL's `forEachFeatureAtPixel`, which can be very slow on some systems, with manual bounds checking
- Some more optimizations to fulltext loading (load async/non-blocking) and rendering

Some ways to test the PR:
- Check that the image is loaded correctly, also from HTTP and non-CORS URLs.
- In DevTools, check the "Finish" times when loading a document, for example:
  - https://ddev-kitodo-presentation.ddev.site/en/workview?tx_dlf[id]=https%3A%2F%2Fdigital.slub-dresden.de%2Fdata%2Fkitodo%2Faufdesun_351357262%2Faufdesun_351357262_mets.xml&tx_dlf[page]=4
  - https://ddev-kitodo-presentation.ddev.site/workview?tx_dlf[double]=0&tx_dlf[id]=https%3A%2F%2Fapi.deutsche-digitale-bibliothek.de%2Fitems%2F4UMJQFKXM2E2WZEAG6H5BH6JVHW4ZRW6%2Fsource%2Frecord
- In case you have a system where hovering over fulltext is very laggy, check if this PR improves it.