### PR TITLE
Backport for fix with sanitize of request data

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -1022,6 +1022,21 @@ class Helper
     }
 
     /**
+     * Check if given value is a valid XML ID.
+     * @see https://www.w3.org/TR/xmlschema-2/#ID
+     *
+     * @access public
+     *
+     * @param mixed $id: The ID value to check
+     *
+     * @return bool: TRUE if $id is valid XML ID, FALSE otherwise
+     */
+    public static function isValidXmlId($id): bool
+    {
+        return preg_match('/^[_a-z][_a-z0-9-.]*$/i', $id) === 1;
+    }
+
+    /**
      * Prevent instantiation by hiding the constructor
      *
      * @access private

--- a/Classes/Plugin/AudioPlayer.php
+++ b/Classes/Plugin/AudioPlayer.php
@@ -91,19 +91,10 @@ class AudioPlayer extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setDefaultPage();
+
         // Check if there are any audio files available.
         $fileGrpsAudio = GeneralUtility::trimExplode(',', $this->conf['fileGrpAudio']);
         while ($fileGrpAudio = array_shift($fileGrpsAudio)) {

--- a/Classes/Plugin/Navigation.php
+++ b/Classes/Plugin/Navigation.php
@@ -111,22 +111,7 @@ class Navigation extends \Kitodo\Dlf\Common\AbstractPlugin
         } else {
             // Set default values if not set.
             if ($this->doc->numPages > 0) {
-                if (!empty($this->piVars['logicalPage'])) {
-                    $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                    // The logical page parameter should not appear
-                    unset($this->piVars['logicalPage']);
-                }
-                // Set default values if not set.
-                // $this->piVars['page'] may be integer or string (physical structure @ID)
-                if (
-                    (int) $this->piVars['page'] > 0
-                    || empty($this->piVars['page'])
-                ) {
-                    $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-                } else {
-                    $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-                }
-                $this->piVars['double'] = MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
+                $this->setPage();
             } else {
                 $this->piVars['page'] = 0;
                 $this->piVars['double'] = 0;

--- a/Classes/Plugin/PageGrid.php
+++ b/Classes/Plugin/PageGrid.php
@@ -167,21 +167,9 @@ class PageGrid extends \Kitodo\Dlf\Common\AbstractPlugin
             // Quit without doing anything if required variables are not set.
             return $content;
         }
-        if (!empty($this->piVars['logicalPage'])) {
-            $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-            // The logical page parameter should not appear
-            unset($this->piVars['logicalPage']);
-        }
-        // Set some variable defaults.
-        // $this->piVars['page'] may be integer or string (physical structure @ID)
-        if (
-            (int) $this->piVars['page'] > 0
-            || empty($this->piVars['page'])
-        ) {
-            $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-        } else {
-            $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-        }
+
+        $this->setPage();
+
         if (!empty($this->piVars['page'])) {
             $this->piVars['pointer'] = intval(floor(($this->piVars['page'] - 1) / $this->conf['limit']));
         }

--- a/Classes/Plugin/PageView.php
+++ b/Classes/Plugin/PageView.php
@@ -324,21 +324,10 @@ class PageView extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if ((int) $this->piVars['page'] > 0 || empty($this->piVars['page'])) {
-                $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Load template file.
         $this->getTemplate();
         // Get image data.

--- a/Classes/Plugin/TableOfContents.php
+++ b/Classes/Plugin/TableOfContents.php
@@ -166,24 +166,10 @@ class TableOfContents extends \Kitodo\Dlf\Common\AbstractPlugin
         if ($this->doc === null) {
             // Quit without doing anything if required variables are not set.
             return [];
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values for page if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         $menuArray = [];
         // Does the document have physical elements or is it an external file?
         if (

--- a/Classes/Plugin/Tools/AnnotationTool.php
+++ b/Classes/Plugin/Tools/AnnotationTool.php
@@ -59,24 +59,10 @@ class AnnotationTool extends AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Load template file.
         $this->getTemplate();
         $annotationContainers = $this->doc->physicalStructureInfo[$this->doc->physicalStructure[$this->piVars['page']]]['annotationContainers'];

--- a/Classes/Plugin/Tools/FulltextDownloadTool.php
+++ b/Classes/Plugin/Tools/FulltextDownloadTool.php
@@ -54,24 +54,10 @@ class FulltextDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Load template file.
         $this->getTemplate();
         // Get text download.

--- a/Classes/Plugin/Tools/FulltextTool.php
+++ b/Classes/Plugin/Tools/FulltextTool.php
@@ -55,24 +55,10 @@ class FulltextTool extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Load template file.
         $this->getTemplate();
         $fileGrpsFulltext = GeneralUtility::trimExplode(',', $this->conf['fileGrpFulltext']);

--- a/Classes/Plugin/Tools/ImageDownloadTool.php
+++ b/Classes/Plugin/Tools/ImageDownloadTool.php
@@ -52,24 +52,10 @@ class ImageDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = \TYPO3\CMS\Core\Utility\MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Load template file.
         $this->getTemplate();
         // Get left or single page download.

--- a/Classes/Plugin/Tools/PdfDownloadTool.php
+++ b/Classes/Plugin/Tools/PdfDownloadTool.php
@@ -55,24 +55,10 @@ class PdfDownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
-            $this->piVars['double'] = MathUtility::forceIntegerInRange($this->piVars['double'], 0, 1, 0);
         }
+
+        $this->setPage();
+
         // Load template file.
         $this->getTemplate();
         // Get single page downloads.

--- a/Classes/Plugin/Tools/SearchInDocumentTool.php
+++ b/Classes/Plugin/Tools/SearchInDocumentTool.php
@@ -60,23 +60,9 @@ class SearchInDocumentTool extends \Kitodo\Dlf\Common\AbstractPlugin
         ) {
             // Quit without doing anything if required variables are not set.
             return $content;
-        } else {
-            if (!empty($this->piVars['logicalPage'])) {
-                $this->piVars['page'] = $this->doc->getPhysicalPage($this->piVars['logicalPage']);
-                // The logical page parameter should not appear again
-                unset($this->piVars['logicalPage']);
-            }
-            // Set default values if not set.
-            // $this->piVars['page'] may be integer or string (physical structure @ID)
-            if (
-                (int) $this->piVars['page'] > 0
-                || empty($this->piVars['page'])
-            ) {
-                $this->piVars['page'] = MathUtility::forceIntegerInRange((int) $this->piVars['page'], 1, $this->doc->numPages, 1);
-            } else {
-                $this->piVars['page'] = array_search($this->piVars['page'], $this->doc->physicalStructure);
-            }
         }
+
+        $this->setPage();
 
         // Quit if no fulltext file is present
         $fileGrpsFulltext = GeneralUtility::trimExplode(',', $this->conf['fileGrpFulltext']);


### PR DESCRIPTION
There is an error in SLUB Digital Collections with page being 0 instead of 1.

Example:
[https://digital.slub-dresden.de/werkansicht/dlf/652658/0](https://digital.slub-dresden.de/werkansicht/dlf/652658/0?tx_dlf%5Bhighlight_word%5D=ottendorfer%20zeitung&cHash=d21b02ae4735e9102da823bc0abf0dea) (Fehler: Seite nicht gefunden) vs [https://digital.slub-dresden.de/werkansicht/dlf/652658/1](https://digital.slub-dresden.de/werkansicht/dlf/652658/1?tx_dlf%5Bhighlight_word%5D=ottendorfer%20zeitung&cHash=d21b02ae4735e9102da823bc0abf0dea) (korrekte Seite angezeigt).