### PR TITLE
[BUGFIX] Fix missing lastPage option in Navigation-Plugin and swapped pageBack/pageStepBack

### DIFF
--- a/Configuration/FlexForms/Navigation.xml
+++ b/Configuration/FlexForms/Navigation.xml
@@ -60,15 +60,15 @@
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageLast</numIndex>
                                         <numIndex index="1">pageLast</numIndex>
                                     </numIndex>
-                                    <numIndex index="7">
+                                    <numIndex index="8">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.listview</numIndex>
                                         <numIndex index="1">listview</numIndex>
                                     </numIndex>
-                                    <numIndex index="8">
+                                    <numIndex index="9">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.zoom</numIndex>
                                         <numIndex index="1">zoom</numIndex>
                                     </numIndex>
-                                    <numIndex index="9">
+                                    <numIndex index="10">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.rotation</numIndex>
                                         <numIndex index="1">rotation</numIndex>
                                     </numIndex>

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -82,7 +82,7 @@
     </div>
 </f:section>
 
-<f:section name="render.pageBack">
+<f:section name="render.pageStepBack">
     <div class="tx-dlf-navigation-back">
         <f:if condition="{viewData.requestData.page} > {pageSteps}">
             <f:then>
@@ -99,7 +99,7 @@
     </div>
 </f:section>
 
-<f:section name="render.pageStepBack">
+<f:section name="render.pageBack">
     <div class="tx-dlf-navigation-prev">
         <f:if condition="{viewData.requestData.page} > {viewData.requestData.double + 1}">
             <f:then>


### PR DESCRIPTION
This PR fixes the issue, where the option for a lastPage-Button in missing in the Navigation-Plugin in the backend, due to a duplicate indexnumber in the Flexform.
It also fixes an issue in the Navigation-Plugin, where the output of pageBack and pageStepBack was swapped.