### PR TITLE
[FEATURE] Use order in case volume_sorting is empty

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -195,7 +195,7 @@ class BaseCommand extends Command
         $document->setAuthor(implode('; ', $metadata['author']));
         $document->setThumbnail($doc->thumbnail ? : '');
         $document->setMetsLabel($metadata['mets_label'][0] ? : '');
-        $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ? : $metadata['mets_order'][0] ? : '');
+        $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ? : '');
 
         $structure = $this->structureRepository->findOneByIndexName($metadata['type'][0], 'tx_dlf_structures');
         $document->setStructure($structure);
@@ -261,7 +261,7 @@ class BaseCommand extends Command
 
         // set volume data
         $document->setVolume($metadata['volume'][0] ? : '');
-        $document->setVolumeSorting($metadata['volume_sorting'][0] ? : '');
+        $document->setVolumeSorting($metadata['volume_sorting'][0] ? : $metadata['mets_order'][0] ? : '');
 
         // Get UID of parent document.
         if ($document->getDocumentFormat() === 'METS') {


### PR DESCRIPTION
There are volumes which are having empty `volume` and `volume_sorting` fields in **METS** but the `order` field contains sorting information e.g. https://digital.slub-dresden.de/data/kitodo/Insk_1823251404_0001/Insk_1823251404_0001_mets.xml

Note 1: There is also `orderlabel` but in fact it is not suitable for sorting as it contains text in not sortable format.
Example: '1-1000 - A, I.1/1', '10001-11000 - A, I.1/11', '1001-2008 - A, I.1/2'. The correct order for such a 3 elements would be:

1. '1-1000 - A, I.1/1'
2. '1001-2008 - A, I.1/2'
3. '10001-11000 - A, I.1/11'

Note 2: After discussion in the PR https://github.com/kitodo/kitodo-presentation/pull/964 the solution with overwriting `order_label` with `order` is not needed anymore so I remove it here.
