### PR TITLE
[BUGFIX] Prevent attempted indexing of improper dateformats

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -349,10 +349,9 @@ class Indexer
                 } elseif (preg_match("/^[\d]{8}$/", $metadata['date'][0])){
                     $solrDoc->setField('date', date("Y-m-d", strtotime($metadata['date'][0])));
                 // convert any datetime to proper ISO extended datetime format and timezone for SOLR
-                } else {
+                } elseif (preg_match("/^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*$/", $metadata['date'][0])) {
                     $solrDoc->setField('date', date('Y-m-d\TH:i:s\Z', strtotime($metadata['date'][0])));
                 }
-                $solrDoc->setField('date', $metadata['date'][0]);
             }
             $solrDoc->setField('record_id', $metadata['record_id'][0]);
             $solrDoc->setField('purl', $metadata['purl'][0]);


### PR DESCRIPTION
This PR addresses an issue, where improper formatted dates might get passed to the SOLR for indexing, causing the documents not to be indexed at all. So a check for proper datetimes was added, in addition to the existing date-checks that are already in place.

The problem lies within how `strtotime` interprets date-formats, so that even dates like "18XX" or "o.D." are presumably valid time-representations as they could have been interpreted as timezone-designations (https://www.php.net/manual/en/datetime.formats.time.php).