### PR TITLE
fix order of "Previous Page" and page + last page and "Next Page"

### DIFF
--- a/Resources/Private/Partials/Lists/Pagination.html
+++ b/Resources/Private/Partials/Lists/Pagination.html
@@ -3,19 +3,19 @@
     <ul class="pagination">
         <f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
             <f:then>
-                <li class="first">
-                    <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': 1}" arguments="{searchParameter: lastSearch}" title="1">1</f:link.action>
-                </li>
                 <li class="previous">
                     <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'pagination.previous')}">{f:translate(key: 'prevPage')}</f:link.action>
                 </li>
+                <li class="first">
+                    <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': 1}" arguments="{searchParameter: lastSearch}" title="1">1</f:link.action>
+                </li>
             </f:then>
             <f:else>
-                <li class="first disabled">
-                    <span>1</span>
-                </li>
                 <li class="previous disabled">
                     <span>{f:translate(key: 'prevPage')}</span>
+                </li>
+                <li class="first disabled">
+                    <span>1</span>
                 </li>
             </f:else>
         </f:if>
@@ -32,19 +32,19 @@
         </f:if>
         <f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
             <f:then>
-                <li class="next">
-                    <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'nextPage')}">{f:translate(key: 'nextPage')}</f:link.action>
-                </li>
                 <li class="last">
                     <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.lastPageNumber}" arguments="{searchParameter: lastSearch}" title="{pagination.lastPageNumber}">{pagination.lastPageNumber}</f:link.action>
                 </li>
+                <li class="next">
+                    <f:link.action action="{action}" addQueryString="true" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber}" arguments="{searchParameter: lastSearch}" title="{f:translate(key: 'nextPage')}">{f:translate(key: 'nextPage')}</f:link.action>
+                </li>
             </f:then>
             <f:else>
-                <li class="next disabled">
-                    <span>{f:translate(key: 'nextPage')}</span>
-                </li>
                 <li class="last disabled">
                     <span>{pagination.lastPageNumber}</span>
+                </li>
+                <li class="next disabled">
+                    <span>{f:translate(key: 'nextPage')}</span>
                 </li>
             </f:else>
         </f:if>


### PR DESCRIPTION
"Previous Page" and "<number of first page>"  instead of "<number of first page>" and "Previous Page" and
"<number of last page>" and "Next Page" instead of "Next Page" and "<number of last page>"