### PR TITLE
[BUGFIX] Fix call to extension configuration

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -473,7 +473,7 @@ final class MetsDocument extends AbstractDocument
                         class_exists($class)
                         && ($obj = GeneralUtility::makeInstance($class)) instanceof MetadataInterface
                     ) {
-                        $obj->extractMetadata($this->mdSec[$dmdId]['xml'], $metadata, $this->settings['useExternalApisForMetadata']);
+                        $obj->extractMetadata($this->mdSec[$dmdId]['xml'], $metadata, GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey)['useExternalApisForMetadata']);
                     } else {
                         $this->logger->warning('Invalid class/method "' . $class . '->extractMetadata()" for metadata format "' . $this->mdSec[$dmdId]['type'] . '"');
                     }


### PR DESCRIPTION
After 0be9160a566e093c0b8394454e52a38186549300 there is a wrong call in [MetsDocument.php#L476](https://github.com/kitodo/kitodo-presentation/blob/master/Classes/Common/MetsDocument.php#L476).

`$this->settings` are not the extension configuration but some other settings:

```
array(7) {
  ["storagePid"]=>
  string(1) "3"
  ["useInternalProxy"]=>
  string(1) "1"
  ["linkTitle"]=>
  string(1) "0"
  ["getTitle"]=>
  string(1) "0"
  ["showFull"]=>
  string(1) "1"
  ["rootline"]=>
  string(1) "1"
  ["separator"]=>
  string(1) "#"
}
```
Therefore we got following exception:

```
Core: Exception handler (WEB): Uncaught TYPO3 Exception: Argument 3 passed to Kitodo\Dlf\Format\Mods::extractMetadata() must be of the type bool, null given, called in /var/www/typo3/public/typo3conf/ext/dlf/Classes/Common/MetsDocument.php on line 477 | TypeError thrown in file /var/www/typo3/public/typo3conf/ext/dlf/Classes/Format/Mods.php in line 58
```

I propose a simple fix based on similar calls in this class.