### PR TITLE
[BUGFIX] Use $forceReload parameter in getInstance

### DIFF
--- a/Classes/Common/Doc.php
+++ b/Classes/Common/Doc.php
@@ -412,7 +412,7 @@ abstract class Doc
         $xml = null;
         $iiif = null;
 
-        if ($instance = self::getDocCache($location)) {
+        if ($instance = self::getDocCache($location) && !$forceReload) {
             return $instance;
         } else {
             $instance = null;


### PR DESCRIPTION
Parameter `$forceReload` is not used, but there are quiet e a few calls `getInstance` function with `$forceRealod = true`. The check if the instance should be reloaded is restored.