### PR TITLE
[BUGFIX] Fix empty thumbnails and sorting dropdowns in listview

### DIFF
--- a/Resources/Private/Partials/ListView/Results.html
+++ b/Resources/Private/Partials/ListView/Results.html
@@ -25,11 +25,15 @@
                 additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}"
                 class=""
                 title="{docTitle}">
-                    <div class="tx-dlf-listview-thumbnail">
-                        <f:if condition="{document.thumbnail}">
+                    <f:comment>
+                        slub_digitalcollections uses the :empty CSS selector to check for missing thumbnail.
+                        The HTML comments make sure there is no whitespace in that case.
+                    </f:comment>
+                    <div class="tx-dlf-listview-thumbnail"><!--
+                        --><f:if condition="{document.thumbnail}">
                             <img src="{document.thumbnail}" alt="Vorschaubild von {docTitle}" />
-                        </f:if>
-                    </div>
+                        </f:if><!--
+                    --></div>
                     <dl>
                         <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
                         <dd class="tx-dlf-title">{docTitle}</dd>
@@ -87,11 +91,11 @@
                                     additionalParams="{tx_dlf:{page:'1', double:'0', id:'{child.uid}', pagegrid:'0'}}"
                                     class=""
                                     title="{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}">
-                                        <div class="tx-dlf-listview-thumbnail">
-                                        <f:if condition="{child.thumbnail}">
+                                        <div class="tx-dlf-listview-thumbnail"><!--
+                                        --><f:if condition="{child.thumbnail}">
                                             <img src="{child.thumbnail}" alt="Vorschaubild von {f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}" />
-                                        </f:if>
-                                        </div>
+                                        </f:if><!--
+                                        --></div>
                                         <dl>
                                         <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
                                         <dd class="tx-dlf-title">{f:if(condition:'{child.title}', then:'{child.title}', else:'[{document.title}]')}</dd>
@@ -132,11 +136,11 @@
                                     additionalParams="{tx_dlf:{page:'{result.page}', double:'0', id:'{document.uid}', pagegrid:'0', highlight_word: '{result.highlight_word}'}}"
                                     class=""
                                     title="{f:if(condition:'{result.title}', then:'{result.title}', else:'[{document.title}]')}, Seite {result.page}">
-                                    <div class="tx-dlf-listview-thumbnail">
-                                        <f:if condition="{result.thumbnail}">
+                                    <div class="tx-dlf-listview-thumbnail"><!--
+                                        --><f:if condition="{result.thumbnail}">
                                             <img src="{result.thumbnail}" alt="Vorschaubild von {f:if(condition:'{result.title}', then:'{result.title}', else:'[{document.title}]')}" />
-                                        </f:if>
-                                    </div>
+                                        </f:if><!--
+                                    --></div>
                                     <dl>
                                         <f:if condition="{result.title}">
                                             <f:then>

--- a/Resources/Private/Partials/ListView/SortingForm.html
+++ b/Resources/Private/Partials/ListView/SortingForm.html
@@ -29,7 +29,7 @@
                 <label for="form-orderBy-{viewData.uniqueId}">
                     <f:translate key="listview.form.orderBy"/>
                 </label>
-                <f:form.select id="form-orderBy-{viewData.uniqueId}" property="orderBy" value="{lastSearch.orderBy}" onclick="javascript:this.form.submit();">
+                <f:form.select id="form-orderBy-{viewData.uniqueId}" property="orderBy" value="{lastSearch.orderBy}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
                     <f:form.select.option value="score">
                         <f:translate key="listview.form.relevance" />
                     </f:form.select.option>
@@ -42,7 +42,7 @@
                 <label for="form-order-{viewData.uniqueId}">
                     <f:translate key="listview.form.order"/>
                 </label>
-                <f:form.select id="form-order-{viewData.uniqueId}" property="order" value="{lastSearch.order}" onclick="javascript:this.form.submit();">
+                <f:form.select id="form-order-{viewData.uniqueId}" property="order" value="{lastSearch.order}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
                     <f:form.select.option value="asc">
                     <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:listview.form.order.asc' />
                     </f:form.select.option>


### PR DESCRIPTION
- Allow using CSS `:empty` pseudo-class to check for empty thumbnails (as was the case before).
- Use `onchange` instead of `onclick` to trigger search/sort in listview, so that the page doesn't already reload when clicking the dropdown.