### PR TITLE
[BUG] Fix messages for New Tenant module

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -197,26 +197,6 @@
 				<source><![CDATA[...]]></source>
 				<target><![CDATA[...]]></target>
 			</trans-unit>
-			<trans-unit id="newTenant.createFormat" approved="yes">
-				<source><![CDATA[Create default namespaces]]></source>
-				<target><![CDATA[Standard-Namensräume anlegen]]></target>
-			</trans-unit>
-			<trans-unit id="newTenant.createMetadata" approved="yes">
-				<source><![CDATA[Create metadata]]></source>
-				<target><![CDATA[Metadaten Konfiguration anlegen]]></target>
-			</trans-unit>
-			<trans-unit id="newTenant.createSolrCore" approved="yes">
-				<source><![CDATA[Create solr core]]></source>
-				<target><![CDATA[Solr Kern anlegen]]></target>
-			</trans-unit>
-			<trans-unit id="newTenant.createStructure" approved="yes">
-				<source><![CDATA[Create structures]]></source>
-				<target><![CDATA[Strukturdaten Konfiguration anlegen]]></target>
-			</trans-unit>
-			<trans-unit id="newTenant.module" approved="yes">
-				<source><![CDATA[New Tenant Module]]></source>
-				<target><![CDATA[Modul Neuer Mandant]]></target>
-			</trans-unit>
 			<trans-unit id="nextPage" approved="yes">
 				<source><![CDATA[Next Page]]></source>
 				<target><![CDATA[Nächste Seite]]></target>
@@ -481,6 +461,26 @@
 				<source><![CDATA[Zoom Out]]></source>
 				<target><![CDATA[Ansicht verkleinern]]></target>
 			</trans-unit>
+			<trans-unit id="newTenant.module" approved="yes">
+				<source><![CDATA[New Tenant Module]]></source>
+				<target><![CDATA[Modul Neuer Mandant]]></target>
+			</trans-unit>
+			<trans-unit id="newTenant.createFormat" approved="yes">
+				<source><![CDATA[Create default namespaces]]></source>
+				<target><![CDATA[Standard-Namensräume anlegen]]></target>
+			</trans-unit>
+			<trans-unit id="newTenant.createMetadata" approved="yes">
+				<source><![CDATA[Create metadata]]></source>
+				<target><![CDATA[Metadaten Konfiguration anlegen]]></target>
+			</trans-unit>
+			<trans-unit id="newTenant.createSolrCore" approved="yes">
+				<source><![CDATA[Create solr core]]></source>
+				<target><![CDATA[Solr Kern anlegen]]></target>
+			</trans-unit>
+			<trans-unit id="newTenant.createStructure" approved="yes">
+				<source><![CDATA[Create structures]]></source>
+				<target><![CDATA[Strukturdaten Konfiguration anlegen]]></target>
+			</trans-unit>
             <trans-unit id="newTenant.formatOkay" approved="yes">
                 <source><![CDATA[Default namespaces found!]]></source>
                 <target><![CDATA[Standard-Namensräume gefunden!]]></target>
@@ -489,19 +489,11 @@
                 <source><![CDATA[The namespace definitions for MODS, TEIHDR and ALTO do exist.]]></source>
                 <target><![CDATA[Die Standard-Namensräume für MODS, TEIHDR und ALTO sind definiert.]]></target>
             </trans-unit>
-            <trans-unit id="newTenant.formatCreated" approved="yes">
-                <source><![CDATA[Default namespaces created successfully!]]></source>
-                <target><![CDATA[Standard-Namensräume erfolgreich angelegt!]]></target>
-            </trans-unit>
-            <trans-unit id="newTenant.formatCreatedMsg" approved="yes">
-                <source><![CDATA[The namespace definitions for MODS, TEIHDR and/or ALTO were created properly.]]></source>
-                <target><![CDATA[Die Standard-Namensräume für MODS, TEIHDR und/oder ALTO wurden erfolgreich definiert.]]></target>
-            </trans-unit>
-            <trans-unit id="newTenant.formatNotCreated" approved="yes">
+            <trans-unit id="newTenant.formatNotOkay" approved="yes">
                 <source><![CDATA[Default namespaces not found!]]></source>
                 <target><![CDATA[Standard-Namensräume nicht gefunden!]]></target>
             </trans-unit>
-            <trans-unit id="newTenant.formatNotCreatedMsg" approved="yes">
+            <trans-unit id="newTenant.formatNotOkayMsg" approved="yes">
                 <source><![CDATA[The namespace definitions for MODS, TEIHDR and/or ALTO do not exist and could not be created.]]></source>
                 <target><![CDATA[Die Standard-Namensräume für MODS, TEIHDR und/oder ALTO konnten nicht definiert werden.]]></target>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -371,6 +371,12 @@
             <trans-unit id="newTenant.formatOkayMsg" approved="yes">
                 <source><![CDATA[The namespace definitions for MODS, TEIHDR and ALTO do exist.]]></source>
             </trans-unit>
+            <trans-unit id="newTenant.formatNotOkay" approved="yes">
+                <source><![CDATA[Default namespaces not found!]]></source>
+            </trans-unit>
+            <trans-unit id="newTenant.formatNotOkayMsg" approved="yes">
+                <source><![CDATA[The namespace definitions for MODS, TEIHDR and/or ALTO do not exist and could not be created.]]></source>
+            </trans-unit>
             <trans-unit id="newTenant.structureOkay" approved="yes">
                 <source><![CDATA[Structures found!]]></source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/NewTenant/Index.html
+++ b/Resources/Private/Templates/Backend/NewTenant/Index.html
@@ -59,7 +59,7 @@
             <f:form action="addMetadata" name="metadata">
                 <f:if condition="{formatsAvailable} == '0'">
                     <f:then>
-                        <f:form.submit name="submit" value="{f:translate(key: 'newTenant.createMetadata')}" class="btn btn-primary" disabled />
+                        <f:form.button name="submit" class="btn btn-primary" disabled="disabled"><f:translate key="newTenant.createMetadata" /></f:form.button>
                     </f:then>
                     <f:else>
                         <f:form.submit name="submit" value="{f:translate(key: 'newTenant.createMetadata')}" class="btn btn-primary" />


### PR DESCRIPTION
This fixes some bugs in the New Tenant BE module:
- Added missing translations for message about missing namespace configuration (`newTenant.formatNotOkay` and `newTenant.formatNotOkayMsg`)
- Removed old translation keys which were now longer in use (`newTenant.formatCreated` and `newTenant.formatCreatedMsg`)
- Changed disabled submit form field for metadata to a button to allow its label to be visible