### PR TITLE
[FEATURE] Add an option to list empty years in calender plugin

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -282,7 +282,7 @@ class CalendarController extends AbstractController
                 ];
             }
             // create an array that includes years without issues
-            if($this->settings['showEmptyYears']){
+            if (!empty($this->settings['showEmptyYears'])){
                 $yearFilled = [];
                 $min = $yearArray[0]['title'];
                 // round the starting decade down to zero for equal rows

--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -282,20 +282,18 @@ class CalendarController extends AbstractController
                 ];
             }
             // create an array that includes years without issues
-            if (!empty($this->settings['showEmptyYears'])){
+            if (!empty($this->settings['showEmptyYears'])) {
                 $yearFilled = [];
                 $min = $yearArray[0]['title'];
                 // round the starting decade down to zero for equal rows
-                $min = substr_replace($min,"0",-1);
+                $min = substr_replace($min, "0", -1);
                 $max = $yearArray[count($yearArray) - 1]['title'];
                 // if we have an actual documentId it should be used, otherwise leave empty
-                for($i = 0; $i < $max-$min+1; $i++) {
-                    $key = array_search($min+$i,array_column($yearArray, 'title'));
-                    if (is_int($key))
-                    {
+                for ($i = 0; $i < $max - $min + 1; $i++) {
+                    $key = array_search($min + $i, array_column($yearArray, 'title'));
+                    if (is_int($key)) {
                         $yearFilled[] = $yearArray[$key];
-                    }
-                    else {
+                    } else {
                         $yearFilled[] = ['title' => $min+$i, 'documentId' => ''];
                     }
                 }

--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -281,6 +281,27 @@ class CalendarController extends AbstractController
                     'title' => $year['title']
                 ];
             }
+            // create an array that includes years without issues
+            if($this->settings['showEmptyYears']){
+                $yearFilled = [];
+                $min = $yearArray[0]['title'];
+                // round the starting decade down to zero for equal rows
+                $min = substr_replace($min,"0",-1);
+                $max = $yearArray[count($yearArray) - 1]['title'];
+                // if we have an actual documentId it should be used, otherwise leave empty
+                for($i = 0; $i < $max-$min+1; $i++) {
+                    $key = array_search($min+$i,array_column($yearArray, 'title'));
+                    if (is_int($key))
+                    {
+                        $yearFilled[] = $yearArray[$key];
+                    }
+                    else {
+                        $yearFilled[] = ['title' => $min+$i, 'documentId' => ''];
+                    }
+                }
+                $yearArray = $yearFilled;
+            }
+
             $this->view->assign('yearName', $yearArray);
         }
 

--- a/Configuration/Flexforms/Calendar.xml
+++ b/Configuration/Flexforms/Calendar.xml
@@ -60,6 +60,16 @@
                             </config>
                         </TCEforms>
                     </settings.initialDocument>
+                    <settings.showEmptyYears>
+                      <TCEforms>
+                        <exclude>1</exclude>
+                        <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.calendar.flexform.showEmptyYears</label>
+                        <config>
+                          <type>check</type>
+                          <default>1</default>
+                        </config>
+                      </TCEforms>
+                    </settings.showEmptyYears>
                     <settings.showEmptyMonths>
                       <TCEforms>
                         <exclude>1</exclude>

--- a/Configuration/Flexforms/Calendar.xml
+++ b/Configuration/Flexforms/Calendar.xml
@@ -66,7 +66,7 @@
                         <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.calendar.flexform.showEmptyYears</label>
                         <config>
                           <type>check</type>
-                          <default>1</default>
+                          <default>0</default>
                         </config>
                       </TCEforms>
                     </settings.showEmptyYears>

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -224,7 +224,7 @@ now.
    :Data Type:
        :ref:`t3tsref:data-type-boolean`
    :Default:
-       1
+       0
 
  - :Property:
        showEmptyMonths

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -220,6 +220,13 @@ now.
    :Default:
 
  - :Property:
+       showEmptyYears
+   :Data Type:
+       :ref:`t3tsref:data-type-boolean`
+   :Default:
+       1
+
+ - :Property:
        showEmptyMonths
    :Data Type:
        :ref:`t3tsref:data-type-boolean`

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -122,7 +122,7 @@
 				<target><![CDATA[Anfangsdokument (z.B. vom Typ "newspaper" oder "ephemera)]]></target>
 			</trans-unit>
 			<trans-unit id="plugins.calendar.flexform.showEmptyYears" approved="yes">
-				<source><![CDATA[Show months without issues in calendar?]]></source>
+				<source><![CDATA[Show years without issues in calendar?]]></source>
 				<target><![CDATA[Zeige Jahre ohne Ausgaben im Kalender?]]></target>
 			</trans-unit>
 			<trans-unit id="plugins.calendar.flexform.showEmptyMonths" approved="yes">

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -121,6 +121,10 @@
 				<source><![CDATA[Initial document to show (e.g. of type "newspaper" or "ephemera")]]></source>
 				<target><![CDATA[Anfangsdokument (z.B. vom Typ "newspaper" oder "ephemera)]]></target>
 			</trans-unit>
+			<trans-unit id="plugins.calendar.flexform.showEmptyYears" approved="yes">
+				<source><![CDATA[Show months without issues in calendar?]]></source>
+				<target><![CDATA[Zeige Jahre ohne Ausgaben im Kalender?]]></target>
+			</trans-unit>
 			<trans-unit id="plugins.calendar.flexform.showEmptyMonths" approved="yes">
 				<source><![CDATA[Show months without issues in calendar?]]></source>
 				<target><![CDATA[Zeige Monate ohne Ausgaben im Kalender?]]></target>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -56,6 +56,9 @@
 			<trans-unit id="plugins.calendar.flexform.initialDocument">
 				<source><![CDATA[Initial document to show (e.g. of type "newspaper" or "ephemera")]]></source>
 			</trans-unit>
+			<trans-unit id="plugins.calendar.flexform.showEmptyYears">
+				<source><![CDATA[Show years without issues in calendar?]]></source>
+			</trans-unit>
 			<trans-unit id="plugins.calendar.flexform.showEmptyMonths">
 				<source><![CDATA[Show months without issues in calendar?]]></source>
 			</trans-unit>

--- a/Resources/Private/Templates/Calendar/Years.html
+++ b/Resources/Private/Templates/Calendar/Years.html
@@ -26,11 +26,20 @@
         <div class="year-view">
             <ul>
                 <f:for each="{yearName}" as="yearEntry">
-                    <li class="year">
-                        <f:link.page additionalParams="{'tx_dlf[id]': yearEntry.documentId}">
-                            {yearEntry.title}
-                        </f:link.page>
-                    </li>
+                    <f:if condition="{yearEntry.documentId}">
+                        <f:then>
+                            <li class="year">
+                                <f:link.page additionalParams="{'tx_dlf[id]': yearEntry.documentId}">
+                                    {yearEntry.title}
+                                </f:link.page>
+                            </li>
+                        </f:then>
+                        <f:else>
+                            <li class="year-empty">
+                                <p>{yearEntry.title}</p>
+                            </li>
+                        </f:else>
+                    </f:if>
                 </f:for>
             </ul>
         </div>


### PR DESCRIPTION
This PR adds an additional option, to list empty years in the calender plugin. This allows for an easier overview of the actual years available, since we can group whole decades in single rows. The benefit is a quicker eye browsing over the years, especially when there are gaps without any issues being published.