### PR TITLE
[BUGFIX] Handle incomplete OAI plugin configuration

### DIFF
--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -387,14 +387,14 @@ class OaiPmhController extends AbstractController
             $this->logger->notice('Incomplete plugin configuration');
         }
 
-        $oaiIdentifyInfo['oai_label'] = $library->getOaiLabel();
+        $oaiIdentifyInfo['oai_label'] = $library ? $library->getOaiLabel() : '';
         // Use default values for an installation with incomplete plugin configuration.
         if (empty($oaiIdentifyInfo['oai_label'])) {
             $oaiIdentifyInfo['oai_label'] = 'Kitodo.Presentation OAI-PMH Interface (default configuration)';
             $this->logger->notice('Incomplete plugin configuration (oai_label is missing)');
         }
 
-        $oaiIdentifyInfo['contact'] = $library->getContact();
+        $oaiIdentifyInfo['contact'] = $library ? $library->getContact() : '';
         if (empty($oaiIdentifyInfo['contact'])) {
             $oaiIdentifyInfo['contact'] = 'unknown@example.org';
             $this->logger->notice('Incomplete plugin configuration (contact is missing)');


### PR DESCRIPTION
Don't throw an exception when $library is null because the OAI plugin was not configured, but use the default values for oai_label and contact.

That makes the code more robust and helps admins who install Kitodo.Presentation.

Signed-off-by: Stefan Weil <sw@weilnetz.de>