### PR TITLE
[BUGFIX] Multidomain typoscript configuration

### DIFF
--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -67,15 +67,15 @@ class ItemsProcFunc implements LoggerAwareInterface
         $pid = $params['flexParentDatabaseRow']['pid'];
         $rootline = \TYPO3\CMS\Backend\Utility\BackendUtility::BEgetRootLine($pid);
         $siterootRow = [];
-        foreach($rootline as $_uid=>$_row) {
-            if($_row['is_siteroot'] == '1') {
+        foreach ($rootline as $_row) {
+            if ($_row['is_siteroot'] == '1') {
                 $siterootRow = $_row;
                 break;
             }
         }
 
         try {
-            $ts = $objectManager->get(\TYPO3\CMS\Core\TypoScript\TemplateService::class,[$siterootRow['uid']]);
+            $ts = $objectManager->get(\TYPO3\CMS\Core\TypoScript\TemplateService::class, [$siterootRow['uid']]);
             $ts->rootLine = $rootline;
             $ts->runThroughTemplates($rootline, 0);
             $ts->generateConfig();

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -13,6 +13,8 @@
 namespace Kitodo\Dlf\Hooks;
 
 use Kitodo\Dlf\Common\Helper;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
@@ -26,8 +28,10 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
  * @subpackage dlf
  * @access public
  */
-class ItemsProcFunc
+class ItemsProcFunc implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var int
      */
@@ -76,7 +80,7 @@ class ItemsProcFunc
             $ts->runThroughTemplates($rootline, 0);
             $ts->generateConfig();
         } catch (\Exception $e) {
-            die($e->getMessage());
+            $this->logger->error($e->getMessage());
         }
 
         $typoscriptConfig = $ts->setup;

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -80,7 +80,7 @@ class ItemsProcFunc
         }
 
         $typoscriptConfig = $ts->setup;
-        $this->storagePid = $typoscriptConfig["plugin."]["tx_dlf."]["persistence."]["storagePid"];
+        $this->storagePid = $typoscriptConfig['plugin.']['tx_dlf.']['persistence.']['storagePid'];
 
     }
 

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -60,7 +60,7 @@ class ItemsProcFunc
      */
     public function getTyposcriptConfigFromPluginSiteRoot($params) {
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $pid = 2;
+        $pid = $params['flexParentDatabaseRow']['pid'];
         $rootline = \TYPO3\CMS\Backend\Utility\BackendUtility::BEgetRootLine($pid);
         $siterootRow = [];
         foreach($rootline as $_uid=>$_row) {


### PR DESCRIPTION
Read the typoscript configuration depending on the page where it is placed on.
Otherwise, multi domain installation only get the default site root typoscript.
This PR is linked to issue #841 