### PR TITLE
[BUGFIX] Add fallback to location if there is no record id in METS file

### DIFF
--- a/.github/phpstan.neon
+++ b/.github/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findByIsSortable\(\)\.#'
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findOneByFeUserId\(\)\.#'
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findOneByIndexName\(\)\.#'
+            - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findOneByLocation\(\)\.#'
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findOneByPid\(\)\.#'
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findOneByRecordId\(\)\.#'
             - '#Call to an undefined method Kitodo\\Dlf\\Domain\\Repository\\[a-zA-Z]+Repository::findOneByRoot\(\)\.#'

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -168,19 +168,7 @@ class IndexCommand extends BaseCommand
         } else if (GeneralUtility::isValidUrl($input->getOption('doc'))) {
             $doc = AbstractDocument::getInstance($input->getOption('doc'), ['storagePid' => $this->storagePid], true);
 
-            if ($doc->recordId) {
-                $document = $this->documentRepository->findOneByRecordId($doc->recordId);
-            }
-
-            if ($document === null) {
-                // create new Document object
-                $document = GeneralUtility::makeInstance(Document::class);
-            }
-
-            // now there must exist a document object
-            if ($document) {
-                $document->setLocation($input->getOption('doc'));
-            }
+            $document = $this->getDocumentFromUrl($doc, $input->getOption('doc'));
         }
 
         if ($doc === null) {
@@ -208,4 +196,36 @@ class IndexCommand extends BaseCommand
         return 0;
     }
 
+    /**
+     * Get document from given URL. Find it in database, if not found create the new one.
+     *
+     * @access private
+     *
+     * @param AbstractDocument $doc
+     * @param string $url
+     *
+     * @return Document
+     */
+    private function getDocumentFromUrl($doc, string $url): Document
+    {
+        $document = null;
+
+        if ($doc->recordId) {
+            $document = $this->documentRepository->findOneByRecordId($doc->recordId);
+        } else {
+            $document = $this->documentRepository->findOneByLocation($url);
+        }
+
+        if ($document === null) {
+            // create new Document object
+            $document = GeneralUtility::makeInstance(Document::class);
+        }
+
+        // now there must exist a document object
+        if ($document) {
+            $document->setLocation($url);
+        }
+
+        return $document;
+    }
 }


### PR DESCRIPTION
Sometimes METS doesn't contain recordIdentifier and then new object is created for already existing documents