### PR TITLE
[BUGFIX] Fix displaying pages for images in grid view

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -329,6 +329,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
      * @param PaginatorInterface $paginator
      * @return array
      */
+    //TODO: clean this function
     protected function buildSimplePagination(PaginationInterface $pagination, PaginatorInterface $paginator): array
     {
         $firstPage = $pagination->getFirstPageNumber();
@@ -406,8 +407,9 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             array_push($pagesSect, ['label' => '...', 'startRecordNumber' => '...']);
         };
 
-        $nextPageNumber = $pages[$currentPageNumber + 1]['startRecordNumber'];
-        $previousPageNumber = $pages[$currentPageNumber - 1]['startRecordNumber'];
+        // Safely get the next and previous page numbers
+        $nextPageNumber = isset($pages[$currentPageNumber + 1]['startRecordNumber']) ? $pages[$currentPageNumber + 1]['startRecordNumber'] : null;
+        $previousPageNumber = isset($pages[$currentPageNumber - 1]['startRecordNumber']) ? $pages[$currentPageNumber - 1]['startRecordNumber'] : null;
 
         // 'startRecordNumber' is not required in GridView, only the variant for each loop is required
         // 'endRecordNumber' is not required in both views


### PR DESCRIPTION
Previously instead of page numbers were displayed ' - '.
<img width="584" alt="page" src="https://github.com/kitodo/kitodo-presentation/assets/9614459/1d06b5ae-deee-4f7f-a04c-70de2c5aea99">
