### PR TITLE
[FEATURE] show divs for thumbnails and descriptions only when needed and add link

### DIFF
--- a/Resources/Private/Templates/Collection/List.html
+++ b/Resources/Private/Templates/Collection/List.html
@@ -36,16 +36,20 @@
                         </span>
                     </f:if>
                 </h2>
-                <f:if condition="{item.collection.thumbnail}"><div class="tx-dlf-collection-thumbnail">
-                    <f:link.action action="show"
-                                   arguments="{collection : item.collection}"
-                                   pageUid="{pageUid}">
-                        <f:image image="{item.collection.thumbnail}" alt="{f:translate(key: 'thumbnail')} {item.collection.label}" title="{item.collection.label}" maxWidth="250" />
-                    </f:link.action>
-                </div></f:if>
-                <f:if condition="{item.collection.description}"><div class="tx-dlf-collection-description">
-                    <f:format.html>{item.collection.description}</f:format.html>
-                </div></f:if>
+                <f:if condition="{item.collection.thumbnail}">
+                    <div class="tx-dlf-collection-thumbnail">
+                        <f:link.action action="show"
+                                       arguments="{collection : item.collection}"
+                                       pageUid="{pageUid}">
+                            <f:image image="{item.collection.thumbnail}" alt="{f:translate(key: 'thumbnail')} {item.collection.label}" title="{item.collection.label}" maxWidth="250" />
+                        </f:link.action>
+                    </div>
+                </f:if>
+                <f:if condition="{item.collection.description}">
+                    <div class="tx-dlf-collection-description">
+                        <f:format.html>{item.collection.description}</f:format.html>
+                    </div>
+                </f:if>
                 <p class="tx-dlf-collection-counts">
                     ({item.info.titles -> f:count()}
                     <f:translate key="{f:if(condition:'{item.info.titles -> f:count()} > 1', then: 'titles', else: 'title')}" />

--- a/Resources/Private/Templates/Collection/List.html
+++ b/Resources/Private/Templates/Collection/List.html
@@ -36,14 +36,16 @@
                         </span>
                     </f:if>
                 </h2>
-                <div class="tx-dlf-collection-thumbnail">
-                    <f:if condition="{item.collection.thumbnail}">
+                <f:if condition="{item.collection.thumbnail}"><div class="tx-dlf-collection-thumbnail">
+                    <f:link.action action="show"
+                                   arguments="{collection : item.collection}"
+                                   pageUid="{pageUid}">
                         <f:image image="{item.collection.thumbnail}" alt="{f:translate(key: 'thumbnail')} {item.collection.label}" title="{item.collection.label}" maxWidth="250" />
-                     </f:if>
-                </div>
-                <div class="tx-dlf-collection-description">
+                    </f:link.action>
+                </div></f:if>
+                <f:if condition="{item.collection.description}"><div class="tx-dlf-collection-description">
                     <f:format.html>{item.collection.description}</f:format.html>
-                </div>
+                </div></f:if>
                 <p class="tx-dlf-collection-counts">
                     ({item.info.titles -> f:count()}
                     <f:translate key="{f:if(condition:'{item.info.titles -> f:count()} > 1', then: 'titles', else: 'title')}" />


### PR DESCRIPTION
- only insert divs for thumbnails and description if the related fields have content.
- add a link to the collection page to the collection thumbnail image.

**This eliminates the need for customization in slub_digitalcollections:**
The link to the collection thumbnail replaces a short javascript code (marked with: "// Add click event to complete collections element on intro page") in the [DigitalcollectionsListScripts.js file](https://github.com/slub/slub_digitalcollections/blob/master/Resources/Private/JavaScript/DigitalcollectionsListScripts.js#L59) in slub_digitalcollections.