### PR TITLE
[BUG] Fix use a scalar value as an array

### DIFF
--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -261,8 +261,6 @@ class MetadataController extends AbstractController
                         foreach ($metadata[$i][$name] as &$langValue) {
                             $langValue = Helper::getLanguageName($langValue);
                         }
-                    } elseif (!empty($value)) {
-                        $metadata[$i][$name][0] = $metadata[$i][$name][0];
                     }
 
                     if (is_array($metadata[$i][$name])) {


### PR DESCRIPTION
Fix for the error:

`PHP Warning: Cannot use a scalar value as an array in /var/www/extensions/kitodo-presentation/Classes/Controller/MetadataController.php line 265`