### PR TITLE
[BUGFIX] Fix a typo in a condition, {{ insted of {

### DIFF
--- a/Resources/Private/Partials/ListView/SortingForm.html
+++ b/Resources/Private/Partials/ListView/SortingForm.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:if condition="{{sortableMetadata}">
+    <f:if condition="{sortableMetadata}">
         <f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />
         <f:variable name="pageOffset" value="{settings.list.paginate.itemsPerPage * currentPage}" />
         <f:variable name="allDocuments" value="{documents->f:count()}" />


### PR DESCRIPTION
Error may have occurred when inserting code. See ab93eb2184ef36659ed9aa9b646b588c4a629a16  (Resources/Private/Partials/ListView/SortingForm.html)