### PR TITLE
[MAINTENANCE] Add ViewHelper functional tests instead of unit tests.

### DIFF
--- a/Tests/Functional/ViewHelpers/JsFooterViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/JsFooterViewHelperTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Kitodo\Dlf\Tests\Unit\ViewHelpers;
+
+use Kitodo\Dlf\Tests\Functional\FunctionalTestCase;
+use Kitodo\Dlf\ViewHelpers\JsFooterViewHelper;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+
+/**
+ * @covers JsFooterViewHelper
+ */
+class JsFooterViewHelperTest extends FunctionalTestCase
+{
+    /**
+     * @var bool Speed up this test case, it needs no database
+     */
+    protected $initializeDatabase = false;
+
+    /**
+     * @test
+     */
+    public function pageRendererCallsAddJsFooterInlineCode(): void
+    {
+        $pageRendererProphecy = $this->getMockBuilder(PageRenderer::class)
+            ->onlyMethods(['addJsFooterInlineCode'])
+            ->getMock();
+
+        $pageRendererProphecy->expects(self::once())->method('addJsFooterInlineCode')->with(
+            'js-dlf-inline-footer', '$(document).ready(function() {});'
+        );
+
+        GeneralUtility::setSingletonInstance(PageRenderer::class, $pageRendererProphecy);
+
+        $view = new StandaloneView();
+        $view->setTemplateSource(
+            '<html xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers">
+                <kitodo:jsFooter inlineCode="$(document).ready(function() {});" />
+            </html>'
+        );
+
+        $view->render();
+    }
+}

--- a/Tests/Functional/ViewHelpers/JsFooterViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/JsFooterViewHelperTest.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
 
 namespace Kitodo\Dlf\Tests\Unit\ViewHelpers;
 

--- a/Tests/Functional/ViewHelpers/JsFooterViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/JsFooterViewHelperTest.php
@@ -23,9 +23,7 @@ class JsFooterViewHelperTest extends FunctionalTestCase
      */
     public function pageRendererCallsAddJsFooterInlineCode(): void
     {
-        $pageRendererProphecy = $this->getMockBuilder(PageRenderer::class)
-            ->onlyMethods(['addJsFooterInlineCode'])
-            ->getMock();
+        $pageRendererProphecy = $this->getMockBuilder(PageRenderer::class)->getMock();
 
         $pageRendererProphecy->expects(self::once())->method('addJsFooterInlineCode')->with(
             'js-dlf-inline-footer', '$(document).ready(function() {});'

--- a/Tests/Functional/ViewHelpers/MetadataWrapVariableViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/MetadataWrapVariableViewHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kitodo\Dlf\Tests\Unit\ViewHelpers;
+
+use Kitodo\Dlf\Tests\Functional\FunctionalTestCase;
+use Kitodo\Dlf\ViewHelpers\MetadataWrapVariableViewHelper;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+
+/**
+ * @covers MetadataWrapVariableViewHelper
+ */
+class MetadataWrapVariableViewHelperTest extends FunctionalTestCase
+{
+    /**
+     * @var bool Speed up this test case, it needs no database
+     */
+    protected $initializeDatabase = false;
+
+    /**
+     * @test
+     */
+    public function renderingContextCallsGetVariableProviderAdd(): void
+    {
+        $view = new StandaloneView();
+
+        $view->assign('configObject',
+            [ 'wrap' => 'all.wrap = <article class="shlb-metadata-text-item metadata-title">|</article>
+                 key.wrap = <label>|</label>
+                 value.required = 1
+                 value.wrap = <li>|</li>'
+            ]
+        );
+        $view->setTemplateSource(
+            '<html xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers">
+                {configObject.wrap -> kitodo:metadataWrapVariable(name: \'metadataWrap\')}
+            </html>'
+        );
+        $view->render();
+
+        $this->assertEquals(
+            [
+                'key' => ['wrap' => '<label>|</label>'],
+                'value' => ['required' => 1, 'wrap' => '<li>|</li>'],
+                'all' => ['wrap' => '<article class="shlb-metadata-text-item metadata-title">|</article>']
+            ],
+            $view->getRenderingContext()->getVariableProvider()->get('metadataWrap')
+        );
+    }
+}

--- a/Tests/Functional/ViewHelpers/MetadataWrapVariableViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/MetadataWrapVariableViewHelperTest.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
 
 namespace Kitodo\Dlf\Tests\Unit\ViewHelpers;
 

--- a/Tests/Functional/ViewHelpers/MetadataWrapVariableViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/MetadataWrapVariableViewHelperTest.php
@@ -33,7 +33,8 @@ class MetadataWrapVariableViewHelperTest extends FunctionalTestCase
     {
         $view = new StandaloneView();
 
-        $view->assign('configObject',
+        $view->assign(
+            'configObject',
             [ 'wrap' => 'all.wrap = <article class="shlb-metadata-text-item metadata-title">|</article>
                  key.wrap = <label>|</label>
                  value.required = 1

--- a/Tests/Functional/ViewHelpers/StdWrapViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/StdWrapViewHelperTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Kitodo\Dlf\Tests\Unit\ViewHelpers;
+
+use Kitodo\Dlf\Tests\Functional\FunctionalTestCase;
+use Kitodo\Dlf\ViewHelpers\StdWrapViewHelper;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+
+/**
+ * @covers StdWrapViewHelper
+ */
+class StdWrapViewHelperTest extends FunctionalTestCase
+{
+    /**
+     * @var bool Speed up this test case, it needs no database
+     */
+    protected $initializeDatabase = false;
+
+    /**
+     * @test
+     */
+    public function renderWithStdWrap(): void
+    {
+        $view = new StandaloneView();
+        $view->assign('metadataWrap',
+            [
+                'key' => ['wrap' => '<label>|</label>'],
+                'value' => ['required' => 1, 'wrap' => '<li>|</li>'],
+                'all' => ['wrap' => '<article class="shlb-metadata-text-item metadata-title">|</article>']
+            ]
+        );
+
+        // A fully filled array with correct values does not make any difference. The rendering result
+        // is not been influenced by the viewhelpers data parameter.
+        $view->assign('metaSectionCObj', [0 => ['tilte' => 'A test title']]);
+
+        $view->setTemplateSource(
+            '<html xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers">
+              <kitodo:stdWrap wrap="{metadataWrap.all}" data="{metaCObjData.0}">
+                <kitodo:stdWrap wrap="{metadataWrap.key}" data="{metaCObjData.0}">Label</kitodo:stdWrap>
+                    <h2>Title</h2><p>Text</p>
+                </kitodo:stdWrap>
+            </html>'
+        );
+
+        $this->assertXmlStringEqualsXmlString(
+            '<html xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers">
+              <article class="shlb-metadata-text-item metadata-title">
+                <label>Label</label>
+                    <h2>Title</h2><p>Text</p>
+                </article>
+            </html>',
+            $view->render()
+        );
+
+        // Without using the data parameter the rendering result is the same as above.
+        $view->setTemplateSource(
+            '<html xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers">
+              <kitodo:stdWrap wrap="{metadataWrap.all}">
+                <kitodo:stdWrap wrap="{metadataWrap.key}">Label</kitodo:stdWrap>
+                    <h2>Title</h2><p>Text</p>
+                </kitodo:stdWrap>
+            </html>'
+        );
+
+        $this->assertXmlStringEqualsXmlString(
+            '<html xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers">
+              <article class="shlb-metadata-text-item metadata-title">
+                <label>Label</label>
+                    <h2>Title</h2><p>Text</p>
+                </article>
+            </html>',
+            $view->render()
+        );
+    }
+}

--- a/Tests/Functional/ViewHelpers/StdWrapViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/StdWrapViewHelperTest.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
 
 namespace Kitodo\Dlf\Tests\Unit\ViewHelpers;
 

--- a/Tests/Functional/ViewHelpers/StdWrapViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/StdWrapViewHelperTest.php
@@ -32,7 +32,8 @@ class StdWrapViewHelperTest extends FunctionalTestCase
     public function renderWithStdWrap(): void
     {
         $view = new StandaloneView();
-        $view->assign('metadataWrap',
+        $view->assign(
+            'metadataWrap',
             [
                 'key' => ['wrap' => '<label>|</label>'],
                 'value' => ['required' => 1, 'wrap' => '<li>|</li>'],


### PR DESCRIPTION
Instead of unit testing ViewHelpers it is recommended to do functional tests.