### PR TITLE
[BUGFIX] Make other metadata available in metadata wrap

### DIFF
--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -194,11 +194,21 @@ class MetadataController extends AbstractController
                 'is_listed' => !$this->settings['showFull'],
             ]);
 
+            // Collect raw metadata into an array that will be passed as data to cObj.
+            // This lets metadata wraps reference (own or foreign) values via TypoScript "field".
+            $metaCObjData = [];
+
             $buildUrl = [];
             $i = 0;
             foreach ($metadataArray as $metadataSection) {
+                $metaCObjData[$i] = [];
+
                 foreach ($metadataSection as $metadataName => $metadataValue) {
                     // NOTE: Labels are to be escaped in Fluid template
+
+                    $metaCObjData[$i][$metadataName] = is_array($metadataValue)
+                        ? implode($this->settings['separator'], $metadataValue)
+                        : $metadataValue;
 
                     if ($metadataName == 'title') {
                         // Get title of parent document if needed.
@@ -263,6 +273,7 @@ class MetadataController extends AbstractController
             $this->view->assign('documentMetadataSections', $metadataArray);
             $this->view->assign('configMetadata', $metadataResult);
             $this->view->assign('separator', $this->settings['separator']);
+            $this->view->assign('metaCObjData', $metaCObjData);
         }
     }
 

--- a/Classes/ViewHelpers/StdWrapViewHelper.php
+++ b/Classes/ViewHelpers/StdWrapViewHelper.php
@@ -23,6 +23,7 @@ class StdWrapViewHelper extends AbstractViewHelper
     {
         parent::initializeArguments();
         $this->registerArgument('wrap', 'string', 'The wrap information', true);
+        $this->registerArgument('data', 'array', 'Data for the content object', false);
     }
 
     /**
@@ -33,11 +34,21 @@ class StdWrapViewHelper extends AbstractViewHelper
     public function render()
     {
         $wrap = $this->arguments['wrap'];
+        $data = $this->arguments['data'] ?? [];
 
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+        $cObj = $configurationManager->getContentObject();
 
         $insideContent = $this->renderChildren();
 
-        return $configurationManager->getContentObject()->stdWrap($insideContent, $wrap);
+        $prevData = $cObj->data;
+        $cObj->data = $data;
+        try {
+            $result = $cObj->stdWrap($insideContent, $wrap);
+        } finally {
+            $cObj->data = $prevData;
+        }
+
+        return $result;
     }
 }

--- a/Documentation/Developers/Metadata.rst
+++ b/Documentation/Developers/Metadata.rst
@@ -58,3 +58,39 @@ There are three objects that may be set, each of which is passed to ``stdWrap`` 
 -  ``all``: The combined output (label and values) is processed using the ``all`` object.
 
 Finally, all entries are wrapped in a definition list (``<dl>`` tag). If one of the objects is not specified, the unprocessed output is taken as-is.
+
+Displaying Multiple Values
+--------------------------
+
+To allow TypoScript wrap to reference metadata values,
+all configured entries of the current metadata section are set as data before calling ``stdWrap``.
+The index names are used as key.
+Whenever there are multiple values, they are joined by the ``separator`` that is configured in the metadata plugin.
+
+To see where this is useful, consider the following MODS access condition.
+
+.. code-block:: xml
+
+   <mods:accessCondition
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      type="use and reproduction"
+      xlink:href="http://creativecommons.org/licenses/by-sa/4.0/"
+   >
+       CC BY-SA 4.0
+   </mods:accessCondition>
+
+In the metadata table, we may want to render an ``<a>`` tag that links to the license summary page and displays the license name as link text.
+To achieve this, we may create two metadata entries:
+
+*  Create a hidden entry called ``useandreproduction_link`` that has ``xpath`` set to ``./mods:accessCondition[@type="use and reproduction"]/@xlink:href``.
+   This entry is used purely to extract the license URL.
+
+*  The main entry sets ``xpath`` to ``./mods:accessCondition[@type="use and reproduction"]`` (so it extracts the license name)
+   and uses a ``wrap`` along the lines of
+
+   .. code-block:: typoscript
+
+      key.wrap = <dt>|</dt>
+      value.required = 1
+      value.typolink.parameter.field = useandreproduction_link
+      value.wrap = <dd>|</dd>

--- a/Resources/Private/Partials/Metadata/Entries.html
+++ b/Resources/Private/Partials/Metadata/Entries.html
@@ -14,8 +14,9 @@
       data-namespace-typo3-fluid="true">
 
 {configObject.wrap -> kitodo:metadataWrapVariable(name: 'metadataWrap')}
-<kitodo:stdWrap wrap="{metadataWrap.all}">
-    <kitodo:stdWrap wrap="{metadataWrap.key}">{configObject.label}</kitodo:stdWrap>
+<f:variable name="metaSectionCObj" value="{metaCObjData.{sectionIterator.index}}" />
+<kitodo:stdWrap wrap="{metadataWrap.all}" data="{metaSectionCObj}">
+    <kitodo:stdWrap wrap="{metadataWrap.key}" data="{metaSectionCObj}">{configObject.label}</kitodo:stdWrap>
     <f:for each="{documentMetadataSection.{configObject.indexName}}" as="value" iteration="iterator">
         <f:variable name="buildUrlVariable" value="{buildUrl.{sectionIterator.index}}" />
         <f:if condition="{buildUrlVariable.{configObject.indexName}}">
@@ -23,7 +24,7 @@
                 <f:render partial="Metadata/LinkEntry" arguments="{_all}"/>
             </f:then>
             <f:else>
-                <kitodo:stdWrap wrap="{metadataWrap.value}">{value}</kitodo:stdWrap>
+                <kitodo:stdWrap wrap="{metadataWrap.value}" data="{metaSectionCObj}">{value}</kitodo:stdWrap>
             </f:else>
         </f:if>
     </f:for>


### PR DESCRIPTION
This PR restores the previous behavior that all metadata is passed to the ContentObjectRenderer so that it can be accessed in the metadata wrap TypoScript.

Examples of what I've seen this used for:
- Render both name and link of `<mods:accessCondition type="use and reproduction">` via an additional hidden entry `useandreproduction_link` (`value.typolink.parameter.field = useandreproduction_link`)
- Hide entry if it just contains a dash (`key.wrap.override.if.value.field = legislative_period`).