### PR TITLE
[FEATURE] Fall back to data: URLs if blob: fails

### DIFF
--- a/Documentation/Administrator/Index.rst
+++ b/Documentation/Administrator/Index.rst
@@ -120,6 +120,12 @@ page 1: Search Plugin (main column)
 page 3: Collection Plugin (main column)
 ```
 
+Update CSP
+----------
+
+In Kitodo.Presentation 4.0, the way how static images are loaded has changed.
+Plase make sure that ``blob:`` URLs are not forbidden by your Content Security Policy.
+
 
 Version 3.2 -> 3.3
 ==================

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -18,6 +18,17 @@ System Setup
 
 
 
+**********
+Web Server
+**********
+
+Content Security Policy
+=======================
+
+In case a Content Security Policy is set on the Kitodo.Presentation instance, make sure that ``blob:`` URLs are allowed as ``img-src``.
+Otherwise, the page view may remain blank.
+
+
 ***********
 TYPO3 Setup
 ***********


### PR DESCRIPTION
As of #795, the page view uses Blob URLs for images to make sure they are not loaded twice. An effect is that if the CSP sets `img-src * data:`, the browser won't load the image, leaving us with a blank page.

This PR adds a fallback. When loading the Blob fails, it is converted to a Base64 data URL that is then passed to OpenLayers. This makes the page view work in cases where `img-src` is set to `data:` but not to `blob:`. (It still won't work when CSP only has `img-src *` without even `data:`.)

The advantage, then, is that updating the CSP can be postponed. Still, allowing `blob:` URLs is recommended because encoding to then decoding from Base64 can be time consuming especially for larger images.

To test this, you may compare the following settings in `.htaccess`:
- `Header set Content-Security-Policy "img-src * data:"`
  (Expected: Blank page without this PR, works with this PR)
- `Header set Content-Security-Policy "img-src * data: blob:"`
  (Expected: Works regardless of this PR)