### PR TITLE
[BUGFIX] Add cases for tools configured without tx_dlf_

### DIFF
--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -64,24 +64,31 @@ class ToolboxController extends AbstractController
         if (!empty($this->settings['tool'])) {
             switch ($this->settings['tool']) {
                 case 'tx_dlf_annotationtool':
+                case 'annotationtool':
                     $this->renderToolByName('renderAnnotationTool');
                     break;
                 case 'tx_dlf_fulltextdownloadtool':
+                case 'fulltextdownloadtool':
                     $this->renderToolByName('renderFulltextDownloadTool');
                     break;
                 case 'tx_dlf_fulltexttool':
+                case 'fulltexttool':
                     $this->renderToolByName('renderFulltextTool');
                     break;
                 case 'tx_dlf_imagedownloadtool':
+                case 'imagedownloadtool':
                     $this->renderToolByName('renderImageDownloadTool');
                     break;
                 case 'tx_dlf_imagemanipulationtool':
+                case 'imagemanipulationtool':
                     $this->renderToolByName('renderImageManipulationTool');
                     break;
                 case 'tx_dlf_pdfdownloadtool':
+                case 'pdfdownloadtool':
                     $this->renderToolByName('renderPdfDownloadTool');
                     break;
                 case 'tx_dlf_searchindocumenttool':
+                case 'searchindocumenttool':
                     $this->renderToolByName('renderSearchInDocumentTool');
                     break;
                 default:


### PR DESCRIPTION
It looks that configuration of tools can go with strings in format 'tx_dlf_xyztool" or 'xyztool'. Here are added switch cases to handle the second option.