### PR TITLE
[BUGFIX] Fix call to `ExtensionUtility::registerModule`

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -13,7 +13,7 @@
 // Register backend module.
 if (\TYPO3_MODE === 'BE') {
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'Kitodo.Dlf',
+        'Dlf',
         'tools', // Main area
         'newTenantModule', // Name of the module
         'bottom', // Position of the module


### PR DESCRIPTION
Error:
`[NOTICE] request="0d637959f8436" component="TYPO3.CMS.deprecations": Calling method TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule with argument $extensionName containing the vendor name is deprecated and will stop working in TYPO3 11.0. - {"file":"/var/www/html/public/typo3/sysext/extbase/Classes/Utility/ExtensionUtility.php","line":217}`

Since TYPO3 10 `$extensionName` should be called only as 'Dlf'

Source: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html