### PR TITLE
[BUG] Fix pagenavigation on sorted resultsets

### DIFF
--- a/Resources/Private/Partials/ListView/SortingForm.html
+++ b/Resources/Private/Partials/ListView/SortingForm.html
@@ -26,7 +26,7 @@
             </p>
         </f:if>
 
-        <f:form section="showResults" action="{action}" controller="{Controller}" name="searchParameter" method="post" class="tx-dlf-search-form">
+        <f:form section="showResults" action="search" controller="Search" name="searchParameter" method="get" class="tx-dlf-search-form">
             <div>
                 <label for="form-orderBy-{viewData.uniqueId}">
                     <f:translate key="listview.form.orderBy"/>
@@ -60,6 +60,9 @@
                     <f:form.hidden property="dateFrom" value="{lastSearch.dateFrom}" />
                     <f:form.hidden property="dateTo" value="{lastSearch.dateTo}" />
                 </f:if>
+                <f:for each="{lastSearch.fq}" as="filter" iteration="iter">
+                    <f:form.hidden name="searchParameter[fq][{iter.index}]" value="{filter}"/>
+                </f:for>
             </div>
         </f:form>
     </f:if>


### PR DESCRIPTION
This PR is a suggested fix for the issue related to failed pagenavigation in sorted lists. The underlying reason is, that from what i see, all searches require paramters via GET, while the sorting-form does POST. Thus the parameters go missing and an empty search will be returned, after using the page-navigation. Also the sorting-form does not know of the filterqueries applied by the facets. Those need to be applied to the hidden form as well.

This PR would fix the current issue, but its a rather quick fix.

(I have closed the prior PR, because i branched off from a wrong branch with unrelated commits. This is the actual one)
