### PR TITLE
[BUGFIX] Change check for empty result set

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -753,7 +753,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
             }
 
             // Save value in cache.
-            if (!empty($resultSet) && $enableCache === true) {
+            if (!empty($resultSet['documents']) && $enableCache === true) {
                 $cache->set($cacheIdentifier, $resultSet);
             }
         } else {


### PR DESCRIPTION
$resultSet is never empty becasue it is initalized with keys in line 698, so it is necessary to check if some result documents were inserted