### PR TITLE
[MAINTENANCE] Fix OaiPmh functional tests

### DIFF
--- a/Tests/Functional/Api/OaiPmhTest.php
+++ b/Tests/Functional/Api/OaiPmhTest.php
@@ -37,8 +37,8 @@ class OaiPmhTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->oaiUrl = $this->baseUrl . '/index.php?id=' . $this->oaiPage;
-        $this->oaiUrlNoStoragePid = $this->baseUrl . '/index.php?id=' . $this->oaiPageNoStoragePid;
+        $this->oaiUrl = $this->baseUrl . 'index.php?id=' . $this->oaiPage;
+        $this->oaiUrlNoStoragePid = $this->baseUrl . 'index.php?id=' . $this->oaiPageNoStoragePid;
 
         $this->importDataSet(__DIR__ . '/../../Fixtures/Common/documents_1.xml');
         $this->importDataSet(__DIR__ . '/../../Fixtures/Common/metadata.xml');

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -88,11 +88,11 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
 
         $this->baseUrl = 'http://web:8000/public/typo3temp/var/tests/functional-' . $this->identifier . '/';
         $this->httpClient = new HttpClient([
-            'base_uri' => $this->baseUrl,
+            'base_uri' => $this->baseUrl . 'index.php',
             'http_errors' => false,
         ]);
 
-        $this->addSiteConfig('dlf-testing', $this->baseUrl);
+        $this->addSiteConfig('dlf-testing');
     }
 
     protected function getDlfConfiguration()
@@ -103,7 +103,6 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
             'fileGrpDownload' => 'DOWNLOAD',
             'fileGrpFulltext' => 'FULLTEXT',
             'fileGrpAudio' => 'AUDIO',
-
             'solrFieldAutocomplete' => 'autocomplete',
             'solrFieldCollection' => 'collection',
             'solrFieldDefault' => 'default',
@@ -134,11 +133,11 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
         ];
     }
 
-    protected function addSiteConfig($identifier, $baseUrl)
+    protected function addSiteConfig($identifier)
     {
         $siteConfig = Yaml::parseFile(__DIR__ . '/../Fixtures/siteconfig.yaml');
-        $siteConfig['base'] = $baseUrl;
-        $siteConfig['languages'][0]['base'] = $baseUrl;
+        $siteConfig['base'] = $this->baseUrl;
+        $siteConfig['languages'][0]['base'] = $this->baseUrl;
 
         $siteConfigPath = $this->instancePath . '/typo3conf/sites/' . $identifier;
         @mkdir($siteConfigPath, 0775, true);

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -31,9 +31,15 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
                     ],
                 ],
             ],
+            'displayErrors' => '1'
         ],
         'EXTENSIONS' => [
             'dlf' => [], // = $this->getDlfConfiguration(), set in constructor
+        ],
+        'FE' => [
+            'cacheHash' => [
+                'enforceValidation' => false,
+            ],
         ],
         'DB' => [
             'Connections' => [


### PR DESCRIPTION
Remove slashes from search URLs - reason for failing tests:
```
Phpoaipmh\Exception\HttpException: Client error: `GET http://web:8000/public/typo3temp/var/tests/functional-3567482//index.php?id=20001&verb=Identify` resulted in a `404 Not Found` response
```