### PR TITLE
Fix pagenavigation on sorted resultsets

### DIFF
--- a/Configuration/FlexForms/Search.xml
+++ b/Configuration/FlexForms/Search.xml
@@ -41,6 +41,16 @@
                             </config>
                         </TCEforms>
                     </settings.fulltext>
+                    <settings.fulltextPreselect>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.search.flexform.fulltextPreselect</label>
+                            <config>
+                                <type>check</type>
+                                <default>0</default>
+                            </config>
+                        </TCEforms>
+                    </settings.fulltextPreselect>
                     <settings.datesearch>
                         <TCEforms>
                             <exclude>1</exclude>

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -701,6 +701,20 @@ Search
    :Default:
 
  - :Property:
+       fulltextPreselect
+   :Data Type:
+       :ref:`t3tsref:data-type-boolean`
+   :Default:
+       0
+
+ - :Property:
+       datesearch
+   :Data Type:
+       :ref:`t3tsref:data-type-boolean`
+   :Default:
+       0
+
+ - :Property:
        solrcore
    :Data Type:
        :ref:`t3tsref:data-type-integer`

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -435,7 +435,11 @@
 			</trans-unit>
 			<trans-unit id="plugins.search.flexform.fulltext" approved="yes">
 				<source><![CDATA[Enable full text search?]]></source>
-				<target><![CDATA[Volltext-Suche aktivieren?]]></target>
+				<target><![CDATA[Volltextsuche aktivieren?]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.search.flexform.fulltextPreselect" approved="yes">
+				<source><![CDATA[Preselect full text search?]]></source>
+				<target><![CDATA[Volltextsuche vorauswählen?]]></target>
 			</trans-unit>
 			<trans-unit id="plugins.search.flexform.datesearch" approved="yes">
                 <source><![CDATA[Enable date search?]]></source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -89,6 +89,9 @@
 			<trans-unit id="plugins.search.flexform.fulltext">
 				<source><![CDATA[Enable full text search?]]></source>
 			</trans-unit>
+			<trans-unit id="plugins.search.flexform.fulltextPreselect">
+				<source><![CDATA[Preselect full text search?]]></source>
+			</trans-unit>
 			<trans-unit id="plugins.search.flexform.datesearch">
                 <source><![CDATA[Enable date search?]]></source>
             </trans-unit>

--- a/Resources/Private/Partials/ListView/SortingForm.html
+++ b/Resources/Private/Partials/ListView/SortingForm.html
@@ -26,7 +26,7 @@
             </p>
         </f:if>
 
-        <f:form section="showResults" action="{action}" controller="{Controller}" name="searchParameter" method="post" class="tx-dlf-search-form">
+        <f:form section="showResults" action="search" controller="Search" name="searchParameter" method="get" class="tx-dlf-search-form">
             <div>
                 <label for="form-orderBy-{viewData.uniqueId}">
                     <f:translate key="listview.form.orderBy"/>
@@ -60,6 +60,9 @@
                     <f:form.hidden property="dateFrom" value="{lastSearch.dateFrom}" />
                     <f:form.hidden property="dateTo" value="{lastSearch.dateTo}" />
                 </f:if>
+                <f:for each="{lastSearch.fq}" as="filter" iteration="iter">
+                    <f:form.hidden name="searchParameter[fq][{iter.index}]" value="{filter}"/>
+                </f:for>
             </div>
         </f:form>
     </f:if>

--- a/Resources/Private/Templates/Search/Main.html
+++ b/Resources/Private/Templates/Search/Main.html
@@ -38,10 +38,22 @@
 
     <!-- Fulltext switch -->
     <f:if condition="{settings.fulltext}">
-        <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{viewData.uniqueId}" class="tx-dlf-search-fulltext" checked="{lastSearch.fulltext} == 0" />
-        <label for="tx-dlf-search-fulltext-no-{viewData.uniqueId}"><f:translate key="search.inMetadata"/></label>
-        <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{viewData.uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{lastSearch.fulltext} == 1" />
-        <label for="tx-dlf-search-fulltext-yes-{viewData.uniqueId}"><f:translate key="search.inFulltext"/></label>
+        <f:comment><!-- needs to be written like this, to check if fulltext searchparam == NULL --></f:comment>
+        <f:if condition="{lastSearch.fulltext} ==">
+            <f:then>
+                <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{viewData.uniqueId}" class="tx-dlf-search-fulltext" checked="{settings.fulltextPreselect} == 0" />
+                <label for="tx-dlf-search-fulltext-no-{viewData.uniqueId}"><f:translate key="search.inMetadata"/></label>
+                <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{viewData.uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{settings.fulltextPreselect} == 1" />
+                <label for="tx-dlf-search-fulltext-yes-{viewData.uniqueId}"><f:translate key="search.inFulltext"/></label>
+            </f:then>
+            <f:comment><!-- as soon we have a user preference, we use it instead --></f:comment>
+            <f:else>
+                <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{viewData.uniqueId}" class="tx-dlf-search-fulltext" checked="{lastSearch.fulltext} == 0" />
+                <label for="tx-dlf-search-fulltext-no-{viewData.uniqueId}"><f:translate key="search.inMetadata"/></label>
+                <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{viewData.uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{lastSearch.fulltext} == 1" />
+                <label for="tx-dlf-search-fulltext-yes-{viewData.uniqueId}"><f:translate key="search.inFulltext"/></label>
+            </f:else>
+        </f:if>
     </f:if>
 
     <f:comment><!-- Add list of collections as parameter when configured in search plugin --></f:comment>


### PR DESCRIPTION
This PR is a suggested fix for the issue related to failed pagenavigation in sorted lists. The underlying reason is, that from what i see, all searches require paramters via GET, while the sorting-form does POST. Thus the parameters go missing and an empty search will be returned, after using the page-navigation. Also the sorting-form does not know of the filterqueries applied by the facets. Those need to be applied to the hidden form as well.

This PR would fix the current issue, but its a rather quick fix...