### PR TITLE
[BUGFIX] Do not assume that return value from `Extbase\Persistence\Repository::findOneByRecordId` is not null

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -140,13 +140,15 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
                 if ($doc !== null) {
                     if ($doc->recordId) {
-                        $this->document = $this->documentRepository->findOneByRecordId($doc->recordId);
-                    }
-
-                    if ($this->document === null) {
-                        // create new dummy Document object
-                        $this->document = GeneralUtility::makeInstance(Document::class);
-                    }
+                        // find document from repository by recordId
+                        $docFromRepository = $this->documentRepository->findOneByRecordId($doc->recordId);
+                        if ($docFromRepository !== null) {
+                            $this->document = $docFromRepository;
+                        } else {
+                            // create new dummy Document object
+                            $this->document = GeneralUtility::makeInstance(Document::class);
+                        }
+                     }
 
                     // Make sure configuration PID is set when applicable
                     if ($doc->cPid == 0) {

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -148,7 +148,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
                             // create new dummy Document object
                             $this->document = GeneralUtility::makeInstance(Document::class);
                         }
-                     }
+                    }
 
                     // Make sure configuration PID is set when applicable
                     if ($doc->cPid == 0) {


### PR DESCRIPTION
This PR fixes an exception thrown when loading a document:

`Uncaught TYPO3 Exception: Typed property Kitodo\Dlf\Controller\AbstractController::$document must be an instance of Kitodo\Dlf\Domain\Model\Document, null used | TypeError thrown in file /var/www/typo3/public/typo3conf/ext/dlf/Classes/Controller/AbstractController.php in line 143.`

Now with type declarations we should check if returnvalues outside our repository (here from `Extbase\Persistence\Repository::findOneByRecordId` ) are not null.