### PR TITLE
[BUGFIX] Fix missing title of facets groups

### DIFF
--- a/Resources/Private/Templates/Search/Main.html
+++ b/Resources/Private/Templates/Search/Main.html
@@ -104,7 +104,9 @@
     <f:for each="{facetsMenu}" as="facet">
         <ul>
             <li class="tx-dlf-search-no {f:if(condition: '{facet._SUB_MENU}', then: 'tx-dlf-search-ifsub')}">
-                {facet.title}
+                <span class="tx-dlf-facet-title">
+                    <f:translate key="LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.{facet.field}" />
+                </span>
                 <f:if condition="{facet._SUB_MENU}">
                     <f:then>
                         <ul>


### PR DESCRIPTION
`{facet.title}` is never set. It's actually the `index_name` which is present in `{facet.field}` we need to translate here.