### PR TITLE
[BUGFIX] Use paginator in 'SearchController.php' and 'CollectionController.php'

### DIFF
--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -201,10 +201,8 @@ class CollectionController extends AbstractController
 
         // get all documents of given collection
         $solrResults = null;
-        // $numResults = 0;
         if (is_array($searchParams) && !empty($searchParams)) {
             $solrResults = $this->documentRepository->findSolrByCollection($collection, $this->settings, $searchParams, $listedMetadata);
-            // $numResults = $solrResults->getNumFound();
 
             $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'];
             if (empty($itemsPerPage)) {
@@ -219,7 +217,6 @@ class CollectionController extends AbstractController
 
         $this->view->assign('viewData', $this->viewData);
         $this->view->assign('documents', $solrResults);
-        // $this->view->assign('numResults', $numResults);
         $this->view->assign('collection', $collection);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $searchParams);

--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -201,11 +201,10 @@ class CollectionController extends AbstractController
 
         // get all documents of given collection
         $solrResults = null;
-        $numResults = 0;
+        // $numResults = 0;
         if (is_array($searchParams) && !empty($searchParams)) {
-            // @phpstan-ignore-next-line
             $solrResults = $this->documentRepository->findSolrByCollection($collection, $this->settings, $searchParams, $listedMetadata);
-            $numResults = $solrResults->getNumFound();
+            // $numResults = $solrResults->getNumFound();
 
             $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'];
             if (empty($itemsPerPage)) {
@@ -220,6 +219,7 @@ class CollectionController extends AbstractController
 
         $this->view->assign('viewData', $this->viewData);
         $this->view->assign('documents', $solrResults);
+        // $this->view->assign('numResults', $numResults);
         $this->view->assign('collection', $collection);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $searchParams);

--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -11,8 +11,10 @@
 
 namespace Kitodo\Dlf\Controller;
 
+use Kitodo\Dlf\Common\SolrPaginator;
 use Kitodo\Dlf\Common\Solr\Solr;
 use Kitodo\Dlf\Domain\Model\Collection;
+use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use Kitodo\Dlf\Domain\Repository\CollectionRepository;
@@ -198,7 +200,23 @@ class CollectionController extends AbstractController
         $sortableMetadata = $this->metadataRepository->findByIsSortable(true);
 
         // get all documents of given collection
-        $solrResults = $this->documentRepository->findSolrByCollection($collection, $this->settings, $searchParams, $listedMetadata);
+        $solrResults = null;
+        $numResults = 0;
+        if (is_array($searchParams) && !empty($searchParams)) {
+            // @phpstan-ignore-next-line
+            $solrResults = $this->documentRepository->findSolrByCollection($collection, $this->settings, $searchParams, $listedMetadata);
+            $numResults = $solrResults->getNumFound();
+
+            $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'];
+            if (empty($itemsPerPage)) {
+                $itemsPerPage = 25;
+            }
+            $solrPaginator = new SolrPaginator($solrResults, $currentPage, $itemsPerPage);
+            $simplePagination = new SimplePagination($solrPaginator);
+
+            $pagination = $this->buildSimplePagination($simplePagination, $solrPaginator);
+            $this->view->assignMultiple([ 'pagination' => $pagination, 'paginator' => $solrPaginator ]);
+        }
 
         $this->view->assign('viewData', $this->viewData);
         $this->view->assign('documents', $solrResults);

--- a/Classes/Controller/ListViewController.php
+++ b/Classes/Controller/ListViewController.php
@@ -122,7 +122,6 @@ class ListViewController extends AbstractController
         $this->view->assign('numResults', $numResults);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $this->searchParams);
-
         $this->view->assign('sortableMetadata', $sortableMetadata);
         $this->view->assign('listedMetadata', $listedMetadata);
     }

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -14,6 +14,7 @@ namespace Kitodo\Dlf\Controller;
 
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Indexer;
+use Kitodo\Dlf\Common\SolrPaginator;
 use Kitodo\Dlf\Common\Solr\Solr;
 use Kitodo\Dlf\Domain\Model\Collection;
 use Kitodo\Dlf\Domain\Repository\CollectionRepository;
@@ -21,6 +22,7 @@ use Kitodo\Dlf\Domain\Repository\MetadataRepository;
 use Solarium\Component\Result\FacetSet;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -164,8 +166,19 @@ class SearchController extends AbstractController
             $numResults = 0;
             // Do not execute the Solr search if used together with ListView plugin.
             if (!$listViewSearch) {
-                $solrResults = $this->documentRepository->findSolrByCollection(null, $this->settings, $this->searchParams, $listedMetadata);
+                // @phpstan-ignore-next-line
+                $solrResults = $this->documentRepository->findSolrByCollection($collection ? : null, $this->settings, $this->searchParams, $listedMetadata);
                 $numResults = $solrResults->getNumFound();
+
+                $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'];
+                if (empty($itemsPerPage)) {
+                    $itemsPerPage = 25;
+                }
+                $solrPaginator = new SolrPaginator($solrResults, $currentPage, $itemsPerPage);
+                $simplePagination = new SimplePagination($solrPaginator);
+
+                $pagination = $this->buildSimplePagination($simplePagination, $solrPaginator);
+                $this->view->assignMultiple([ 'pagination' => $pagination, 'paginator' => $solrPaginator ]);
             }
 
             $this->view->assign('documents', !empty($solrResults) ? $solrResults : []);

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -167,7 +167,7 @@ class SearchController extends AbstractController
             // Do not execute the Solr search if used together with ListView plugin.
             if (!$listViewSearch) {
                 // @phpstan-ignore-next-line
-                $solrResults = $this->documentRepository->findSolrByCollection($collection ? : null, $this->settings, $this->searchParams, $listedMetadata);
+                $solrResults = $this->documentRepository->findSolrByCollection(null, $this->settings, $this->searchParams, $listedMetadata);
                 $numResults = $solrResults->getNumFound();
 
                 $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'];

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -166,7 +166,6 @@ class SearchController extends AbstractController
             $numResults = 0;
             // Do not execute the Solr search if used together with ListView plugin.
             if (!$listViewSearch) {
-                // @phpstan-ignore-next-line
                 $solrResults = $this->documentRepository->findSolrByCollection(null, $this->settings, $this->searchParams, $listedMetadata);
                 $numResults = $solrResults->getNumFound();
 


### PR DESCRIPTION
This PR should fix my long standing issue with missing search results raised here https://github.com/kitodo/kitodo-presentation/pull/885#issuecomment-1443367080 and further discussed here #1029.

After a lot of digging, I found the root of the issue. But to be honest I'm not sure if my solution is the best. I just copied existing working code from https://github.com/kitodo/kitodo-presentation/blob/master/Classes/Controller/ListViewController.php#L104 and made it fit into the SearchController and the CollectionController, without understanding if it was missing for a reason. I assume that it was simply overlooked.

Now both ways to set up the search are working (https://github.com/kitodo/kitodo-presentation/issues/1029#issuecomment-1792648218) as well as the collections.

As you can see, both are working:
![grafik](https://github.com/kitodo/kitodo-presentation/assets/43964592/29562c98-638d-4a19-a275-735cde479bf6)
