### PR TITLE
[BUGFIX] Rename tool to tools in typoscript setup

### DIFF
--- a/Configuration/TypoScript/Toolbox/setup.typoscript
+++ b/Configuration/TypoScript/Toolbox/setup.typoscript
@@ -1,6 +1,6 @@
 plugin.tx_dlf_fulltexttool {
     settings {
-        tool = fulltexttool
+        tools = fulltexttool
         activateFullTextInitially = 0
         fullTextScrollElement = html, body
         searchHlParameters = tx_dlf[highlight_word]
@@ -9,7 +9,7 @@ plugin.tx_dlf_fulltexttool {
 
 plugin.tx_dlf_searchindocumenttool {
     settings {
-        tool = searchindocumenttool
+        tools = searchindocumenttool
         searchUrl =
         documentIdUrlSchema =
         idInputName = tx_dlf[id]


### PR DESCRIPTION
Whn I was reversing changes in DFG-Viewer I have reminded myself about this part in kitodo-presentation so follow-up for https://github.com/kitodo/kitodo-presentation/pull/1024