### PR TITLE
[SECURITY] Fix potential XSS vulnerability

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -915,4 +915,19 @@ class Helper
 
         return $content;
     }
+
+    /**
+     * Check if given value is a valid XML ID.
+     * @see https://www.w3.org/TR/xmlschema-2/#ID
+     *
+     * @access public
+     *
+     * @param mixed $id: The ID value to check
+     *
+     * @return bool: TRUE if $id is valid XML ID, FALSE otherwise
+     */
+    public static function isValidXmlId($id): bool
+    {
+        return preg_match('/^[_a-z][_a-z0-9-.]*$/i', $id) === 1;
+    }
 }

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -89,28 +89,7 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
         $this->requestData = GeneralUtility::_GPmerged('tx_dlf');
 
         // Sanitize user input to prevent XSS attacks.
-
-        // tx_dlf[id] may only be an UID or URI.
-        if (
-            !empty($this->requestData['id'])
-            && !MathUtility::canBeInterpretedAsInteger($this->requestData['id'])
-            && !GeneralUtility::isValidUrl($this->requestData['id'])
-        ) {
-            $this->logger->error('Invalid ID or URI "' . $this->requestData['id'] . '" for document loading');
-            unset($this->requestData['id']);
-        }
-
-        // tx_dlf[page] may only be a positive integer or valid XML ID.
-        if (
-            !empty($this->requestData['page'])
-            && !MathUtility::canBeInterpretedAsInteger($this->requestData['page'])
-            && !Helper::isValidXmlId($this->requestData['page'])
-        ) {
-            $this->requestData['page'] = 1;
-        }
-
-        // tx_dlf[double] may only be 0 or 1.
-        $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
+        $this->sanitizeRequestData();
 
         // Get extension configuration.
         $this->extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('dlf');
@@ -241,6 +220,36 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
             return $this->request->getArgument($parameterName);
         }
         return null;
+    }
+
+    /**
+     * Sanitize input variables.
+     *
+     * @return void
+     */
+    private function sanitizeRequestData()
+    {
+        // tx_dlf[id] may only be an UID or URI.
+        if (
+            !empty($this->requestData['id'])
+            && !MathUtility::canBeInterpretedAsInteger($this->requestData['id'])
+            && !GeneralUtility::isValidUrl($this->requestData['id'])
+        ) {
+            $this->logger->warning('Invalid ID or URI "' . $this->requestData['id'] . '" for document loading');
+            unset($this->requestData['id']);
+        }
+
+        // tx_dlf[page] may only be a positive integer or valid XML ID.
+        if (
+            !empty($this->requestData['page'])
+            && !MathUtility::canBeInterpretedAsInteger($this->requestData['page'])
+            && !Helper::isValidXmlId($this->requestData['page'])
+        ) {
+            $this->requestData['page'] = 1;
+        }
+
+        // tx_dlf[double] may only be 0 or 1.
+        $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
     }
 
     /**

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -23,7 +23,6 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 
-
 /**
  * Abstract controller class for most of the plugin controller.
  *
@@ -88,9 +87,28 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
     protected function initialize()
     {
         $this->requestData = GeneralUtility::_GPmerged('tx_dlf');
-        if (empty($this->requestData['page'])) {
+
+        // Sanitize user input to prevent XSS attacks.
+
+        // tx_dlf[id] may only be an UID or URI.
+        if (
+            !empty($this->requestData['id'])
+            && !MathUtility::canBeInterpretedAsInteger($this->requestData['id'])
+            && !GeneralUtility::isValidUrl($this->requestData['id'])
+        ) {
+            unset($this->requestData['id']);
+            $this->logger->error('Invalid ID or URI "' . $this->requestData['id'] . '" for document loading');
+        }
+
+        // tx_dlf[page] may only be a positive integer or valid XML ID.
+        if (
+            empty($this->requestData['page'])
+            || !preg_match('/^[1-9][0-9]*$|^[_a-z][_a-z0-9-.]*$/', $this->requestData['page']) === 1
+        ) {
             $this->requestData['page'] = 1;
         }
+
+        // tx_dlf[double] may only be 0 or 1.
         $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
 
         // Get extension configuration.
@@ -108,28 +126,33 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
      *
      * @access protected
      *
-     * @param array $requestData: The request data
+     * @param  int $documentId: The document's UID (fallback: $this->requestData[id])
      *
      * @return void
      */
-    protected function loadDocument($requestData)
+    protected function loadDocument(int $documentId = 0)
     {
+        // Get document ID from request data if not passed as parameter.
+        if ($documentId === 0 && !empty($this->requestData['id'])) {
+            $documentId = $this->requestData['id'];
+        }
+
         // Try to get document format from database
-        if (!empty($requestData['id'])) {
+        if (!empty($documentId)) {
 
             $doc = null;
 
-            if (MathUtility::canBeInterpretedAsInteger($requestData['id'])) {
+            if (MathUtility::canBeInterpretedAsInteger($documentId)) {
                 // find document from repository by uid
-                $this->document = $this->documentRepository->findOneByIdAndSettings((int) $requestData['id']);
+                $this->document = $this->documentRepository->findOneByIdAndSettings((int) $documentId);
                 if ($this->document) {
                     $doc = Doc::getInstance($this->document->getLocation(), $this->settings, true);
                 } else {
-                    $this->logger->error('Invalid UID "' . $requestData['id'] . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
+                    $this->logger->error('Invalid UID "' . $documentId . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
                 }
-            } else if (GeneralUtility::isValidUrl($requestData['id'])) {
+            } else if (GeneralUtility::isValidUrl($documentId)) {
 
-                $doc = Doc::getInstance($requestData['id'], $this->settings, true);
+                $doc = Doc::getInstance($documentId, $this->settings, true);
 
                 if ($doc !== null) {
                     if ($doc->recordId) {
@@ -146,9 +169,9 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
                         $doc->cPid = max(intval($this->settings['storagePid']), 0);
                     }
 
-                    $this->document->setLocation($requestData['id']);
+                    $this->document->setLocation($documentId);
                 } else {
-                    $this->logger->error('Invalid location given "' . $requestData['id'] . '" for document loading');
+                    $this->logger->error('Invalid location given "' . $documentId . '" for document loading');
                 }
             }
 
@@ -156,20 +179,20 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
                 $this->document->setDoc($doc);
             }
 
-        } elseif (!empty($requestData['recordId'])) {
+        } elseif (!empty($this->requestData['recordId'])) {
 
-            $this->document = $this->documentRepository->findOneByRecordId($requestData['recordId']);
+            $this->document = $this->documentRepository->findOneByRecordId($this->requestData['recordId']);
 
             if ($this->document !== null) {
                 $doc = Doc::getInstance($this->document->getLocation(), $this->settings, true);
                 if ($this->document !== null && $doc !== null) {
                     $this->document->setDoc($doc);
                 } else {
-                    $this->logger->error('Failed to load document with record ID "' . $requestData['recordId'] . '"');
+                    $this->logger->error('Failed to load document with record ID "' . $this->requestData['recordId'] . '"');
                 }
             }
         } else {
-            $this->logger->error('Invalid ID "' . $requestData['id'] . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
+            $this->logger->error('Invalid ID "' . $documentId . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
         }
     }
 

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -102,8 +102,9 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
 
         // tx_dlf[page] may only be a positive integer or valid XML ID.
         if (
-            empty($this->requestData['page'])
-            || !preg_match('/^[1-9][0-9]*$|^[_a-z][_a-z0-9-.]*$/', $this->requestData['page']) === 1
+            !empty($this->requestData['page'])
+            && !MathUtility::canBeInterpretedAsInteger($this->requestData['page'])
+            && !Helper::isValidXmlId($this->requestData['page'])
         ) {
             $this->requestData['page'] = 1;
         }

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -144,7 +144,7 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
 
             if (MathUtility::canBeInterpretedAsInteger($documentId)) {
                 // find document from repository by uid
-                $this->document = $this->documentRepository->findOneByIdAndSettings((int) $documentId);
+                $this->document = $this->documentRepository->findOneByIdAndSettings($documentId);
                 if ($this->document) {
                     $doc = Doc::getInstance($this->document->getLocation(), $this->settings, true);
                 } else {

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -96,8 +96,8 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
             && !MathUtility::canBeInterpretedAsInteger($this->requestData['id'])
             && !GeneralUtility::isValidUrl($this->requestData['id'])
         ) {
-            unset($this->requestData['id']);
             $this->logger->error('Invalid ID or URI "' . $this->requestData['id'] . '" for document loading');
+            unset($this->requestData['id']);
         }
 
         // tx_dlf[page] may only be a positive integer or valid XML ID.

--- a/Classes/Controller/AudioPlayerController.php
+++ b/Classes/Controller/AudioPlayerController.php
@@ -75,7 +75,7 @@ class AudioplayerController extends AbstractController
     public function mainAction()
     {
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->isDocMissingOrEmpty()) {
             // Quit without doing anything if required variables are not set.
             return '';

--- a/Classes/Controller/BasketController.php
+++ b/Classes/Controller/BasketController.php
@@ -300,7 +300,7 @@ class BasketController extends AbstractController
     protected function getDocumentData($id, $data)
     {
         // get document instance to load further information
-        $this->loadDocument(['id' => $id]);
+        $this->loadDocument((int) $id);
         if ($this->document) {
             // replace url param placeholder
             $urlParams = str_replace("##page##", (int) $data['page'], $this->settings['pdfparams']);
@@ -395,7 +395,7 @@ class BasketController extends AbstractController
                 $items = [];
             }
             // get document instance to load further information
-            $this->loadDocument(['id' => $documentItem['id']]);
+            $this->loadDocument((int) $documentItem['id']);
             if ($this->isDocMissing()) {
                 // Quit without doing anything if required variables are not set.
                 return;

--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -62,7 +62,7 @@ class CalendarController extends AbstractController
         }
 
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->document === null) {
             // Quit without doing anything if required variables are not set.
             return '';
@@ -109,7 +109,7 @@ class CalendarController extends AbstractController
         $this->requestData = array_merge($this->requestData, $mainrequestData);
 
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->document === null) {
             // Quit without doing anything if required variables are not set.
             return '';
@@ -238,7 +238,7 @@ class CalendarController extends AbstractController
         $this->requestData = array_merge($this->requestData, $mainrequestData);
 
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->document === null) {
             // Quit without doing anything if required variables are not set.
             return '';

--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -78,7 +78,7 @@ class MetadataController extends AbstractController
         $this->cObj = $this->configurationManager->getContentObject();
 
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return '';

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -56,7 +56,7 @@ class NavigationController extends AbstractController
     public function mainAction()
     {
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return '';

--- a/Classes/Controller/PageGridController.php
+++ b/Classes/Controller/PageGridController.php
@@ -31,7 +31,7 @@ class PageGridController extends AbstractController
      */
     public function mainAction()
     {
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if (
             $this->isDocMissingOrEmpty()
             || empty($this->extConf['fileGrpThumbs'])

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -68,7 +68,7 @@ class PageViewController extends AbstractController
     public function mainAction()
     {
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->isDocMissingOrEmpty()) {
             // Quit without doing anything if required variables are not set.
             return '';

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -42,7 +42,7 @@ class TableOfContentsController extends AbstractController
     public function mainAction()
     {
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return;

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -33,7 +33,7 @@ class ToolboxController extends AbstractController
     public function mainAction()
     {
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
 
         $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
         $this->view->assign('double', $this->requestData['double']);

--- a/Classes/Controller/View3DController.php
+++ b/Classes/Controller/View3DController.php
@@ -31,7 +31,7 @@ class View3DController extends AbstractController
     {
         $this->cObj = $this->configurationManager->getContentObject();
         // Load current document.
-        $this->loadDocument($this->requestData);
+        $this->loadDocument();
         if (
             $this->isDocMissingOrEmpty()
             || $this->document->getDoc()->metadataArray['LOG_0001']['type'][0] != 'object'
@@ -56,7 +56,7 @@ class View3DController extends AbstractController
 
             if ($this->settings['useInternalProxy']) {
                 $absoluteUri = !empty($this->settings['forceAbsoluteUrl']) ? true : false;
-                
+
                 $model = $this->uriBuilder->reset()
                     ->setTargetPageUid($GLOBALS['TSFE']->id)
                     ->setCreateAbsoluteUri($absoluteUri)


### PR DESCRIPTION
There is a potential security issue in Kitodo.Presentation allowing attackers to forge XSS URLs using the `tx_dlf['page']` parameter. In order to be vulnerable to this attack the instance must not use TYPO3 routing and the Fluid template of the `Navigation` plugin must fail to properly escape the `page` value of the request data.

This pull request adds proper sanitizing for `tx_dlf['page']` and moves sanitation of `tx_dlf[id]` to plugin initialization (the latter was already sanitized before, but at a later point).