### PR TITLE
[BUGFIX] Fix wrong caching backend and default lifetime

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -86,20 +86,20 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr'] = [];
 }
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['backend'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\SimpleFileBackend';
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\FileBackend';
 }
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['options']['defaultLifeTime'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['options']['defaultLifeTime'] = 87600; // 87600 seconds = 1 day
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['options']['defaultLifeTime'] = 86400; // 86400 seconds = 1 day
 }
 // Use Caching Framework for XML file caching
 if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc'] = [];
 }
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['backend'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\SimpleFileBackend';
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\FileBackend';
 }
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['options']['defaultLifeTime'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['options']['defaultLifeTime'] = 87600; // 87600 seconds = 1 day
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['options']['defaultLifeTime'] = 86400; // 86400 seconds = 1 day
 }
 // Add new renderType for TCA fields.
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][] = [


### PR DESCRIPTION
This PR fixes caching related issues, that arise due to the wrong cache backend for the caches `tx_dlf_solr` and `tx_dlf_doc`. For example, that resultsets dont get updated even if the default lifetime of the cache has passed and new documents have been indexed.

## Explanation:

The `SimpleFileBackend` does not care about expiry times:

> A caching backend which stores cache entries in files, but does not support or care about expiry times and tags. 

(see: https://api.typo3.org/10.4/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_cache_1_1_backend_1_1_simple_file_backend.html)

This leaves once cached data permanently on disk if it is not manually removed by using "clear all caches" in the backend or a scheduler extension. The currently configured default lifetime does not get applied and has thus no function.

This PR uses the slightly more powerful `FileBackend` instead (see: https://api.typo3.org/10.4/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_cache_1_1_backend_1_1_file_backend.html), which considers the default lifetime and updates caches accordingly (which can be tracked via the modification date of cache files on disk -> `[...]/cache/data/tx_dlf_solr`). This PR also fixes the default lifetime to an actual day (86400 seconds = 1 day).