### PR TITLE
[BUGFIX] Display paginated results only if there are some results

### DIFF
--- a/Resources/Private/Templates/ListView/Main.html
+++ b/Resources/Private/Templates/ListView/Main.html
@@ -26,9 +26,11 @@
 
         <f:variable name="action" value="main" />
         <f:variable name="controller" value="ListView" />
-        <f:render partial="ListView/SortingForm" arguments="{_all}" />
 
-        <f:render partial="ListView/Results" arguments="{_all}" />
+        <f:if condition="{numResults} > 0">
+            <f:render partial="ListView/SortingForm" arguments="{_all}" />
+            <f:render partial="ListView/Results" arguments="{_all}" />
+        </f:if>
 
     </div>
 

--- a/Resources/Private/Templates/Search/Main.html
+++ b/Resources/Private/Templates/Search/Main.html
@@ -118,8 +118,10 @@
         <f:render partial="ListView/SearchHits" arguments="{_all}" />
         <f:variable name="action" value="search" />
         <f:variable name="controller" value="Search" />
-        <f:render partial="ListView/SortingForm" arguments="{_all}" />
-        <f:render partial="ListView/Results" arguments="{_all}" />
+        <f:if condition="{numResults} > 0">
+            <f:render partial="ListView/SortingForm" arguments="{_all}" />
+            <f:render partial="ListView/Results" arguments="{_all}" />
+        </f:if>
     </div>
 
 </f:if>


### PR DESCRIPTION
Fix for `Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1476107295: PHP Warning: A non-numeric value encountered in /var/www/html/vendor/typo3fluid/fluid/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php line 77 `

Error is caused by `pagination` being null in expression `<f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />`. It is `null` when `numResults` is 0. This line can be found in two files:
```
ListView/SortingForm
ListView/Results
```
The are used also by some other projects which also need the same fix like here.