### PR TITLE
[BUGFIX] Prevent empty facets when sorting by index

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -280,6 +280,7 @@ class SearchController extends AbstractController
         foreach (array_keys($facets) as $field) {
             $search['params']['component']['facetset']['facet'][] = [
                 'type' => 'field',
+                'mincount' => '1',
                 'key' => $field,
                 'field' => $field,
                 'limit' => $this->settings['limitFacets'],
@@ -315,7 +316,7 @@ class SearchController extends AbstractController
         if ($facet) {
             foreach ($facet as $field => $values) {
                 $entryArray = [];
-                $entryArray['field'] = substr($field, 0, strpos($field, '_'));
+                $entryArray['field'] = substr($field, 0, strpos($field, '_faceting'));
                 $entryArray['count'] = 0;
                 $entryArray['_OVERRIDE_HREF'] = '';
                 $entryArray['ITEM_STATE'] = 'NO';


### PR DESCRIPTION
When sorting by index, facets may be rendered empty, if there's potentially a large amount of fields (like the publication year). The first results in the response (when sorted by index) may have zero related documents, so they wont be rendered in the view. We omit it, when requiring a mininum facet field count in the response, so no empty fields should be returned.

Secondly solr-fields were not allowed a "_" in the fieldname and to be a facet the same time. The needle for determening facets fields should match "_faceting" instead of just "_", so it would be found properly in the haystack.