### PR TITLE
[BUGFIX] Remove not needed call to createDocument function

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -320,7 +320,6 @@ class Indexer
             }
             // Create new Solr document.
             $updateQuery = self::$solr->service->createUpdate();
-            $solrDoc = $updateQuery->createDocument();
             $solrDoc = self::getSolrDocument($updateQuery, $document, $logicalUnit);
             if (MathUtility::canBeInterpretedAsInteger($logicalUnit['points'])) {
                 $solrDoc->setField('page', $logicalUnit['points']);


### PR DESCRIPTION
This is already called in `getSolrDocument` function.