### PR TITLE
[BUGFIX] Display issues correctly in ToC plugin

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -333,7 +333,7 @@ final class MetsDocument extends Doc
         $details['orderlabel'] = (isset($attributes['ORDERLABEL']) ? $attributes['ORDERLABEL'] : '');
         $details['contentIds'] = (isset($attributes['CONTENTIDS']) ? $attributes['CONTENTIDS'] : '');
         $details['volume'] = '';
-        // Set volume information only if no label is set and this is the toplevel structure element.
+        // Set volume any year information only if no label is set and this is the toplevel structure element.
         if (
             empty($details['label'])
             && $details['id'] == $this->_getToplevelId()
@@ -341,6 +341,9 @@ final class MetsDocument extends Doc
             $metadata = $this->getMetadata($details['id']);
             if (!empty($metadata['volume'][0])) {
                 $details['volume'] = $metadata['volume'][0];
+            }
+            if (!empty($metadata['year'][0])) {
+                $details['year'] = $metadata['year'][0];
             }
         }
         $details['pagination'] = '';

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -181,8 +181,10 @@ final class MetsDocument extends Doc
         $details = $this->getLogicalStructure($id);
         if (!empty($details)) {
             $metadata['mets_order'][0] = $details['order'];
-            $metadata['mets_label'][0] = $details['label'];
-            $metadata['mets_orderlabel'][0] = $details['orderlabel'];
+            if ($metadata['type'][0] != 'issue') {
+                $metadata['mets_label'][0] = $details['label'];
+                $metadata['mets_orderlabel'][0] = $details['orderlabel'];
+            }
         }
     }
 
@@ -630,6 +632,14 @@ final class MetsDocument extends Doc
         if (empty($metadata['date'][0])) {
             $metadata['date'][0] = '';
         }
+        // Set mets_label for issues
+        if ($metadata['type'][0] == 'issue' && empty($metadata['mets_label'][0])) {
+            $dayLabel = $this->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]//mets:div[@TYPE="day"]/@ORDERLABEL');
+            if (!empty($dayLabel)) {
+                $metadata['mets_label'] = [(string) $dayLabel[0]];
+            }
+        }
+
         // Files are not expected to reference a dmdSec
         if (isset($this->fileInfos[$id]) || isset($hasMetadataSection['dmdSec'])) {
             return $metadata;

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -181,10 +181,8 @@ final class MetsDocument extends Doc
         $details = $this->getLogicalStructure($id);
         if (!empty($details)) {
             $metadata['mets_order'][0] = $details['order'];
-            if ($metadata['type'][0] != 'issue') {
-                $metadata['mets_label'][0] = $details['label'];
-                $metadata['mets_orderlabel'][0] = $details['orderlabel'];
-            }
+            $metadata['mets_label'][0] = $details['label'];
+            $metadata['mets_orderlabel'][0] = $details['orderlabel'];
         }
     }
 
@@ -631,13 +629,6 @@ final class MetsDocument extends Doc
         // Set date to empty string if not present.
         if (empty($metadata['date'][0])) {
             $metadata['date'][0] = '';
-        }
-        // Set mets_label for issues
-        if ($metadata['type'][0] == 'issue' && empty($metadata['mets_label'][0])) {
-            $dayLabel = $this->mets->xpath('./mets:structMap[@TYPE="LOGICAL"]//mets:div[@TYPE="day"]/@ORDERLABEL');
-            if (!empty($dayLabel)) {
-                $metadata['mets_label'] = [(string) $dayLabel[0]];
-            }
         }
 
         // Files are not expected to reference a dmdSec

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -333,7 +333,7 @@ final class MetsDocument extends Doc
         $details['orderlabel'] = (isset($attributes['ORDERLABEL']) ? $attributes['ORDERLABEL'] : '');
         $details['contentIds'] = (isset($attributes['CONTENTIDS']) ? $attributes['CONTENTIDS'] : '');
         $details['volume'] = '';
-        // Set volume any year information only if no label is set and this is the toplevel structure element.
+        // Set volume and year information only if no label is set and this is the toplevel structure element.
         if (
             empty($details['label'])
             && empty($details['orderlabel'])

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -336,7 +336,7 @@ final class MetsDocument extends Doc
         // Set volume any year information only if no label is set and this is the toplevel structure element.
         if (
             empty($details['label'])
-            && $details['id'] == $this->_getToplevelId()
+            && empty($details['orderlabel'])
         ) {
             $metadata = $this->getMetadata($details['id']);
             if (!empty($metadata['volume'][0])) {

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -288,7 +288,7 @@ class TableOfContentsController extends AbstractController
     }
 
     /**
-     * Sort menu by orderlabel - currently implemented for newspaper.
+     * Sort menu by orderlabel.
      *
      * @param array &$menu
      *
@@ -296,20 +296,23 @@ class TableOfContentsController extends AbstractController
      */
     private function sortMenu(&$menu) {
         if ($menu[0]['type'] == $this->getTranslatedType("newspaper")) {
-            $this->sortMenuForNewspapers($menu);
+            $this->sortSubMenu($menu);
+        }
+        if ($menu[0]['type'] == $this->getTranslatedType("year")) {
+            $this->sortSubMenu($menu);
         }
     }
 
     /**
-     * Sort menu years of the newspaper by orderlabel.
+     * Sort sub menu e.g years of the newspaper by orderlabel.
      *
      * @param array &$menu
      *
      * @return void
      */
-    private function sortMenuForNewspapers(&$menu) {
-        usort($menu[0]['_SUB_MENU'], function ($firstYear, $secondYear) {
-            return $firstYear['orderlabel'] <=> $secondYear['orderlabel'];
+    private function sortSubMenu(&$menu) {
+        usort($menu[0]['_SUB_MENU'], function ($firstElement, $secondElement) {
+            return $firstElement['orderlabel'] <=> $secondElement['orderlabel'];
         });
     }
 }

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -303,7 +303,6 @@ class TableOfContentsController extends AbstractController
                 if ($entry['type'] == $titleReplacement['type']) {
                     $fields = explode(",", $titleReplacement['fields']);
                     $title = '';
-        
                     foreach ($fields as $field) {
                         if ($field == 'type') {
                             $title .= $this->getTranslatedType($entry['type']) . ' ';

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -132,7 +132,7 @@ class TableOfContentsController extends AbstractController
 
         $entryArray = [];
         // Set "title", "volume", "type" and "pagination" from $entry array.
-        $entryArray['title'] = !empty($entry['label']) ? $entry['label'] : $entry['orderlabel'];
+        $entryArray['title'] = $this->setTitle($entry);
         $entryArray['volume'] = $entry['volume'];
         $entryArray['orderlabel'] = $entry['orderlabel'];
         $entryArray['type'] = $this->getTranslatedType($entry['type']);
@@ -141,9 +141,6 @@ class TableOfContentsController extends AbstractController
         $entryArray['doNotLinkIt'] = 1;
         $entryArray['ITEM_STATE'] = 'NO';
 
-        if ($entry['type'] == 'volume') {
-            $entryArray['title'] = $this->getTranslatedType($entry['type']) . ' ' . $entry['volume'];
-        }
         // Build menu links based on the $entry['points'] array.
         if (
             !empty($entry['points'])
@@ -272,6 +269,23 @@ class TableOfContentsController extends AbstractController
     private function isMultiElement($type) {
         return $type === 'multivolume_work' || $type === 'multipart_manuscript';
     }
+    /**
+     * Set title from entry.
+     *
+     * @param array $entry
+     * @return string
+     */
+    private function setTitle($entry) {
+        if ($entry['type'] == 'issue') {
+            return $this->getTranslatedType($entry['type']) . ' ' . $entry['label'];
+        }
+
+        if ($entry['type'] == 'volume') {
+            return $this->getTranslatedType($entry['type']) . ' ' . $entry['volume'];
+        }
+
+        return !empty($entry['label']) ? $entry['label'] : $entry['orderlabel'];
+    }
 
     /**
      * Sort menu by orderlabel - currently implemented for newspaper.
@@ -288,7 +302,7 @@ class TableOfContentsController extends AbstractController
 
     /**
      * Sort menu years of the newspaper by orderlabel.
-     * 
+     *
      * @param array &$menu
      *
      * @return void

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -280,7 +280,7 @@ class TableOfContentsController extends AbstractController
             return $this->getTranslatedType($entry['type']) . ' ' . $entry['label'];
         }
 
-        if ($entry['type'] == 'volume') {
+        if ($entry['type'] == 'volume' && empty($entry['label'])) {
             return $this->getTranslatedType($entry['type']) . ' ' . $entry['volume'];
         }
 

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -348,7 +348,10 @@ class TableOfContentsController extends AbstractController
      */
     private function sortSubMenu(&$menu) {
         usort($menu[0]['_SUB_MENU'], function ($firstElement, $secondElement) {
-            return $firstElement['orderlabel'] <=> $secondElement['orderlabel'];
+            if (!empty($firstElement['orderlabel'])) {
+                return $firstElement['orderlabel'] <=> $secondElement['orderlabel'];
+            }
+            return $firstElement['year'] <=> $secondElement['year'];
         });
     }
 }

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -365,6 +365,7 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
                 'tx_dlf_documents.uid AS uid',
                 'tx_dlf_documents.title AS title',
                 'tx_dlf_documents.volume AS volume',
+                'tx_dlf_documents.year AS year',
                 'tx_dlf_documents.mets_label AS mets_label',
                 'tx_dlf_documents.mets_orderlabel AS mets_orderlabel',
                 'tx_dlf_structures_join.index_name AS type'

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -104,3 +104,18 @@ plugin.tx_dlf_search {
         }
     }
 }
+
+plugin.tx_dlf_tableofcontents {
+    settings {
+        titleReplacements {
+            0 {
+                type = issue
+                fields = type,year
+            }
+            1 {
+                type = volume
+                fields = type,volume
+            }
+        }
+    }
+}

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -867,6 +867,8 @@ Table Of Contents
        Data type
    :Default:
        Default
+   :Description:
+       Description
 
  - :Property:
        excludeOther_
@@ -893,6 +895,24 @@ Table Of Contents
    :Data Type:
        :ref:`t3tsref:data-type-page-id`
    :Default:
+
+ - :Property:
+       titleReplacement
+   :Data Type:
+       :ref:`t3tsref:data-type-list`
+   :Default:
+   :Description:
+       List containing types for which title should be replaced
+       when the label is empty. The defined fields are used for
+       replacement. Example data:
+            0 {
+                type = issue
+                fields = type,year
+            }
+            1 {
+                type = volume
+                fields = type,volume
+            }
 
 Toolbox
 -------


### PR DESCRIPTION
The issues were not displayed correctly because their METS structure doesn't contain `LABEL` nor `ORDERLABEL`:

<img width="888" alt="mets-issue" src="https://github.com/kitodo/kitodo-presentation/assets/9614459/a438336f-35cd-4896-b16e-ba2ac7e575dc">

It is fixed by taking `LABEL` from `ORDERLABEL` of day (parent) structure:

<img width="959" alt="issues-fixed" src="https://github.com/kitodo/kitodo-presentation/assets/9614459/7688f564-7fc7-413f-9e4d-51cbd995d0aa">

Probably more suitable solution would be to have METS which already contains `LABEL` or `ORDERLABEL` for issue type.

Depends on #957