### PR TITLE
[MAINTENANCE] Remove not needed sanitize for double parameter

### DIFF
--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -57,15 +57,14 @@ class NavigationController extends AbstractController
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return;
+        }
+
+        // Set default values if not set.
+        if ($this->document->getCurrentDocument()->numPages > 0) {
+            $this->setPage();
         } else {
-            // Set default values if not set.
-            if ($this->document->getCurrentDocument()->numPages > 0) {
-                $this->setPage();
-                $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
-            } else {
-                $this->requestData['page'] = 0;
-                $this->requestData['double'] = 0;
-            }
+            $this->requestData['page'] = 0;
+            $this->requestData['double'] = 0;
         }
 
         // Steps for X pages backward / forward. Double page view uses double steps.

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -71,10 +71,10 @@ class PageViewController extends AbstractController
         if ($this->isDocMissingOrEmpty()) {
             // Quit without doing anything if required variables are not set.
             return;
-        } else {
-            $this->setPage();
-            $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Get image data.
         $this->images[0] = $this->getImage($this->requestData['page']);
         $this->fulltexts[0] = $this->getFulltext($this->requestData['page']);

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -63,7 +63,6 @@ class TableOfContentsController extends AbstractController
      */
     private function makeMenuArray()
     {
-        $this->requestData['double'] = MathUtility::forceIntegerInRange($this->requestData['double'], 0, 1, 0);
         $menuArray = [];
         // Does the document have physical elements or is it an external file?
         if (


### PR DESCRIPTION
It happens already in `sanitizeRequestData()` function of `AbstractController`