### PR TITLE
[FEATURE] Implement document validation before document is saved to database

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -22,6 +22,7 @@ use Kitodo\Dlf\Domain\Repository\StructureRepository;
 use Kitodo\Dlf\Domain\Model\Collection;
 use Kitodo\Dlf\Domain\Model\Document;
 use Kitodo\Dlf\Domain\Model\Library;
+use Kitodo\Dlf\Validation\DocumentValidator;
 use Symfony\Component\Console\Command\Command;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -216,71 +217,70 @@ class BaseCommand extends Command
         $doc->cPid = $this->storagePid;
 
         $metadata = $doc->getToplevelMetadata($this->storagePid);
+        $validator = new DocumentValidator($metadata, explode(',', $this->extConf['requiredMetadataFields']));
 
-        // set title data
-        $document->setTitle($metadata['title'][0] ? : '');
-        $document->setTitleSorting($metadata['title_sorting'][0] ? : '');
-        $document->setPlace(implode('; ', $metadata['place']));
-        $document->setYear(implode('; ', $metadata['year']));
+        if ($validator->hasAllMandatoryMetadataFields()) {
+            // set title data
+            $document->setTitle($metadata['title'][0] ? : '');
+            $document->setTitleSorting($metadata['title_sorting'][0] ? : '');
+            $document->setPlace(implode('; ', $metadata['place']));
+            $document->setYear(implode('; ', $metadata['year']));
+            $document->setAuthor($this->getAuthors($metadata['author']));
+            $document->setThumbnail($doc->thumbnail ? : '');
+            $document->setMetsLabel($metadata['mets_label'][0] ? : '');
+            $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ? : '');
 
-        // Remove appended "valueURI" from authors' names for storing in database.
-        foreach ($metadata['author'] as $i => $author) {
-            $splitName = explode(pack('C', 31), $author);
-            $metadata['author'][$i] = $splitName[0];
+            $structure = $this->structureRepository->findOneByIndexName($metadata['type'][0]);
+            $document->setStructure($structure);
+
+            if (is_array($metadata['collection'])) {
+                $this->addCollections($document, $metadata['collection']);
+            }
+
+            // set identifiers
+            $document->setProdId($metadata['prod_id'][0] ? : '');
+            $document->setOpacId($metadata['opac_id'][0] ? : '');
+            $document->setUnionId($metadata['union_id'][0] ? : '');
+
+            $document->setRecordId($metadata['record_id'][0]);
+            $document->setUrn($metadata['urn'][0] ? : '');
+            $document->setPurl($metadata['purl'][0] ? : '');
+            $document->setDocumentFormat($metadata['document_format'][0] ? : '');
+
+            // set access
+            $document->setLicense($metadata['license'][0] ? : '');
+            $document->setTerms($metadata['terms'][0] ? : '');
+            $document->setRestrictions($metadata['restrictions'][0] ? : '');
+            $document->setOutOfPrint($metadata['out_of_print'][0] ? : '');
+            $document->setRightsInfo($metadata['rights_info'][0] ? : '');
+            $document->setStatus(0);
+
+            $this->setOwner($metadata['owner'][0]);
+            $document->setOwner($this->owner);
+
+            // set volume data
+            $document->setVolume($metadata['volume'][0] ? : '');
+            $document->setVolumeSorting($metadata['volume_sorting'][0] ? : $metadata['mets_order'][0] ? : '');
+
+            // Get UID of parent document.
+            if ($document->getDocumentFormat() === 'METS') {
+                $document->setPartof($this->getParentDocumentUidForSaving($document));
+            }
+
+            if ($document->getUid() === null) {
+                // new document
+                $this->documentRepository->add($document);
+            } else {
+                // update of existing document
+                $this->documentRepository->update($document);
+            }
+
+            $this->persistenceManager->persistAll();
+
+            return true;
         }
-        $document->setAuthor($this->getAuthors($metadata['author']));
-        $document->setThumbnail($doc->thumbnail ? : '');
-        $document->setMetsLabel($metadata['mets_label'][0] ? : '');
-        $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ? : '');
 
-        $structure = $this->structureRepository->findOneByIndexName($metadata['type'][0]);
-        $document->setStructure($structure);
-
-        if (is_array($metadata['collection'])) {
-            $this->addCollections($document, $metadata['collection']);
-        }
-
-        // set identifiers
-        $document->setProdId($metadata['prod_id'][0] ? : '');
-        $document->setOpacId($metadata['opac_id'][0] ? : '');
-        $document->setUnionId($metadata['union_id'][0] ? : '');
-
-        $document->setRecordId($metadata['record_id'][0] ? : ''); // (?) $doc->recordId
-        $document->setUrn($metadata['urn'][0] ? : '');
-        $document->setPurl($metadata['purl'][0] ? : '');
-        $document->setDocumentFormat($metadata['document_format'][0] ? : '');
-
-        // set access
-        $document->setLicense($metadata['license'][0] ? : '');
-        $document->setTerms($metadata['terms'][0] ? : '');
-        $document->setRestrictions($metadata['restrictions'][0] ? : '');
-        $document->setOutOfPrint($metadata['out_of_print'][0] ? : '');
-        $document->setRightsInfo($metadata['rights_info'][0] ? : '');
-        $document->setStatus(0);
-
-        $this->setOwner($metadata['owner'][0]);
-        $document->setOwner($this->owner);
-
-        // set volume data
-        $document->setVolume($metadata['volume'][0] ? : '');
-        $document->setVolumeSorting($metadata['volume_sorting'][0] ? : $metadata['mets_order'][0] ? : '');
-
-        // Get UID of parent document.
-        if ($document->getDocumentFormat() === 'METS') {
-            $document->setPartof($this->getParentDocumentUidForSaving($document));
-        }
-
-        if ($document->getUid() === null) {
-            // new document
-            $this->documentRepository->add($document);
-        } else {
-            // update of existing document
-            $this->documentRepository->update($document);
-        }
-
-        $this->persistenceManager->persistAll();
-
-        return true;
+        return false;
     }
 
     /**
@@ -371,6 +371,12 @@ class BaseCommand extends Command
      */
     private function getAuthors(array $metadataAuthor): string
     {
+        // Remove appended "valueURI" from authors' names for storing in database.
+        foreach ($metadataAuthor as $i => $author) {
+            $splitName = explode(pack('C', 31), $author);
+            $metadataAuthor[$i] = $splitName[0];
+        }
+
         $authors = '';
         $delimiter = '; ';
         $ellipsis = 'et al.';

--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -217,7 +217,7 @@ class BaseCommand extends Command
         $doc->cPid = $this->storagePid;
 
         $metadata = $doc->getToplevelMetadata($this->storagePid);
-        $validator = new DocumentValidator($metadata, explode(',', $this->extConf['requiredMetadataFields']));
+        $validator = new DocumentValidator($metadata, explode(',', $this->extConf['general']['requiredMetadataFields']));
 
         if ($validator->hasAllMandatoryMetadataFields()) {
             // set title data

--- a/Classes/Validation/DocumentValidator.php
+++ b/Classes/Validation/DocumentValidator.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Validation;
+
+use TYPO3\CMS\Core\Log\Logger;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class for document validation. Currently used for validating metadata
+ * fields but in the future should be extended also for other fields.
+ *
+ * @package TYPO3
+ * @subpackage dlf
+ *
+ * @access public
+ */
+class DocumentValidator
+{
+     /**
+     * @access protected
+     * @var Logger This holds the logger
+     */
+    protected Logger $logger;
+
+    /**
+     * @access private
+     * @var array
+     */
+    private array $metadata;
+
+    /**
+     * @access private
+     * @var array
+     */
+    private array $requiredMetadataFields;
+
+    /**
+     * @access private
+     * @var ?\SimpleXMLElement
+     */
+    private ?\SimpleXMLElement $xml;
+
+    /**
+     * Constructs DocumentValidator instance.
+     *
+     * @access public
+     *
+     * @param array $metadata
+     * @param array $requiredMetadataFields
+     *
+     * @return void
+     */
+    public function __construct(array $metadata = [], array $requiredMetadataFields = [], ?\SimpleXMLElement $xml = null)
+    {
+        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(static::class);
+        $this->metadata = $metadata;
+        $this->requiredMetadataFields = $requiredMetadataFields;
+        $this->xml = $xml;
+    }
+
+    /**
+     * Check if metadata array contains all mandatory fields before save.
+     *
+     * @access public
+     *
+     * @return bool
+     */
+    public function hasAllMandatoryMetadataFields(): bool
+    {
+        foreach ($this->requiredMetadataFields as $requiredMetadataField) {
+            if (empty($this->metadata[$requiredMetadataField][0])) {
+                $this->logger->error('Missing required metadata field "' . $requiredMetadataField . '".');
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if xml contains at least one logical structure with given type.
+     *
+     * @access public
+     * 
+     * @param string $type e.g. documentary, newspaper or object
+     *
+     * @return bool
+     */
+    public function hasCorrectLogicalStructure(string $type): bool
+    {
+        $expectedNodes = $this->xml->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div[@TYPE="' . $type . '"]');
+        if ($expectedNodes) {
+            return true;
+        }
+
+        $existingNodes = $this->xml->xpath('./mets:structMap[@TYPE="LOGICAL"]/mets:div');
+        if ($existingNodes) {
+            $this->logger->error('Document contains logical structure but @TYPE="' . $type . '" is missing.');
+            return false;
+        }
+
+        $this->logger->error('Document does not contain logical structure.');
+        return false;
+    }
+
+    /**
+     * Check if xml contains at least one physical structure with type 'physSequence'.
+     *
+     * @access public
+     *
+     * @return bool
+     */
+    public function hasCorrectPhysicalStructure(): bool
+    {
+        $physSequenceNodes = $this->xml->xpath('./mets:structMap[@TYPE="PHYSICAL"]/mets:div[@TYPE="physSequence"]');
+        if ($physSequenceNodes) {
+            return true;
+        }
+
+        $physicalStructureNodes = $this->xml->xpath('./mets:structMap[@TYPE="PHYSICAL"]/mets:div');
+        if ($physicalStructureNodes) {
+            $this->logger->error('Document contains physical structure but @TYPE="physSequence" is missing.');
+            return false;
+        }
+
+        $this->logger->error('Document does not contain physical structure.');
+        return false;
+    }
+}

--- a/Resources/Private/Language/de.locallang_labels.xlf
+++ b/Resources/Private/Language/de.locallang_labels.xlf
@@ -633,214 +633,214 @@
 				<source>Default metadata namespaces</source>
 				<target>Standard-Namensräume für Metadaten</target>
 			</trans-unit>
-      <trans-unit id="config.general.enableInternalProxy">
-        <source>Enable internal page view proxy?: (default is "FALSE")</source>
-        <target>Internen Proxy für Werkansicht aktivieren? (Standard ist "FALSE")</target>
-      </trans-unit>
-      <trans-unit id="config.general.userAgent">
-        <target>DLF User-Agent: (Standard ist "Kitodo.Presentation")</target>
-        <source>DLF User-Agent: (default is "Kitodo.Presentation")</source>
-      </trans-unit>
-      <trans-unit id="config.general.forceAbsoluteUrl">
-        <target>Verwende nur absolute Links für Seiten und Ressourcen?: Wird nur in speziellen Multi-Domain-Umgebungen benötigt; erfordert einen voll qualifizierten Einstiegspunkt in der Seitenkonfiguration (Standard ist "FALSE")</target>
-        <source>Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments; requires a fully qualified Entry Point in Site Configuration (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.forceAbsoluteUrlHttps">
-        <target>Verwende HTTPS for absolute Links?: erfordert einen Einstiegspunkt mit "https://..." in der Seitenkonfiguration (Standard ist "FALSE")</target>
-        <source>Use HTTPS for absolute links?: requires a valid Entry Point with "https://..." in Site Configuration (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.caching">
-        <target>Eingelesene METS Dateien / IIIF-Manifeste zwischenspeichern: Dies kann die Geschwindigkeit geringfügig verbessern, führt aber zu einer sehr großen "fe_session_data" Tabelle (Standard ist "FALSE")</target>
-        <source>Cache parsed METS files / IIIF manifests: Caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.publishNewCollections">
-        <target>Neue Kollektionen publizieren?: Sollen neue Kollektionen automatisch in der OAI-PMH-Schnittstelle veröffentlicht werden? (Standard ist "TRUE")</target>
-        <source>Publish new collections?: Should new collections automatically be published in the OAI-PMH interface? (default is "TRUE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.unhideOnIndex">
-        <source>Unhide ided documents?: Should hidden documents be unhidden when re-iding them? (default is "FALSE")</source>
-        <target>Indexierte Dokumente einblenden?: Sollen ausgeblendete Dokumente bei der erneuten Indexierung wieder eingeblendet werden? (Standard ist "FALSE")</target>
-      </trans-unit>
-      <trans-unit id="config.general.useExternalApisForMetadata">
-        <target>Verwende externe APIs zum Abrufen von Metadaten?: (Standard ist "FALSE")</target>
-        <source>Use external APIs for getting metadata?: (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.requiredMetadataFields">
-        <target>Für die Indexierung von Dokumenten erforderliche Metadatenfelder</target>
-        <source>Metadata fields required for indexing documents</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpImages">
-        <target>Seiten fileGrps: Komma-getrennte Liste der @USE Attributwerte der Seitenansichten nach aufsteigender Größe sortiert (Standard ist "DEFAULT,MAX")</target>
-        <source>Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "DEFAULT,MAX")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpThumbs">
-        <target>Vorschau fileGrp: Komma-getrennte Liste der @USE Attributwerte der Vorschaubilder nach absteigender Priorität sortiert (Standard ist "THUMBS")</target>
-        <source>Thumbnail fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "THUMBS")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpDownload">
-        <target>Download fileGrp: Komma-getrennte Liste der @USE Attributwerte der Downloads nach absteigender Priorität sortiert (Standard ist "DOWNLOAD")</target>
-        <source>Download fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "DOWNLOAD")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpFulltext">
-        <target>Volltext fileGrp: Komma-getrennte Liste der @USE Attributwerte der Volltexte nach absteigender Priorität sortiert (Standard ist "FULLTEXT")</target>
-        <source>Fulltext fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "FULLTEXT")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpAudio">
-        <target>Audio fileGrp: Komma-getrennte Liste der @USE Attributwerte der Audiodateien nach absteigender Priorität sortiert (Standard ist "AUDIO")</target>
-        <source>Audio fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "AUDIO")</source>
-      </trans-unit>
-      <trans-unit id="config.iiif.indexAnnotations">
-        <target>IIIF-Annotationen mit Motivation "painting" als Volltext behandeln?: Als Volltext behandelte Annotationen werden im Suchid idiert (Standard ist "FALSE")</target>
-        <source>Handle IIIF annotations with motivation "painting" as fulltext?: Handling annotations as fulltexts means they are ided (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.iiif.thumbnailWidth">
-        <target>Maximale Thumbnail-Breite für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</target>
-        <source>Maximum thumbnail width for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
-      </trans-unit>
-      <trans-unit id="config.iiif.thumbnailHeight">
-        <target>Maximale Thumbnail-Höhe für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</target>
-        <source>Maximum thumbnail height for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.connect">
-        <source>Solr Connection</source>
-        <target>Solr Verbindung</target>
-      </trans-unit>
-      <trans-unit id="config.solr.https">
-        <target>HTTPS verwenden: (Standard ist "FALSE")</target>
-        <source>Use HTTPS: (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.host">
-        <target>Solr Server Host: (Standard ist "localhost")</target>
-        <source>Solr Server Host: (default is "localhost")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.port">
-        <target>Solr Server Port: (Standard ist "8983")</target>
-        <source>Solr Server Port: (default is "8983")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.path">
-        <target>Solr Server Pfad: ohne API-Endpunkt "/solr" (Standard ist "/")</target>
-        <source>Solr Server Path: without API endpoint "/solr" (default is "/")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.user">
-        <target>Solr Server Benutzername: (Standard ist "")</target>
-        <source>Solr Server User: (default is "")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.pass">
-        <target>Solr Server Kennwort: (Standard ist "")</target>
-        <source>Solr Server Password: (default is "")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.timeout">
-        <target>Solr Server Timeout: (Standard ist "10")</target>
-        <source>Solr Server Timeout: (default is "10")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.allowCoreDelete">
-        <target>Löschen von Solr Kern zulassen?: Soll beim Löschen eines Solr Kerns im TYPO3 Backend auch der entsprechende Index in Apache Solr gelöscht werden? (Standard ist "FALSE")</target>
-        <source>Allow Solr Core Deletion?: If a Solr Core is deleted in the TYPO3 Backend, should it be deleted in Apache Solr as well? (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.id">
-        <target>Solr-Schema-Feld "id" : Unique identifier for the document in the id (Standard ist "id")</target>
-        <source>Solr Schema Field "id" : Unique identifier for the document in the id (default is "id")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.uid">
-        <target>Solr-Schema-Feld "uid" : Unique identifier for the document (or its top-level parent) in the TYPO3 database (Standard ist "uid")</target>
-        <source>Solr Schema Field "uid" : Unique identifier for the document (or its top-level parent) in the TYPO3 database (default is "uid")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.pid">
-        <target>Solr-Schema-Feld "pid" : PageID for the document (or its top-level parent) in the TYPO3 database (Standard ist "pid")</target>
-        <source>Solr Schema Field "pid" : PageID for the document (or its top-level parent) in the TYPO3 database (default is "pid")</source>
-      </trans-unit>
-      <trans-unit id="configsolr.fields.page">
-        <target>Solr-Schema-Feld "page" : Image number where this document starts (Standard ist "page")</target>
-        <source>Solr Schema Field "page" : Image number where this document starts (default is "page")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.partof">
-        <target>Solr-Schema-Feld "partof" : Unique identifier for the parent document in the TYPO3 database. Only if this is a multi-volume work! (Standard ist "partof")</target>
-        <source>Solr Schema Field "partof" : Unique identifier for the parent document in the TYPO3 database. Only if this is a multi-volume work! (default is "partof")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.root">
-        <target>Solr-Schema-Feld "root" : Unique identifier for the root document in the TYPO3 database. Only if this is a multi-volume work! (Standard ist "root")</target>
-        <source>Solr Schema Field "root" : Unique identifier for the root document in the TYPO3 database. Only if this is a multi-volume work! (default is "root")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.sid">
-        <target>Solr-Schema-Feld "sid" : XML ID of this document in the METS file. This is only unique within the METS file! (Standard ist "sid")</target>
-        <source>Solr Schema Field "sid" : XML ID of this document in the METS file. This is only unique within the METS file! (default is "sid")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.toplevel">
-        <target>Solr-Schema-Feld "toplevel" : Information if it is a top-level document (Standard ist "toplevel")</target>
-        <source>Solr Schema Field "toplevel" : Information if it is a top-level document (default is "toplevel")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.type">
-        <target>Solr-Schema-Feld "type" : Type of document (eg. monograph, chapter, etc.) (Standard ist "type")</target>
-        <source>Solr Schema Field "type" : Type of document (eg. monograph, chapter, etc.) (default is "type")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.title">
-        <target>Solr-Schema-Feld "title" : Title field is mandatory for identifying documents (Standard ist "title")</target>
-        <source>Solr Schema Field "title" : Title field is mandatory for identifying documents (default is "title")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.volume">
-        <target>Solr-Schema-Feld "volume" : Volume field is mandatory for identifying documents (Standard ist "volume")</target>
-        <source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.date">
-        <target>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (Standard ist "date")</target>
-        <source>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (default is "date")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.thumbnail">
-        <target>Solr-Schema-Feld "thumbnail" : URL of thumbnail image for the document (Standard ist "thumbnail")</target>
-        <source>Solr Schema Field "thumbnail" : URL of thumbnail image for the document (default is "thumbnail")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.default">
-        <target>Solr-Schema-Feld "default" : CatchAll field (Standard ist "default")</target>
-        <source>Solr Schema Field default" : CatchAll field (default is "default")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.timestamp">
-        <target>Solr-Schema-Feld "timestamp" : (Standard ist "timestamp")</target>
-        <source>Solr Schema Field "timestamp" : (default is "timestamp")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.autocomplete">
-        <target>Solr-Schema-Feld "autocomplete" : Autocomplete field for search form (Standard ist "autocomplete")</target>
-        <source>Solr Schema Field "autocomplete" : Autocomplete field for search form (default is "autocomplete")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.fulltext">
-        <target>Solr-Schema-Feld "fulltext" : Fulltext field for OCR results (Standard ist "fulltext")</target>
-        <source>Solr Schema Field "fulltext" : Fulltext field for OCR results (default is "fulltext")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.recordId">
-        <target>Solr-Schema-Feld "record_id" : Record ID of the document (required for OAI_DC output) (Standard ist "record_id")</target>
-        <source>Solr Schema Field "record_id" : Record ID of the document (required for OAI_DC output) (default is "record_id")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.purl">
-        <target>Solr-Schema-Feld "purl" : Permanent URL of the document (required for EPICUR output) (Standard ist "purl")</target>
-        <source>Solr Schema Field "purl" : Permanent URL of the document (required for EPICUR output) (default is "purl")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.urn">
-        <target>Solr-Schema-Feld "urn" : URN of the Document (required for EPICUR output) (Standard ist "urn")</target>
-        <source>Solr Schema Field "urn" : URN of the Document (required for EPICUR output) (default is "urn")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.location">
-        <target>Solr-Schema-Feld "location" : Location of METS XML (required for METS output) (Standard ist "location")</target>
-        <source>Solr Schema Field "location" : Location of METS XML (required for METS output) (default is "location")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.collection">
-        <target>Solr-Schema-Feld "collection" : Associated collection(s) of the document (Standard ist "collection")</target>
-        <source>Solr Schema Field "collection" : Associated collection(s) of the document (default is "collection")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.license">
-        <target>Solr-Schema-Feld "license" : License (should be URI) (Standard ist "license")</target>
-        <source>Solr Schema Field "license" : License (should be URI) (default is "license")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.terms">
-        <target>Solr-Schema-Feld "terms" : Term of Use (should be URI) (Standard ist "terms")</target>
-        <source>Solr Schema Field "terms" : Term of Use (should be URI) (default is "terms")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.restrictions">
-        <target>Solr-Schema-Feld "restrictions" : Access Restrictions (should be URI) (Standard ist "restrictions")</target>
-        <source>Solr Schema Field "restrictions" : Access Restrictions (should be URI) (default is "restrictions")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.geom">
-        <target>Solr-Schema-Feld "geom" : GeoJSON geometry for spatial search (Standard ist "geom")</target>
-        <source>Solr Schema Field "geom" : GeoJSON geometry for spatial search (default is "geom")</source>
-      </trans-unit>
+			<trans-unit id="config.general.enableInternalProxy">
+				<source>Enable internal page view proxy?: (default is "FALSE")</source>
+				<target>Internen Proxy für Werkansicht aktivieren? (Standard ist "FALSE")</target>
+			</trans-unit>
+			<trans-unit id="config.general.userAgent">
+				<target>DLF User-Agent: (Standard ist "Kitodo.Presentation")</target>
+				<source>DLF User-Agent: (default is "Kitodo.Presentation")</source>
+			</trans-unit>
+			<trans-unit id="config.general.forceAbsoluteUrl">
+				<target>Verwende nur absolute Links für Seiten und Ressourcen?: Wird nur in speziellen Multi-Domain-Umgebungen benötigt; erfordert einen voll qualifizierten Einstiegspunkt in der Seitenkonfiguration (Standard ist "FALSE")</target>
+				<source>Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments; requires a fully qualified Entry Point in Site Configuration (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.forceAbsoluteUrlHttps">
+				<target>Verwende HTTPS for absolute Links?: erfordert einen Einstiegspunkt mit "https://..." in der Seitenkonfiguration (Standard ist "FALSE")</target>
+				<source>Use HTTPS for absolute links?: requires a valid Entry Point with "https://..." in Site Configuration (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.caching">
+				<target>Eingelesene METS Dateien / IIIF-Manifeste zwischenspeichern: Dies kann die Geschwindigkeit geringfügig verbessern, führt aber zu einer sehr großen "fe_session_data" Tabelle (Standard ist "FALSE")</target>
+				<source>Cache parsed METS files / IIIF manifests: Caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.publishNewCollections">
+				<target>Neue Kollektionen publizieren?: Sollen neue Kollektionen automatisch in der OAI-PMH-Schnittstelle veröffentlicht werden? (Standard ist "TRUE")</target>
+				<source>Publish new collections?: Should new collections automatically be published in the OAI-PMH interface? (default is "TRUE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.unhideOnIndex">
+				<source>Unhide ided documents?: Should hidden documents be unhidden when re-iding them? (default is "FALSE")</source>
+				<target>Indexierte Dokumente einblenden?: Sollen ausgeblendete Dokumente bei der erneuten Indexierung wieder eingeblendet werden? (Standard ist "FALSE")</target>
+			</trans-unit>
+			<trans-unit id="config.general.useExternalApisForMetadata">
+				<target>Verwende externe APIs zum Abrufen von Metadaten?: (Standard ist "FALSE")</target>
+				<source>Use external APIs for getting metadata?: (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.requiredMetadataFields">
+				<target>Für die Indexierung von Dokumenten erforderliche Metadatenfelder</target>
+				<source>Metadata fields required for indexing documents</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpImages">
+				<target>Seiten fileGrps: Komma-getrennte Liste der @USE Attributwerte der Seitenansichten nach aufsteigender Größe sortiert (Standard ist "DEFAULT,MAX")</target>
+				<source>Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "DEFAULT,MAX")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpThumbs">
+				<target>Vorschau fileGrp: Komma-getrennte Liste der @USE Attributwerte der Vorschaubilder nach absteigender Priorität sortiert (Standard ist "THUMBS")</target>
+				<source>Thumbnail fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "THUMBS")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpDownload">
+				<target>Download fileGrp: Komma-getrennte Liste der @USE Attributwerte der Downloads nach absteigender Priorität sortiert (Standard ist "DOWNLOAD")</target>
+				<source>Download fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "DOWNLOAD")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpFulltext">
+				<target>Volltext fileGrp: Komma-getrennte Liste der @USE Attributwerte der Volltexte nach absteigender Priorität sortiert (Standard ist "FULLTEXT")</target>
+				<source>Fulltext fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "FULLTEXT")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpAudio">
+				<target>Audio fileGrp: Komma-getrennte Liste der @USE Attributwerte der Audiodateien nach absteigender Priorität sortiert (Standard ist "AUDIO")</target>
+				<source>Audio fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "AUDIO")</source>
+			</trans-unit>
+			<trans-unit id="config.iiif.indexAnnotations">
+				<target>IIIF-Annotationen mit Motivation "painting" als Volltext behandeln?: Als Volltext behandelte Annotationen werden im Suchid idiert (Standard ist "FALSE")</target>
+				<source>Handle IIIF annotations with motivation "painting" as fulltext?: Handling annotations as fulltexts means they are ided (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.iiif.thumbnailWidth">
+				<target>Maximale Thumbnail-Breite für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</target>
+				<source>Maximum thumbnail width for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
+			</trans-unit>
+			<trans-unit id="config.iiif.thumbnailHeight">
+				<target>Maximale Thumbnail-Höhe für IIIF-Images: Gilt nur für Bilder ohne Thumbnail-Angaben (Standard ist "150")</target>
+				<source>Maximum thumbnail height for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.connect">
+				<source>Solr Connection</source>
+				<target>Solr Verbindung</target>
+			</trans-unit>
+			<trans-unit id="config.solr.https">
+				<target>HTTPS verwenden: (Standard ist "FALSE")</target>
+				<source>Use HTTPS: (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.host">
+				<target>Solr Server Host: (Standard ist "localhost")</target>
+				<source>Solr Server Host: (default is "localhost")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.port">
+				<target>Solr Server Port: (Standard ist "8983")</target>
+				<source>Solr Server Port: (default is "8983")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.path">
+				<target>Solr Server Pfad: ohne API-Endpunkt "/solr" (Standard ist "/")</target>
+				<source>Solr Server Path: without API endpoint "/solr" (default is "/")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.user">
+				<target>Solr Server Benutzername: (Standard ist "")</target>
+				<source>Solr Server User: (default is "")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.pass">
+				<target>Solr Server Kennwort: (Standard ist "")</target>
+				<source>Solr Server Password: (default is "")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.timeout">
+				<target>Solr Server Timeout: (Standard ist "10")</target>
+				<source>Solr Server Timeout: (default is "10")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.allowCoreDelete">
+				<target>Löschen von Solr Kern zulassen?: Soll beim Löschen eines Solr Kerns im TYPO3 Backend auch der entsprechende Index in Apache Solr gelöscht werden? (Standard ist "FALSE")</target>
+				<source>Allow Solr Core Deletion?: If a Solr Core is deleted in the TYPO3 Backend, should it be deleted in Apache Solr as well? (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.id">
+				<target>Solr-Schema-Feld "id" : Unique identifier for the document in the id (Standard ist "id")</target>
+				<source>Solr Schema Field "id" : Unique identifier for the document in the id (default is "id")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.uid">
+				<target>Solr-Schema-Feld "uid" : Unique identifier for the document (or its top-level parent) in the TYPO3 database (Standard ist "uid")</target>
+				<source>Solr Schema Field "uid" : Unique identifier for the document (or its top-level parent) in the TYPO3 database (default is "uid")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.pid">
+				<target>Solr-Schema-Feld "pid" : PageID for the document (or its top-level parent) in the TYPO3 database (Standard ist "pid")</target>
+				<source>Solr Schema Field "pid" : PageID for the document (or its top-level parent) in the TYPO3 database (default is "pid")</source>
+			</trans-unit>
+			<trans-unit id="configsolr.fields.page">
+				<target>Solr-Schema-Feld "page" : Image number where this document starts (Standard ist "page")</target>
+				<source>Solr Schema Field "page" : Image number where this document starts (default is "page")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.partof">
+				<target>Solr-Schema-Feld "partof" : Unique identifier for the parent document in the TYPO3 database. Only if this is a multi-volume work! (Standard ist "partof")</target>
+				<source>Solr Schema Field "partof" : Unique identifier for the parent document in the TYPO3 database. Only if this is a multi-volume work! (default is "partof")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.root">
+				<target>Solr-Schema-Feld "root" : Unique identifier for the root document in the TYPO3 database. Only if this is a multi-volume work! (Standard ist "root")</target>
+				<source>Solr Schema Field "root" : Unique identifier for the root document in the TYPO3 database. Only if this is a multi-volume work! (default is "root")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.sid">
+				<target>Solr-Schema-Feld "sid" : XML ID of this document in the METS file. This is only unique within the METS file! (Standard ist "sid")</target>
+				<source>Solr Schema Field "sid" : XML ID of this document in the METS file. This is only unique within the METS file! (default is "sid")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.toplevel">
+				<target>Solr-Schema-Feld "toplevel" : Information if it is a top-level document (Standard ist "toplevel")</target>
+				<source>Solr Schema Field "toplevel" : Information if it is a top-level document (default is "toplevel")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.type">
+				<target>Solr-Schema-Feld "type" : Type of document (eg. monograph, chapter, etc.) (Standard ist "type")</target>
+				<source>Solr Schema Field "type" : Type of document (eg. monograph, chapter, etc.) (default is "type")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.title">
+				<target>Solr-Schema-Feld "title" : Title field is mandatory for identifying documents (Standard ist "title")</target>
+				<source>Solr Schema Field "title" : Title field is mandatory for identifying documents (default is "title")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.volume">
+				<target>Solr-Schema-Feld "volume" : Volume field is mandatory for identifying documents (Standard ist "volume")</target>
+				<source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.date">
+				<target>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (Standard ist "date")</target>
+				<source>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (default is "date")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.thumbnail">
+				<target>Solr-Schema-Feld "thumbnail" : URL of thumbnail image for the document (Standard ist "thumbnail")</target>
+				<source>Solr Schema Field "thumbnail" : URL of thumbnail image for the document (default is "thumbnail")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.default">
+				<target>Solr-Schema-Feld "default" : CatchAll field (Standard ist "default")</target>
+				<source>Solr Schema Field default" : CatchAll field (default is "default")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.timestamp">
+				<target>Solr-Schema-Feld "timestamp" : (Standard ist "timestamp")</target>
+				<source>Solr Schema Field "timestamp" : (default is "timestamp")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.autocomplete">
+				<target>Solr-Schema-Feld "autocomplete" : Autocomplete field for search form (Standard ist "autocomplete")</target>
+				<source>Solr Schema Field "autocomplete" : Autocomplete field for search form (default is "autocomplete")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.fulltext">
+				<target>Solr-Schema-Feld "fulltext" : Fulltext field for OCR results (Standard ist "fulltext")</target>
+				<source>Solr Schema Field "fulltext" : Fulltext field for OCR results (default is "fulltext")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.recordId">
+				<target>Solr-Schema-Feld "record_id" : Record ID of the document (required for OAI_DC output) (Standard ist "record_id")</target>
+				<source>Solr Schema Field "record_id" : Record ID of the document (required for OAI_DC output) (default is "record_id")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.purl">
+				<target>Solr-Schema-Feld "purl" : Permanent URL of the document (required for EPICUR output) (Standard ist "purl")</target>
+				<source>Solr Schema Field "purl" : Permanent URL of the document (required for EPICUR output) (default is "purl")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.urn">
+				<target>Solr-Schema-Feld "urn" : URN of the Document (required for EPICUR output) (Standard ist "urn")</target>
+				<source>Solr Schema Field "urn" : URN of the Document (required for EPICUR output) (default is "urn")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.location">
+				<target>Solr-Schema-Feld "location" : Location of METS XML (required for METS output) (Standard ist "location")</target>
+				<source>Solr Schema Field "location" : Location of METS XML (required for METS output) (default is "location")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.collection">
+				<target>Solr-Schema-Feld "collection" : Associated collection(s) of the document (Standard ist "collection")</target>
+				<source>Solr Schema Field "collection" : Associated collection(s) of the document (default is "collection")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.license">
+				<target>Solr-Schema-Feld "license" : License (should be URI) (Standard ist "license")</target>
+				<source>Solr Schema Field "license" : License (should be URI) (default is "license")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.terms">
+				<target>Solr-Schema-Feld "terms" : Term of Use (should be URI) (Standard ist "terms")</target>
+				<source>Solr Schema Field "terms" : Term of Use (should be URI) (default is "terms")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.restrictions">
+				<target>Solr-Schema-Feld "restrictions" : Access Restrictions (should be URI) (Standard ist "restrictions")</target>
+				<source>Solr Schema Field "restrictions" : Access Restrictions (should be URI) (default is "restrictions")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.geom">
+				<target>Solr-Schema-Feld "geom" : GeoJSON geometry for spatial search (Standard ist "geom")</target>
+				<source>Solr Schema Field "geom" : GeoJSON geometry for spatial search (default is "geom")</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_labels.xlf
+++ b/Resources/Private/Language/de.locallang_labels.xlf
@@ -665,6 +665,10 @@
 				<target>Verwende externe APIs zum Abrufen von Metadaten?: (Standard ist "FALSE")</target>
 				<source>Use external APIs for getting metadata?: (default is "FALSE")</source>
 			</trans-unit>
+            <trans-unit id="config.requiredMetadataFields">
+                <target>Für die Indizierung von Dokumenten erforderliche Metadatenfelder</target>
+                <source>Metadata fields required for indexing documents</source>
+            </trans-unit>
 			<trans-unit id="config.fileGrpImages">
 				<target>Seiten fileGrps: Komma-getrennte Liste der @USE Attributwerte der Seitenansichten nach aufsteigender Größe sortiert (Standard ist "DEFAULT,MAX")</target>
 				<source>Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "DEFAULT,MAX")</source>

--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -500,6 +500,9 @@
 			<trans-unit id="config.useExternalApisForMetadata">
 				<source>Use external APIs for getting metadata?: (default is "FALSE")</source>
 			</trans-unit>
+            <trans-unit id="config.requiredMetadataFields">
+                <source>Metadata fields required for indexing documents</source>
+            </trans-unit>
 			<trans-unit id="config.fileGrpImages">
 				<source>Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "DEFAULT,MAX")</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -476,162 +476,162 @@
 			<trans-unit id="config.metadataFormats">
 				<source>Default metadata namespaces</source>
 			</trans-unit>
-      <trans-unit id="config.general.enableInternalProxy">
-        <source>Enable internal page view proxy?: (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.userAgent">
-        <source>DLF User-Agent: (default is "Kitodo.Presentation")</source>
-      </trans-unit>
-      <trans-unit id="config.general.forceAbsoluteUrl">
-        <source>Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments; requires a fully qualified Entry Point in Site Configuration (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.forceAbsoluteUrlHttps">
-        <source>Use HTTPS for absolute links?: requires a valid Entry Point with "https://..." in Site Configuration (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.caching">
-        <source>Cache parsed METS files / IIIF manifests: Caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.publishNewCollections">
-        <source>Publish new collections?: Should new collections automatically be published in the OAI-PMH interface? (default is "TRUE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.unhideOnIndex">
-        <source>Unhide ided documents?: Should hidden documents be unhidden when re-iding them? (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.useExternalApisForMetadata">
-        <source>Use external APIs for getting metadata?: (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.general.requiredMetadataFields">
-        <source>Metadata fields required for indexing documents</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpImages">
-        <source>Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "DEFAULT,MAX")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpThumbs">
-        <source>Thumbnail fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "THUMBS")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpDownload">
-        <source>Download fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "DOWNLOAD")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpFulltext">
-        <source>Fulltext fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "FULLTEXT")</source>
-      </trans-unit>
-      <trans-unit id="config.files.fileGrpAudio">
-        <source>Audio fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "AUDIO")</source>
-      </trans-unit>
-      <trans-unit id="config.iiif.indexAnnotations">
-        <source>Handle IIIF annotations with motivation "painting" as fulltext?: Handling annotations as fulltexts means they are ided (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.iiif.thumbnailWidth">
-        <source>Maximum thumbnail width for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
-      </trans-unit>
-      <trans-unit id="config.iiif.thumbnailHeight">
-        <source>Maximum thumbnail height for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.connect">
-        <source>Solr Connection</source>
-      </trans-unit>
-      <trans-unit id="config.solr.https">
-        <source>Use HTTPS: (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.host">
-        <source>Solr Server Host: (default is "localhost")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.port">
-        <source>Solr Server Port: (default is "8983")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.path">
-        <source>Solr Server Path: without API endpoint "/solr" (default is "/")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.user">
-        <source>Solr Server User: (default is "")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.pass">
-        <source>Solr Server Password: (default is "")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.timeout">
-        <source>Solr Server Timeout: (default is "10")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.allowCoreDelete">
-        <source>Allow Solr Core Deletion?: If a Solr Core is deleted in the TYPO3 Backend, should it be deleted in Apache Solr as well? (default is "FALSE")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.id">
-        <source>Solr Schema Field "id" : Unique identifier for the document in the id (default is "id")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.uid">
-        <source>Solr Schema Field "uid" : Unique identifier for the document (or its top-level parent) in the TYPO3 database (default is "uid")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.pid">
-        <source>Solr Schema Field "pid" : PageID for the document (or its top-level parent) in the TYPO3 database (default is "pid")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.page">
-        <source>Solr Schema Field "page" : Image number where this document starts (default is "page")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.partof">
-        <source>Solr Schema Field "partof" : Unique identifier for the parent document in the TYPO3 database. Only if this is a multi-volume work! (default is "partof")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.root">
-        <source>Solr Schema Field "root" : Unique identifier for the root document in the TYPO3 database. Only if this is a multi-volume work! (default is "root")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.sid">
-        <source>Solr Schema Field "sid" : XML ID of this document in the METS file. This is only unique within the METS file! (default is "sid")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.toplevel">
-        <source>Solr Schema Field "toplevel" : Information if it is a top-level document (default is "toplevel")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.type">
-        <source>Solr Schema Field "type" : Type of document (eg. monograph, chapter, etc.) (default is "type")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.title">
-        <source>Solr Schema Field "title" : Title field is mandatory for identifying documents (default is "title")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.volume">
-        <source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.date">
-        <source>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (default is "date")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.thumbnail">
-        <source>Solr Schema Field "thumbnail" : URL of thumbnail image for the document (default is "thumbnail")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.default">
-        <source>Solr Schema Field default" : CatchAll field (default is "default")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.timestamp">
-        <source>Solr Schema Field "timestamp" : (default is "timestamp")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.autocomplete">
-        <source>Solr Schema Field "autocomplete" : Autocomplete field for search form (default is "autocomplete")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.fulltext">
-        <source>Solr Schema Field "fulltext" : Fulltext field for OCR results (default is "fulltext")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.recordId">
-        <source>Solr Schema Field "record_id" : Record ID of the document (required for OAI_DC output) (default is "record_id")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.purl">
-        <source>Solr Schema Field "purl" : Permanent URL of the document (required for EPICUR output) (default is "purl")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.urn">
-        <source>Solr Schema Field "urn" : URN of the Document (required for EPICUR output) (default is "urn")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.location">
-        <source>Solr Schema Field "location" : Location of METS XML (required for METS output) (default is "location")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.collection">
-        <source>Solr Schema Field "collection" : Associated collection(s) of the document (default is "collection")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.license">
-        <source>Solr Schema Field "license" : License (should be URI) (default is "license")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.terms">
-        <source>Solr Schema Field "terms" : Term of Use (should be URI) (default is "terms")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.restrictions">
-        <source>Solr Schema Field "restrictions" : Access Restrictions (should be URI) (default is "restrictions")</source>
-      </trans-unit>
-      <trans-unit id="config.solr.fields.geom">
-        <source>Solr Schema Field "geom" : GeoJSON geometry for spatial search (default is "geom")</source>
-      </trans-unit>
+			<trans-unit id="config.general.enableInternalProxy">
+				<source>Enable internal page view proxy?: (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.userAgent">
+				<source>DLF User-Agent: (default is "Kitodo.Presentation")</source>
+			</trans-unit>
+			<trans-unit id="config.general.forceAbsoluteUrl">
+				<source>Force all links to pages and resources to be absolute?: Only needed for some multi-domain environments; requires a fully qualified Entry Point in Site Configuration (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.forceAbsoluteUrlHttps">
+				<source>Use HTTPS for absolute links?: requires a valid Entry Point with "https://..." in Site Configuration (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.caching">
+				<source>Cache parsed METS files / IIIF manifests: Caching improves performance a little bit but can result in a very large "fe_session_data" table (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.publishNewCollections">
+				<source>Publish new collections?: Should new collections automatically be published in the OAI-PMH interface? (default is "TRUE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.unhideOnIndex">
+				<source>Unhide ided documents?: Should hidden documents be unhidden when re-iding them? (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.useExternalApisForMetadata">
+				<source>Use external APIs for getting metadata?: (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.general.requiredMetadataFields">
+				<source>Metadata fields required for indexing documents</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpImages">
+				<source>Page fileGrps: comma-separated list of @USE attribute values ordered by increasing size (default is "DEFAULT,MAX")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpThumbs">
+				<source>Thumbnail fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "THUMBS")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpDownload">
+				<source>Download fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "DOWNLOAD")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpFulltext">
+				<source>Fulltext fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "FULLTEXT")</source>
+			</trans-unit>
+			<trans-unit id="config.files.fileGrpAudio">
+				<source>Audio fileGrp: comma-separated list of @USE attribute values ordered by decreasing priority (default is "AUDIO")</source>
+			</trans-unit>
+			<trans-unit id="config.iiif.indexAnnotations">
+				<source>Handle IIIF annotations with motivation "painting" as fulltext?: Handling annotations as fulltexts means they are ided (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.iiif.thumbnailWidth">
+				<source>Maximum thumbnail width for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
+			</trans-unit>
+			<trans-unit id="config.iiif.thumbnailHeight">
+				<source>Maximum thumbnail height for IIIF images: Only for images without a thumbnail declaration (default is "150")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.connect">
+				<source>Solr Connection</source>
+			</trans-unit>
+			<trans-unit id="config.solr.https">
+				<source>Use HTTPS: (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.host">
+				<source>Solr Server Host: (default is "localhost")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.port">
+				<source>Solr Server Port: (default is "8983")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.path">
+				<source>Solr Server Path: without API endpoint "/solr" (default is "/")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.user">
+				<source>Solr Server User: (default is "")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.pass">
+				<source>Solr Server Password: (default is "")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.timeout">
+				<source>Solr Server Timeout: (default is "10")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.allowCoreDelete">
+				<source>Allow Solr Core Deletion?: If a Solr Core is deleted in the TYPO3 Backend, should it be deleted in Apache Solr as well? (default is "FALSE")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.id">
+				<source>Solr Schema Field "id" : Unique identifier for the document in the id (default is "id")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.uid">
+				<source>Solr Schema Field "uid" : Unique identifier for the document (or its top-level parent) in the TYPO3 database (default is "uid")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.pid">
+				<source>Solr Schema Field "pid" : PageID for the document (or its top-level parent) in the TYPO3 database (default is "pid")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.page">
+				<source>Solr Schema Field "page" : Image number where this document starts (default is "page")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.partof">
+				<source>Solr Schema Field "partof" : Unique identifier for the parent document in the TYPO3 database. Only if this is a multi-volume work! (default is "partof")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.root">
+				<source>Solr Schema Field "root" : Unique identifier for the root document in the TYPO3 database. Only if this is a multi-volume work! (default is "root")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.sid">
+				<source>Solr Schema Field "sid" : XML ID of this document in the METS file. This is only unique within the METS file! (default is "sid")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.toplevel">
+				<source>Solr Schema Field "toplevel" : Information if it is a top-level document (default is "toplevel")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.type">
+				<source>Solr Schema Field "type" : Type of document (eg. monograph, chapter, etc.) (default is "type")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.title">
+				<source>Solr Schema Field "title" : Title field is mandatory for identifying documents (default is "title")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.volume">
+				<source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.date">
+				<source>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (default is "date")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.thumbnail">
+				<source>Solr Schema Field "thumbnail" : URL of thumbnail image for the document (default is "thumbnail")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.default">
+				<source>Solr Schema Field default" : CatchAll field (default is "default")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.timestamp">
+				<source>Solr Schema Field "timestamp" : (default is "timestamp")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.autocomplete">
+				<source>Solr Schema Field "autocomplete" : Autocomplete field for search form (default is "autocomplete")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.fulltext">
+				<source>Solr Schema Field "fulltext" : Fulltext field for OCR results (default is "fulltext")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.recordId">
+				<source>Solr Schema Field "record_id" : Record ID of the document (required for OAI_DC output) (default is "record_id")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.purl">
+				<source>Solr Schema Field "purl" : Permanent URL of the document (required for EPICUR output) (default is "purl")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.urn">
+				<source>Solr Schema Field "urn" : URN of the Document (required for EPICUR output) (default is "urn")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.location">
+				<source>Solr Schema Field "location" : Location of METS XML (required for METS output) (default is "location")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.collection">
+				<source>Solr Schema Field "collection" : Associated collection(s) of the document (default is "collection")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.license">
+				<source>Solr Schema Field "license" : License (should be URI) (default is "license")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.terms">
+				<source>Solr Schema Field "terms" : Term of Use (should be URI) (default is "terms")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.restrictions">
+				<source>Solr Schema Field "restrictions" : Access Restrictions (should be URI) (default is "restrictions")</source>
+			</trans-unit>
+			<trans-unit id="config.solr.fields.geom">
+				<source>Solr Schema Field "geom" : GeoJSON geometry for spatial search (default is "geom")</source>
+			</trans-unit>
 		</body>
   </file>
 </xliff>

--- a/Tests/Unit/Validation/DocumentValidatorTest.php
+++ b/Tests/Unit/Validation/DocumentValidatorTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Tests\Unit\Common;
+
+use Kitodo\Dlf\Validation\DocumentValidator;
+use SimpleXMLElement;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class DocumentValidatorTest extends UnitTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetSingletonInstances = true;
+    }
+
+    /**
+     * @test
+     */
+    public function passesHasAllMandatoryMetadataFields()
+    {
+        $metadata = [
+            'record_id' => [
+                'xyz'
+            ]
+        ];
+        $documentValidator = new DocumentValidator($metadata, $this->getRequiredMetadataFields());
+        self::assertTrue($documentValidator->hasAllMandatoryMetadataFields());
+    }
+
+    /**
+     * @test
+     */
+    public function notPassesHasAllMandatoryMetadataFields()
+    {
+        $metadata = [
+            'document_format' => [
+                'METS'
+            ]
+        ];
+        $documentValidator = new DocumentValidator($metadata, $this->getRequiredMetadataFields());
+        self::assertFalse($documentValidator->hasAllMandatoryMetadataFields());
+    }
+
+    /**
+     * @test
+     */
+    public function passesHasCorrectLogicalStructure()
+    {
+        $xml = $this->getXml('av_beispiel.xml');
+
+        $documentValidator = new DocumentValidator([], [], $xml);
+        self::assertTrue($documentValidator->hasCorrectLogicalStructure('advertisement'));
+    }
+
+    /**
+     * @test
+     */
+    public function notPassesHasCorrectLogicalStructure()
+    {
+        $xml = $this->getXml('av_beispiel.xml');
+
+        $documentValidator = new DocumentValidator([], [], $xml);
+        self::assertFalse($documentValidator->hasCorrectLogicalStructure('newspaper'));
+    }
+
+    /**
+     * @test
+     */
+    public function passesHasCorrectPhysicalStructure()
+    {
+        $xml = $this->getXml('av_beispiel.xml');
+
+        $documentValidator = new DocumentValidator([], [], $xml);
+        self::assertTrue($documentValidator->hasCorrectPhysicalStructure());
+    }
+
+    /**
+     * @test
+     */
+    public function notPassesHasCorrectPhysicalStructure()
+    {
+        $xml = $this->getXml('two_dmdsec.xml');
+
+        $documentValidator = new DocumentValidator([], [], $xml);
+        self::assertFalse($documentValidator->hasCorrectPhysicalStructure());
+    }
+
+    private function getRequiredMetadataFields(): array
+    {
+        return [
+            'record_id'
+        ];
+    }
+
+    private function getXml(string $file): SimpleXMLElement
+    {
+        $xml = simplexml_load_file(__DIR__ . '/../../Fixtures/MetsDocument/' . $file);
+        self::assertNotFalse($xml);
+        return $xml;
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -14,7 +14,7 @@ general.publishNewCollections = 1
 general.unhideOnIndex = 0
 # cat=General; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.general.useExternalApisForMetadata
 general.useExternalApisForMetadata = 0
-# cat=General; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.requiredMetadataFields
+# cat=General; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.general.requiredMetadataFields
 general.requiredMetadataFields = document_format,record_id
 # cat=Files; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.files.fileGrpImages
 files.fileGrpImages = DEFAULT,MAX

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -14,6 +14,8 @@ publishNewCollections = 1
 unhideOnIndex = 0
 # cat=Basic; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.useExternalApisForMetadata
 useExternalApisForMetadata = 0
+# cat=Document; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.requiredMetadataFields
+requiredMetadataFields = document_format,record_id
 # cat=Files; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.fileGrpImages
 fileGrpImages = DEFAULT,MAX
 # cat=Files; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.fileGrpThumbs


### PR DESCRIPTION
Allow index documents only if their metadata contains document format and record identifier

This functionality can be extended for more mandatory fields without which document should be treated as incomplete and as such should not be inserted into database and SOLR Index.