### PR TITLE
[BUGFIX] Display volumes correctly in ToC plugin

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -196,7 +196,7 @@ class BaseCommand extends Command
         $document->setAuthor(implode('; ', $metadata['author']));
         $document->setThumbnail($doc->thumbnail ? : '');
         $document->setMetsLabel($metadata['mets_label'][0] ? : '');
-        $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ? : '');
+        $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ? : $metadata['mets_order'][0] ? : '');
 
         $structure = $this->structureRepository->findOneByIndexName($metadata['type'][0], 'tx_dlf_structures');
         $document->setStructure($structure);
@@ -258,9 +258,9 @@ class BaseCommand extends Command
             }
         }
 
-        // to be still (re-) implemented
-        // 'volume' => $metadata['volume'][0],
-        // 'volume_sorting' => $metadata['volume_sorting'][0],
+        // set volume data
+        $document->setVolume($metadata['volume'][0] ? : '');
+        $document->setVolume_Sorting($metadata['volume_sorting'][0] ? : '');
 
         // Get UID of parent document.
         if ($document->getDocumentFormat() === 'METS') {

--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -172,11 +172,9 @@ class BaseCommand extends Command
      */
     protected function saveToDatabase(Document $document)
     {
-        $success = false;
-
         $doc = $document->getDoc();
         if ($doc === null) {
-            return $success;
+            return false;
         }
         $doc->cPid = $this->storagePid;
 
@@ -260,7 +258,7 @@ class BaseCommand extends Command
 
         // set volume data
         $document->setVolume($metadata['volume'][0] ? : '');
-        $document->setVolume_Sorting($metadata['volume_sorting'][0] ? : '');
+        $document->setVolumeSorting($metadata['volume_sorting'][0] ? : '');
 
         // Get UID of parent document.
         if ($document->getDocumentFormat() === 'METS') {
@@ -278,9 +276,7 @@ class BaseCommand extends Command
         $persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
         $persistenceManager->persistAll();
 
-        $success = true;
-
-        return $success;
+        return true;
     }
 
     /**

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -141,6 +141,10 @@ class TableOfContentsController extends AbstractController
         $entryArray['_OVERRIDE_HREF'] = '';
         $entryArray['doNotLinkIt'] = 1;
         $entryArray['ITEM_STATE'] = 'NO';
+
+        if ($entry['type'] == 'volume') {
+            $entryArray['title'] = $this->getTranslatedType($entry['type']) . ' ' . $entry['volume'];
+        }
         // Build menu links based on the $entry['points'] array.
         if (
             !empty($entry['points'])
@@ -251,7 +255,6 @@ class TableOfContentsController extends AbstractController
 
     /**
      * Sort menu by orderlabel - currently implemented for newspaper.
-     * //TODO: add for years
      * 
      * @param array &$menu
      * @return void


### PR DESCRIPTION
Depends on #956

This works but all in all it is a bit confusing.

I would propose that fields `mets_orderlabel`, `mets_order` and `volume_sorting` in database are getting consolidated into one field called `order`. Then we should add general method to keep ToC arrays sorted by this field. Is there any difference between those 3 fields? Or they usage depends on the document type?

In general we are using now for title 3 different fields: `title`, `label` or `orderlabel`. And they have also two forms of naming `label` or `mets_label`, the same for `orderlabel`. Here should be also considered the naming of this fields while querying data because it is also quiet confusing. 

Example:
```
$entry = [
    'label' => !empty($resArray['mets_label']) ? $resArray['mets_label'] : $resArray['title'],
    'orderlabel' => $resArray['mets_orderlabel'],
```
then it is used here
```
$entryArray['title'] = !empty($entry['label']) ? $entry['label'] : $entry['orderlabel'];
```