### PR TITLE
[MAINTENANCE] Add 'SameSite' attribute to cookies

### DIFF
--- a/Resources/Public/JavaScript/PageView/AnnotationControl.js
+++ b/Resources/Public/JavaScript/PageView/AnnotationControl.js
@@ -263,7 +263,7 @@ DlfAnnotationControl.prototype.activate = function() {
 
     // now activate the annotation overlay and map behavior
     this.enableAnnotationSelect();
-    dlfUtils.setCookie("tx-dlf-pageview-annotation-select", 'enabled');
+    dlfUtils.setCookie("tx-dlf-pageview-annotation-select", 'enabled', "lax");
     $(controlEl).addClass('active');
 
     // trigger event
@@ -275,7 +275,7 @@ DlfAnnotationControl.prototype.deactivate = function() {
     var controlEl = $('#tx-dlf-tools-annotations');
     // deactivate annotations
     this.disableAnnotationSelect();
-    dlfUtils.setCookie("tx-dlf-pageview-annotation-select", 'disabled');
+    dlfUtils.setCookie("tx-dlf-pageview-annotation-select", 'disabled', "lax");
     $(controlEl).removeClass('active');
     // trigger event
     $(this).trigger("deactivate-annotations", this);

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -446,7 +446,7 @@ dlfViewerFullTextControl.prototype.activate = function() {
 
     // now activate the fulltext overlay and map behavior
     this.enableFulltextSelect();
-    dlfUtils.setCookie("tx-dlf-pageview-fulltext-select", 'enabled');
+    dlfUtils.setCookie("tx-dlf-pageview-fulltext-select", 'enabled', "lax");
     $(controlEl).addClass('active');
     this.isActive = true;
 
@@ -463,7 +463,7 @@ dlfViewerFullTextControl.prototype.deactivate = function() {
 
     // deactivate fulltext
     this.disableFulltextSelect();
-    dlfUtils.setCookie("tx-dlf-pageview-fulltext-select", 'disabled');
+    dlfUtils.setCookie("tx-dlf-pageview-fulltext-select", 'disabled', "lax");
     $(controlEl).removeClass('active');
     this.isActive = false;
 

--- a/Resources/Public/JavaScript/PageView/PageView.js
+++ b/Resources/Public/JavaScript/PageView/PageView.js
@@ -591,9 +591,9 @@ dlfViewer.prototype.init = function(controlNames) {
                     center = this.map.getView().getCenter() !== undefined ? this.map.getView().getCenter() : ['', ''];
 
                 // save actual map view parameters to cookie
-                dlfUtils.setCookie('tx-dlf-pageview-zoomLevel', zoom);
-                dlfUtils.setCookie('tx-dlf-pageview-centerLon', center[0]);
-                dlfUtils.setCookie('tx-dlf-pageview-centerLat', center[1]);
+                dlfUtils.setCookie('tx-dlf-pageview-zoomLevel', zoom, "lax");
+                dlfUtils.setCookie('tx-dlf-pageview-centerLon', center[0], "lax");
+                dlfUtils.setCookie('tx-dlf-pageview-centerLat', center[1], "lax");
             }, this));
         }, this));
         this.source = new ol.source.Vector();

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -579,10 +579,22 @@ dlfUtils.parseDataDic = function (element) {
  *
  * @param {string} name The key of the value
  * @param {?} value The value to save
+ * @param {string} samesite Sets the SameSite attribute: lax, strict or none
+ * 
  */
-dlfUtils.setCookie = function (name, value) {
-
-    document.cookie = name + "=" + decodeURI(value) + "; path=/";
+dlfUtils.setCookie = function (name, value, samesite) {
+    switch(samesite) {
+        case "lax":
+        case "strict": 
+            break;
+        case "none":
+            samesite+= ";secure"
+            break;
+        default:
+            samesite = "lax"
+    }
+    
+    document.cookie = name + "=" + decodeURI(value) + "; path=/" + "; SameSite="+samesite;
 };
 
 /**

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -594,7 +594,7 @@ dlfUtils.setCookie = function (name, value, samesite) {
             samesite = "lax"
     }
     
-    document.cookie = name + "=" + decodeURI(value) + "; path=/" + "; SameSite="+samesite;
+    document.cookie = name + "=" + decodeURI(value) + "; path=/" + "; SameSite=" + samesite;
 };
 
 /**


### PR DESCRIPTION
Under the Firefox browser, it has been noted for some time that cookies without SameSite attributes will soon no longer be supported and will instead be treated as "lax".

This is the message for the `tx-dlf-pageview-fulltext-select` cookie: 
```
Das Cookie "tx-dlf-pageview-fulltext-select" verfügt über keinen gültigen Wert für das "SameSite"-Attribut. Bald werden Cookies ohne das "SameSite"-Attribut oder mit einem ungültigen Wert dafür als "Lax" behandelt. Dadurch wird das Cookie nicht länger an Kontexte gesendet, die zu einem Drittanbieter gehören. 
Falls Ihre Anwendung das Cookie in diesen Kontexten benötigt, fügen Sie bitte das Attribut "SameSite=None" zu ihm hinzu. Weitere Informationen zum "SameSite"-Attribut finden Sie unter https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite.
```

This PR adds another parameter to the [setCookie function](https://github.com/kitodo/kitodo-presentation/blob/master/Resources/Public/JavaScript/PageView/Utility.js#L583) which can set the SameSite attribute individually.