### PR TITLE
[BUGFIX] Catch guzzle exceptions in getUrl.

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -909,7 +909,12 @@ class Helper
                 'User-Agent' => $extConf['useragent'] ?? 'Kitodo.Presentation Proxy',
             ],
         ];
-        $response = $requestFactory->request($url, 'GET', $configuration);
+        try {
+            $response = $requestFactory->request($url, 'GET', $configuration);
+        } catch (\Exception $e) {
+            self::log('Could not fetch data from URL "' . $url . '". Error: ' . $e->getMessage() . '.', LOG_SEVERITY_WARNING);
+            return false;
+        }
         $content  = $response->getBody()->getContents();
 
         return $content;


### PR DESCRIPTION
If a location is not accessible, guzzle with throw an exception. This
will stop the CLI indexing or reindexing job. In the backend this
exception is shown on saving documents.

Howto reproduce: Just modify a location and try to reindex the document or save it in the backend.