### PR TITLE
[MAINTENANCE] Remove usage of deprecated `addQueryStringMethod`

### DIFF
--- a/Resources/Private/Partials/TableOfContents/Children.html
+++ b/Resources/Private/Partials/TableOfContents/Children.html
@@ -44,7 +44,6 @@
                 pageUid="{settings.targetPid}"
                 additionalParams="{f:if(condition:'{child.id}', then:'{\'tx_dlf[id]\':child.id, \'tx_dlf[page]\':child.page}', else: '{\'tx_dlf[page]\':child.page}')}"
                 addQueryString="1"
-                addQueryStringMethod="GET"
                 title="{f:if(condition:'{child.title}', then: '{child.title}', else: '{child.type}')}">
                     <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
             </f:link.action>

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -26,14 +26,14 @@
             <f:if condition="{viewData.requestData.double}">
                 <f:then>
                     <div class="tx-dlf-navigation-single">
-                        <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[double]':'0'}">
+                        <f:link.action addQueryString="1" additionalParams="{'tx_dlf[double]':'0'}">
                             <f:translate key="doublePageOff"/>
                         </f:link.action>
                     </div>
                     <div class="tx-dlf-navigation-double+">
                         <f:if condition="{viewData.requestData.double} && ({viewData.requestData.page} < {numPages})">
                             <f:then>
-                                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}'}">
+                                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}'}">
                                     <f:translate key="doublePage+1"/>
                                 </f:link.action>
                             </f:then>
@@ -47,7 +47,7 @@
                 </f:then>
                 <f:else>
                     <div class="tx-dlf-navigation-double">
-                        <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[double]':'1'}">
+                        <f:link.action addQueryString="1" additionalParams="{'tx_dlf[double]':'1'}">
                             <f:translate key="doublePageOn"/>
                         </f:link.action>
                     </div>
@@ -69,7 +69,7 @@
     <div class="tx-dlf-navigation-first">
         <f:if condition="{viewData.requestData.page} > 1">
             <f:then>
-                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'1'}">
+                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'1'}">
                     <f:translate key="firstPage"/>
                 </f:link.action>
             </f:then>
@@ -86,7 +86,7 @@
     <div class="tx-dlf-navigation-back">
         <f:if condition="{viewData.requestData.page} > {pageSteps}">
             <f:then>
-                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}'}">
+                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}'}">
                     <f:translate key="backXPages" arguments="{0: '{pageSteps}'}"/>
                 </f:link.action>
             </f:then>
@@ -103,7 +103,7 @@
     <div class="tx-dlf-navigation-prev">
         <f:if condition="{viewData.requestData.page} > {viewData.requestData.double + 1}">
             <f:then>
-                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}'}">
+                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}'}">
                     <f:translate key="prevPage"/>
                 </f:link.action>
             </f:then>
@@ -162,7 +162,7 @@
         <div class="tx-dlf-navigation-fwd">
             <f:if condition="{viewData.requestData.page} <= {numPages - pageSteps}">
                 <f:then>
-                    <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}'}">
+                    <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}'}">
                         <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
                     </f:link.action>
                 </f:then>
@@ -179,7 +179,7 @@
     <div class="tx-dlf-navigation-last">
         <f:if condition="{viewData.requestData.page} < {numPages - viewData.requestData.double}">
             <f:then>
-                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}'}">
+                <f:link.action addQueryString="1" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}'}">
                     <f:translate key="lastPage"/>
                 </f:link.action>
             </f:then>


### PR DESCRIPTION
Error:
`[NOTICE] request="30fdef5ee8214" component="TYPO3.CMS.deprecations": Core: Error handler (FE): TYPO3 Deprecation Notice: Using the argument "addQueryStringMethod" in <f:link.action> ViewHelper has no effect anymore and will be removed in TYPO3 v12. Remove the argument in your fluid template, as it will result in a fatal error. in /var/www/html/public/typo3/sysext/fluid/Classes/ViewHelpers/Link/ActionViewHelper.php line 80 `

In TYPO3 10 is usage of this argument with certain parameters deprecated and in TYPO3 11 the argument itself is marked as deprecated.

Sources:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-88755-RemovePOSTOptionFromTypolinkaddQueryStringmethod.html
https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/Changelog/11.0/Breaking-93041-RemoveTypoScriptOptionAddQueryStringmethod.html