### PR TITLE
[BUGFIX] Assign correct html id to `fullTextScrollElement`

### DIFF
--- a/Configuration/TypoScript/Toolbox/setup.typoscript
+++ b/Configuration/TypoScript/Toolbox/setup.typoscript
@@ -2,7 +2,7 @@ plugin.tx_dlf_fulltexttool {
     settings {
         tools = fulltexttool
         activateFullTextInitially = 0
-        fullTextScrollElement = html, body
+        fullTextScrollElement = #tx-dlf-fulltextselection
         searchHlParameters = tx_dlf[highlight_word]
     }
 }


### PR DESCRIPTION
Fixes https://github.com/kitodo/kitodo-presentation/issues/1151