### PR TITLE
[BUGFIX] DataHandler: Change uid type from `int` to `string`

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -72,7 +72,7 @@ class DataHandler implements LoggerAwareInterface
      *
      * @return void
      */
-    public function processDatamap_postProcessFieldArray(string $status, string $table, int $id, array &$fieldArray): void
+    public function processDatamap_postProcessFieldArray(string $status, string $table, string $id, array &$fieldArray): void
     {
         if ($status == 'new') {
             switch ($table) {
@@ -204,7 +204,7 @@ class DataHandler implements LoggerAwareInterface
      *
      * @return void
      */
-    public function processDatamap_afterDatabaseOperations(string $status, string $table, int $id, array &$fieldArray): void
+    public function processDatamap_afterDatabaseOperations(string $status, string $table, string $id, array &$fieldArray): void
     {
         if ($status == 'update') {
             switch ($table) {

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -151,7 +151,7 @@ class DataHandler implements LoggerAwareInterface
                             ->select($table . '.is_listed AS is_listed')
                             ->from($table)
                             ->where(
-                                $queryBuilder->expr()->eq($table . '.uid', intval($id)),
+                                $queryBuilder->expr()->eq($table . '.uid', (int) $id),
                                 Helper::whereExpression($table)
                             )
                             ->setMaxResults(1)
@@ -176,7 +176,7 @@ class DataHandler implements LoggerAwareInterface
                             ->select($table . '.index_autocomplete AS index_autocomplete')
                             ->from($table)
                             ->where(
-                                $queryBuilder->expr()->eq($table . '.uid', intval($id)),
+                                $queryBuilder->expr()->eq($table . '.uid', (int) $id),
                                 Helper::whereExpression($table)
                             )
                             ->setMaxResults(1)
@@ -238,7 +238,7 @@ class DataHandler implements LoggerAwareInterface
                             ->where(
                                 $queryBuilder->expr()->eq(
                                     'tx_dlf_documents_join.uid',
-                                    intval($id)
+                                    (int) $id
                                 )
                             )
                             ->setMaxResults(1)
@@ -251,19 +251,19 @@ class DataHandler implements LoggerAwareInterface
                                 if ($solr->ready) {
                                     // Delete Solr document.
                                     $updateQuery = $solr->service->createUpdate();
-                                    $updateQuery->addDeleteQuery('uid:' . intval($id));
+                                    $updateQuery->addDeleteQuery('uid:' . (int) $id);
                                     $updateQuery->addCommit();
                                     $solr->service->update($updateQuery);
                                 }
                             } else {
                                 // Reindex document.
-                                $document = $this->getDocumentRepository()->findByUid(intval($id));
+                                $document = $this->getDocumentRepository()->findByUid((int) $id);
                                 $doc = AbstractDocument::getInstance($document->getLocation(), ['storagePid' => $document->getPid()], true);
                                 if ($document !== null && $doc !== null) {
                                     $document->setCurrentDocument($doc);
                                     Indexer::add($document, $this->getDocumentRepository());
                                 } else {
-                                    $this->logger->error('Failed to re-index document with UID ' . intval($id));
+                                    $this->logger->error('Failed to re-index document with UID ' . (string) $id);
                                 }
                             }
                         }
@@ -315,7 +315,7 @@ class DataHandler implements LoggerAwareInterface
                 ->where(
                     $queryBuilder->expr()->eq(
                         'tx_dlf_documents_join.uid',
-                        intval($id)
+                        (int) $id
                     )
                 )
                 ->setMaxResults(1)
@@ -330,7 +330,7 @@ class DataHandler implements LoggerAwareInterface
                         if ($solr->ready) {
                             // Delete Solr document.
                             $updateQuery = $solr->service->createUpdate();
-                            $updateQuery->addDeleteQuery('uid:' . intval($id));
+                            $updateQuery->addDeleteQuery('uid:' . (int) $id);
                             $updateQuery->addCommit();
                             $solr->service->update($updateQuery);
                             if ($command == 'delete') {
@@ -339,13 +339,13 @@ class DataHandler implements LoggerAwareInterface
                         }
                     case 'undelete':
                         // Reindex document.
-                        $document = $this->getDocumentRepository()->findByUid(intval($id));
+                        $document = $this->getDocumentRepository()->findByUid((int) $id);
                         $doc = AbstractDocument::getInstance($document->getLocation(), ['storagePid' => $document->getPid()], true);
                         if ($document !== null && $doc !== null) {
                             $document->setCurrentDocument($doc);
                             Indexer::add($document, $this->getDocumentRepository());
                         } else {
-                            $this->logger->error('Failed to re-index document with UID ' . intval($id));
+                            $this->logger->error('Failed to re-index document with UID ' . (string) $id);
                         }
                         break;
                 }
@@ -371,7 +371,7 @@ class DataHandler implements LoggerAwareInterface
                         'tx_dlf_solrcores.index_name AS core'
                     )
                     ->from('tx_dlf_solrcores')
-                    ->where($queryBuilder->expr()->eq('tx_dlf_solrcores.uid', intval($id)))
+                    ->where($queryBuilder->expr()->eq('tx_dlf_solrcores.uid', (int) $id))
                     ->setMaxResults(1)
                     ->execute();
 

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -67,12 +67,12 @@ class DataHandler implements LoggerAwareInterface
      *
      * @param string $status 'new' or 'update'
      * @param string $table The destination table
-     * @param int $id The uid of the record
+     * @param int|string $id The uid of the record
      * @param array &$fieldArray Array of field values
      *
      * @return void
      */
-    public function processDatamap_postProcessFieldArray(string $status, string $table, string $id, array &$fieldArray): void
+    public function processDatamap_postProcessFieldArray(string $status, string $table, $id, array &$fieldArray): void // TODO: Add type-hinting for $id when dropping support for PHP 7.
     {
         if ($status == 'new') {
             switch ($table) {
@@ -199,12 +199,12 @@ class DataHandler implements LoggerAwareInterface
      *
      * @param string $status 'new' or 'update'
      * @param string $table The destination table
-     * @param int $id The uid of the record
+     * @param int|string $id The uid of the record
      * @param array &$fieldArray Array of field values
      *
      * @return void
      */
-    public function processDatamap_afterDatabaseOperations(string $status, string $table, string $id, array &$fieldArray): void
+    public function processDatamap_afterDatabaseOperations(string $status, string $table, $id, array &$fieldArray): void // TODO: Add type-hinting for $id when dropping support for PHP 7.
     {
         if ($status == 'update') {
             switch ($table) {
@@ -251,19 +251,19 @@ class DataHandler implements LoggerAwareInterface
                                 if ($solr->ready) {
                                     // Delete Solr document.
                                     $updateQuery = $solr->service->createUpdate();
-                                    $updateQuery->addDeleteQuery('uid:' . $id);
+                                    $updateQuery->addDeleteQuery('uid:' . intval($id));
                                     $updateQuery->addCommit();
                                     $solr->service->update($updateQuery);
                                 }
                             } else {
                                 // Reindex document.
-                                $document = $this->getDocumentRepository()->findByUid($id);
+                                $document = $this->getDocumentRepository()->findByUid(intval($id));
                                 $doc = AbstractDocument::getInstance($document->getLocation(), ['storagePid' => $document->getPid()], true);
                                 if ($document !== null && $doc !== null) {
                                     $document->setCurrentDocument($doc);
                                     Indexer::add($document, $this->getDocumentRepository());
                                 } else {
-                                    $this->logger->error('Failed to re-index document with UID ' . $id);
+                                    $this->logger->error('Failed to re-index document with UID ' . intval($id));
                                 }
                             }
                         }
@@ -280,11 +280,11 @@ class DataHandler implements LoggerAwareInterface
      *
      * @param string $command 'move', 'copy', 'localize', 'inlineLocalizeSynchronize', 'delete' or 'undelete'
      * @param string $table The destination table
-     * @param int $id The uid of the record
+     * @param int|string $id The uid of the record
      *
      * @return void
      */
-    public function processCmdmap_postProcess(string $command, string $table, int $id): void
+    public function processCmdmap_postProcess(string $command, string $table, $id): void // TODO: Add type-hinting for $id when dropping support for PHP 7.
     {
         if (
             in_array($command, ['move', 'delete', 'undelete'])
@@ -330,7 +330,7 @@ class DataHandler implements LoggerAwareInterface
                         if ($solr->ready) {
                             // Delete Solr document.
                             $updateQuery = $solr->service->createUpdate();
-                            $updateQuery->addDeleteQuery('uid:' . $id);
+                            $updateQuery->addDeleteQuery('uid:' . intval($id));
                             $updateQuery->addCommit();
                             $solr->service->update($updateQuery);
                             if ($command == 'delete') {
@@ -339,13 +339,13 @@ class DataHandler implements LoggerAwareInterface
                         }
                     case 'undelete':
                         // Reindex document.
-                        $document = $this->getDocumentRepository()->findByUid($id);
+                        $document = $this->getDocumentRepository()->findByUid(intval($id));
                         $doc = AbstractDocument::getInstance($document->getLocation(), ['storagePid' => $document->getPid()], true);
                         if ($document !== null && $doc !== null) {
                             $document->setCurrentDocument($doc);
                             Indexer::add($document, $this->getDocumentRepository());
                         } else {
-                            $this->logger->error('Failed to re-index document with UID ' . $id);
+                            $this->logger->error('Failed to re-index document with UID ' . intval($id));
                         }
                         break;
                 }


### PR DESCRIPTION
This should fix #1078. 

For `processDatamap_postProcessFieldArray()` this is save because both times `id` is used, it gets cast to int `intval($id))`

For `processDatamap_afterDatabaseOperations()` this should also be save. I believe the uid will always be an int when dealing with solr and indexed documents.

For `processCmdmap_postProcess()` it should be the same as for the last function. Although I'm not sure. 