### PR TITLE
[FEATURE] Display ORDERLABEL as year in the search results if the structure type is year

### DIFF
--- a/Resources/Private/Partials/ListView/Results.html
+++ b/Resources/Private/Partials/ListView/Results.html
@@ -40,16 +40,16 @@
                         <f:then>
                             <f:for each="{listedMetadata}" as="metadata">
                                 <f:if condition="{document.metadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
-                                    <dt class="tx-dlf-metadata-{metadata.indexName}">
-                                        {metadata.label}
-                                    </dt>
+                                    <dt class="tx-dlf-metadata-{metadata.indexName}">{metadata.label}</dt>
                                     <f:for each="{document.metadata.{metadata.indexName}}" as="metadataentry">
-                                        <dd class="tx-dlf-metadata-{metadata.indexName}">
-                                                {metadataentry}
-                                        </dd>
+                                        <dd class="tx-dlf-metadata-{metadata.indexName}">{metadataentry}</dd>
                                     </f:for>
                                 </f:if>
                             </f:for>
+                            <f:if condition="{document.structure} == 'year'">
+                                <dt class="tx-dlf-metadata-year"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.year' /></dt>
+                                <dd class="tx-dlf-metadata-year">{document.metsOrderlabel} </dd>
+                            </f:if>
                         </f:then>
                         <f:else>
                             <p class="error">No metadata for document with uid={document.uid}</p>


### PR DESCRIPTION
<img width="450" alt="year" src="https://github.com/kitodo/kitodo-presentation/assets/9614459/8003b9c1-b10c-4169-9fd8-630f128fe241">
