### PR TITLE
[BUGFIX] Fix search middleware to use right method

### DIFF
--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -63,7 +63,7 @@ class SearchInDocument implements MiddlewareInterface
     {
         $response = $handler->handle($request);
         // Get input parameters and decrypt core name.
-        $parameters = $request->getParsedBody();
+        $parameters = $request->getQueryParams();
         // Return if not this middleware
         if (!isset($parameters['middleware']) || ($parameters['middleware'] != 'dlf/search-in-document')) {
             return $response;

--- a/Classes/Middleware/SearchSuggest.php
+++ b/Classes/Middleware/SearchSuggest.php
@@ -46,7 +46,7 @@ class SearchSuggest implements MiddlewareInterface
     {
         $response = $handler->handle($request);
         // Get input parameters and decrypt core name.
-        $parameters = $request->getParsedBody();
+        $parameters = $request->getQueryParams();
         // Return if not this middleware
         if (!isset($parameters['middleware']) || ($parameters['middleware'] != 'dlf/search-suggest')) {
             return $response;


### PR DESCRIPTION
We just need the query params as an associative array and not the parsed body here.