### PR TITLE
[BUGFIX] Fix scrolling of text in #tx-dlf-fulltextselection to the text under the cursor

### DIFF
--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -336,6 +336,16 @@ dlfViewerFullTextControl.prototype.addActiveBehaviourForSwitchOff = function() {
 };
 
 /** 
+ * Recalculate position of text lines if full text container was resized
+ */
+dlfViewerFullTextControl.prototype.onResize = function() {
+    if (this.element != undefined && this.element.css('width') != this.lastHeight) {
+        this.lastHeight = this.element.css('width');
+        this.calculatePositions();
+    }
+};
+
+/**
  * Calculate positions of text lines for scrolling
  */
 dlfViewerFullTextControl.prototype.calculatePositions = function() {
@@ -437,6 +447,7 @@ dlfViewerFullTextControl.prototype.addHighlightEffect = function(textlineFeature
 
         if (targetElem.length > 0 && !targetElem.hasClass('highlight')) {
             targetElem.addClass('highlight');
+            this.onResize();
             setTimeout(this.scrollToText, 1000, targetElem, this.fullTextScrollElement, this.positions);
             hoverSourceTextline_.addFeature(textlineFeature);
         }

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -93,7 +93,7 @@ var dlfViewerFullTextControl = function(map) {
             'fulltext-on':'Activate Fulltext',
             'fulltext-off':'Deactivate Fulltext',
             'activate-full-text-initially':'0',
-            'full-text-scroll-element':'html, body'};
+            'full-text-scroll-element':'#tx-dlf-fulltextselection'};
 
     /**
      * @private

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -111,7 +111,13 @@ var dlfViewerFullTextControl = function(map) {
      * @type {string}
      * @private
      */
-    this.fullTextScrollElement = this.dic['full-text-scroll-element'];
+    let regex = /[^A-Za-z0-9\.\-\#\s]/g;
+    let fullTextScrollElementUnChecked = this.dic['full-text-scroll-element'];
+    if (regex.fullTextScrollElementUnChecked) {
+        this.fullTextScrollElement = "";
+    } else {
+        this.fullTextScrollElement = fullTextScrollElementUnChecked;
+    }
 
     /**
      * @type {Object}

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -236,7 +236,7 @@ var dlfViewerFullTextControl = function(map) {
         this)
     };
 
-    $('#tx-dlf-fulltextselection').text(this.dic['fulltext-loading']);
+    $(this.fullTextScrollElement).text(this.dic['fulltext-loading']);
 
     this.changeActiveBehaviour();
 };
@@ -351,7 +351,7 @@ dlfViewerFullTextControl.prototype.onResize = function() {
 dlfViewerFullTextControl.prototype.calculatePositions = function() {
     this.positions.length = 0;
     
-    let texts = $('#tx-dlf-fulltextselection').children('span.textline');
+    let texts = $(this.fullTextScrollElement).children('span.textline');
     let offset = $('#' + texts[0].id).position().top;
     
     for(let text of texts) {
@@ -530,8 +530,9 @@ dlfViewerFullTextControl.prototype.disableFulltextSelect = function() {
         .attr('title', this.dic['fulltext-on']);
     }
 
-    $('#tx-dlf-fulltextselection').removeClass(className);
-    $('#tx-dlf-fulltextselection').hide();
+    $(this.fullTextScrollElement).removeClass(className);
+    $(this.fullTextScrollElement).hide();
+
     $('body').removeClass(className);
 
 };
@@ -562,8 +563,8 @@ dlfViewerFullTextControl.prototype.enableFulltextSelect = function() {
         .attr('title', this.dic['fulltext-off']);
     }
 
-    $('#tx-dlf-fulltextselection').addClass(className);
-    $('#tx-dlf-fulltextselection').show();
+    $(this.fullTextScrollElement).addClass(className);
+    $(this.fullTextScrollElement).show();
     $('body').addClass(className);
 };
 
@@ -596,7 +597,13 @@ dlfViewerFullTextControl.prototype.showFulltext = function(features) {
         return;
     }
 
-    var target = document.getElementById('tx-dlf-fulltextselection');
+    // in getElementById no '#' is necessary / allowed at the beginning
+    // of the string. Therefor remove '#' if present
+    let fullTextScrollElementId = this.fullTextScrollElement;
+    if (fullTextScrollElementId.substr(0,1) === '#') {
+        fullTextScrollElementId = fullTextScrollElementId.substr(1);
+    }
+    var target = document.getElementById(fullTextScrollElementId);
     if (target !== null) {
         target.innerHTML = "";
         for (var feature of features) {

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -242,7 +242,7 @@ var dlfViewerFullTextControl = function(map) {
         this)
     };
 
-    $(this.fullTextScrollElement).text(this.dic['fulltext-loading']);
+    $('html').find(this.fullTextScrollElement).text(this.dic['fulltext-loading']);
 
     this.changeActiveBehaviour();
 };

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -358,11 +358,14 @@ dlfViewerFullTextControl.prototype.calculatePositions = function() {
     this.positions.length = 0;
     
     let texts = $('html').find(this.fullTextScrollElement).children('span.textline');
+    // check if fulltext exists for this page
+    if (texts.length > 0) {
     let offset = $('#' + texts[0].id).position().top;
     
     for(let text of texts) {
         let pos = $('#' + text.id).position().top;
         this.positions[text.id] = pos - offset;
+    }
     }
 };
 

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -85,7 +85,7 @@ var dlfViewerFullTextControl = function(map) {
      * @type {Object}
      * @private
      */
-    this.dic = $('#tx-dlf-tools-fulltext').length > 0 && $('#tx-dlf-tools-fulltext').attr('data-dic') ?
+    this.dic = $('#tx-dlf-tools-fulltext').length > 0 && $('#tx-dlf-tools-fulltext').data('dic') ?
         dlfUtils.parseDataDic($('#tx-dlf-tools-fulltext')) :
         {
             'fulltext':'Fulltext',
@@ -357,7 +357,7 @@ dlfViewerFullTextControl.prototype.onResize = function() {
 dlfViewerFullTextControl.prototype.calculatePositions = function() {
     this.positions.length = 0;
     
-    let texts = $(this.fullTextScrollElement).children('span.textline');
+    let texts = $('html').find(this.fullTextScrollElement).children('span.textline');
     let offset = $('#' + texts[0].id).position().top;
     
     for(let text of texts) {
@@ -536,8 +536,8 @@ dlfViewerFullTextControl.prototype.disableFulltextSelect = function() {
         .attr('title', this.dic['fulltext-on']);
     }
 
-    $(this.fullTextScrollElement).removeClass(className);
-    $(this.fullTextScrollElement).hide();
+    $('html').find(this.fullTextScrollElement).removeClass(className);
+    $('html').find(this.fullTextScrollElement).hide();
 
     $('body').removeClass(className);
 
@@ -569,8 +569,8 @@ dlfViewerFullTextControl.prototype.enableFulltextSelect = function() {
         .attr('title', this.dic['fulltext-off']);
     }
 
-    $(this.fullTextScrollElement).addClass(className);
-    $(this.fullTextScrollElement).show();
+    $('html').find(this.fullTextScrollElement).addClass(className);
+    $('html').find(this.fullTextScrollElement).show();
     $('body').addClass(className);
 };
 

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -111,7 +111,7 @@ var dlfViewerFullTextControl = function(map) {
      * @type {string}
      * @private
      */
-    let regex = /[^A-Za-z0-9\.\-\#\s]/g;
+    let regex = /[^A-Za-z0-9\.\-\#\s_]/g;
     let fullTextScrollElementUnChecked = this.dic['full-text-scroll-element'];
     if (regex.fullTextScrollElementUnChecked) {
         this.fullTextScrollElement = "";

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -162,13 +162,13 @@ var dlfViewerFullTextControl = function(map) {
      * @private
      */
     this.lastRenderedFeatures_ = undefined;
-    
+
     /**
      * @type {Array}
      * @private
      */
      this.positions = {};
-     
+
 
     /**
      * @type {dlfFulltextSegments}
@@ -341,7 +341,7 @@ dlfViewerFullTextControl.prototype.addActiveBehaviourForSwitchOff = function() {
     }
 };
 
-/** 
+/**
  * Recalculate position of text lines if full text container was resized
  */
 dlfViewerFullTextControl.prototype.onResize = function() {
@@ -356,16 +356,16 @@ dlfViewerFullTextControl.prototype.onResize = function() {
  */
 dlfViewerFullTextControl.prototype.calculatePositions = function() {
     this.positions.length = 0;
-    
+
     let texts = $('html').find(this.fullTextScrollElement).children('span.textline');
     // check if fulltext exists for this page
     if (texts.length > 0) {
-    let offset = $('#' + texts[0].id).position().top;
-    
-    for(let text of texts) {
-        let pos = $('#' + text.id).position().top;
-        this.positions[text.id] = pos - offset;
-    }
+        let offset = $('#' + texts[0].id).position().top;
+
+        for(let text of texts) {
+            let pos = $('#' + text.id).position().top;
+            this.positions[text.id] = pos - offset;
+        }
     }
 };
 

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -556,7 +556,7 @@ dlfUtils.isFulltextDescriptor = function (obj) {
  * @return {Object}
  */
 dlfUtils.parseDataDic = function (element) {
-    var dataDicString = $(element).attr('data-dic') || '',
+    var dataDicString = $('html').find(element).data('dic') || '',
         dataDicRecords = dataDicString.split(';'),
         dataDic = {};
 


### PR DESCRIPTION
Fixed the scoll function for fulltext. When the mouse is positioned on a text passage, the text in the configured div scrolls to the respective fulltext line.

- Adjust the default setting of `settings.full-text-scroll-element` to `#tx-dlf-fulltextselection`, instead of `html, body`
- Calculating the scroll positions copied from `ddb_kitodo_zeitungsportal`
- `full-text-scroll-element` now consistently defines the ID of the scroll container. The previously used fixed value `#tx-dlf-fulltextselection` is now only available as a default value.

![image](https://github.com/kitodo/kitodo-presentation/assets/4037984/780f3703-a9f3-4404-ac24-146fd50fe9f2)