### PR TITLE
[BUGFIX] Fix missing superiortitle in metadata and listview

### DIFF
--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -212,7 +212,7 @@ class MetadataController extends AbstractController
 
                     if ($metadataName == 'title') {
                         // Get title of parent document if needed.
-                        if (empty($metadataValue) && $this->settings['getTitle'] && $this->document->getDoc()->parentId) {
+                        if (empty(implode('', $metadataValue)) && $this->settings['getTitle'] && $this->document->getPartof()) {
                             $superiorTitle = Doc::getTitle($this->document->getPartof(), true);
                             if (!empty($superiorTitle)) {
                                 $metadataArray[$i][$metadataName] = ['[' . $superiorTitle . ']'];


### PR DESCRIPTION
This PR fixes the missing superiorTitle in both the metadata and listview.
- empty() fails on array with empty entry, thus imploding it to a string and checking wether this one is empty or not solves this problem
- getDoc()->parentID does not return the superior objects ID but only "0" instead => getPartOf() returns the necessary ID.