### PR TITLE
[FEATURE] Implement document validation before document is saved to SOLR

### DIFF
--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -196,7 +196,7 @@ class IndexCommand extends BaseCommand
                 }
                 $isSaved = Indexer::add($document, $this->documentRepository);
             } else {
-                $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on PID ' . $this->storagePid . ' . There are missing mandatory fields (at least one of those: ' . $this->extConf['requiredMetadataFields'] .') in this document.');
+                $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on PID ' . $this->storagePid . ' . There are missing mandatory fields (at least one of those: ' . $this->extConf['requiredMetadataFields'] . ') in this document.');
                 return BaseCommand::FAILURE;
             }
 

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -205,7 +205,7 @@ class IndexCommand extends BaseCommand
                 return BaseCommand::SUCCESS;
             }
 
-            $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on Solr core ' . $solrCoreUid . ' . There are missing mandatory fields (at least one of those: ' . $this->extConf['requiredMetadataFields'] .') in this document.');
+            $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on Solr core ' . $solrCoreUid . ' . There are missing mandatory fields (at least one of those: ' . $this->extConf['requiredMetadataFields'] . ') in this document.');
             $io->info('INFO: Document with UID "' . $document->getUid() . '" is already in database. If you want to keep the database and index consistent you need to remove it.');
             return BaseCommand::FAILURE;
         }

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -194,13 +194,19 @@ class IndexCommand extends BaseCommand
                 if ($io->isVerbose()) {
                     $io->section('Indexing ' . $document->getUid() . ' ("' . $document->getLocation() . '") on Solr core ' . $solrCoreUid . '.');
                 }
-                Indexer::add($document, $this->documentRepository);
+                $isSaved = Indexer::add($document, $this->documentRepository);
+            } else {
+                $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on PID ' . $this->storagePid . ' . There are missing mandatory fields (at least one of those: ' . $this->extConf['requiredMetadataFields'] .') in this document.');
+                return BaseCommand::FAILURE;
+            }
 
+            if ($isSaved) {
                 $io->success('All done!');
                 return BaseCommand::SUCCESS;
             }
 
-            $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on PID ' . $this->storagePid . ' . There are missing mandatory fields (document format or record identifier) in this document.');
+            $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on Solr core ' . $solrCoreUid . ' . There are missing mandatory fields (at least one of those: ' . $this->extConf['requiredMetadataFields'] .') in this document.');
+            $io->info('INFO: Document with UID "' . $document->getUid() . '" is already in database. If you want to keep the database and index consistent you need to remove it.');
             return BaseCommand::FAILURE;
         }
     }

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -127,7 +127,8 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
 
         return [
             'general' => [
-                'useExternalApisForMetadata' => 0
+                'useExternalApisForMetadata' => 0,
+                'requiredMetadataFields' => 'document_format'
             ],
             'files' => [
                 'fileGrpImages' => 'DEFAULT,MAX',


### PR DESCRIPTION
There exists possibility that during save to database document contains 'record_id', but already during saving to SOLR it doesn't. It is necessary to validate fields in both places to avoid it.

Depends on #1149