### PR TITLE
[BUGFIX] Query children metadata in batches to avoid OutOfMemoryException

### DIFF
--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -261,14 +261,6 @@ The collection plugin shows one collection, all collections or selected collecti
    :Default:
 
  - :Property:
-       childrenRows
-   :Data Type:
-       :ref:`t3tsref:data-type-integer`
-   :Default:
-   :Description:
-       It defines for how many children documents metadata should be fetched
-
- - :Property:
        show_userdefined
    :Data Type:
        :ref:`t3tsref:data-type-integer`
@@ -726,14 +718,6 @@ Search
        :ref:`t3tsref:data-type-boolean`
    :Default:
        0
-
- - :Property:
-       childrenRows
-   :Data Type:
-       :ref:`t3tsref:data-type-integer`
-   :Default:
-   :Description:
-       It defines for how many children documents metadata should be fetched
 
  - :Property:
        solrcore


### PR DESCRIPTION
Related to https://github.com/kitodo/kitodo-presentation/pull/967/files which was reverted in https://github.com/kitodo/kitodo-presentation/pull/969. 

Batching used to avoid 500 Server Error (caused by out of memory exception).