### PR TITLE
[MAINTENANCE] Add fallback option for getLLL()

### DIFF
--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -419,7 +419,7 @@ class NewTenantController extends AbstractController
     {
         if (isset($langArray[$lang][$index][0]['target'])) {
             return $langArray[$lang][$index][0]['target'];
-        } else if (isset($langArray['default'][$index][0]['target'])) {
+        } elseif (isset($langArray['default'][$index][0]['target'])) {
             return $langArray['default'][$index][0]['target'];
         } else {
             return "Missing translation for ".substr($index, 9); //cut 'metadata.' string

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -419,8 +419,10 @@ class NewTenantController extends AbstractController
     {
         if (isset($langArray[$lang][$index][0]['target'])) {
             return $langArray[$lang][$index][0]['target'];
-        } else {
+        } else if (isset($langArray['default'][$index][0]['target'])) {
             return $langArray['default'][$index][0]['target'];
+        } else {
+            return "Missing translation for ".substr($index, 9); //cut 'metadata.' string
         }
     }
 }

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -422,7 +422,7 @@ class NewTenantController extends AbstractController
         } elseif (isset($langArray['default'][$index][0]['target'])) {
             return $langArray['default'][$index][0]['target'];
         } else {
-            return "Missing translation for ".substr($index, 9); //cut 'metadata.' string
+            return 'Missing translation for ' . $index;
         }
     }
 }


### PR DESCRIPTION
This PR implements a fallback option in getLLL() if there is no translation for given key as proposed in https://github.com/kitodo/kitodo-presentation/issues/916

After creating metadata with missing strings:
![grafik](https://user-images.githubusercontent.com/43964592/221189976-f4a67fd9-3193-47fb-8cc2-dedc928df282.png)

But endusers can still change the title to their needings:
![grafik](https://user-images.githubusercontent.com/43964592/221190267-15fd1568-9697-47a8-83c5-773cdf2fa7c6.png)
