### PR TITLE
[BUGFIX] Fix error Illegal string offset 'id'

### DIFF
--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -196,7 +196,7 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
                 }
             }
         } else {
-            $this->logger->error('Invalid UID "' . $requestData['id'] . '" or PID "' . $pid . '" for document loading');
+            $this->logger->error('Empty UID or invalid PID "' . $pid . '" for document loading');
         }
     }
 }


### PR DESCRIPTION
$requestData['id'] is always empty here (in line 149 is used condition !empty($requestData['id']))