### PR TITLE
[MAINTENANCE] Replace calls of function sizeof by calls of function count

### DIFF
--- a/Classes/Controller/BasketController.php
+++ b/Classes/Controller/BasketController.php
@@ -438,7 +438,7 @@ class BasketController extends AbstractController
             // set endpage for toc and subentry based on logid
             if (($piVars['addToBasket'] == 'subentry') or ($piVars['addToBasket'] == 'toc')) {
                 $smLinks = $this->document->getCurrentDocument()->smLinks;
-                $pageCounter = sizeof($smLinks['l2p'][$piVars['logId']]);
+                $pageCounter = count($smLinks['l2p'][$piVars['logId']]);
                 $documentItem['endpage'] = ($documentItem['startpage'] + $pageCounter) - 1;
             }
             // add whole document

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -139,7 +139,7 @@ class ToolboxController extends AbstractController
         $annotationContainers = $this->currentDocument->physicalStructureInfo[$this->currentDocument->physicalStructure[$this->requestData['page']]]['annotationContainers'];
         if (
             $annotationContainers != null
-            && sizeof($annotationContainers) > 0
+            && count($annotationContainers) > 0
         ) {
             $this->view->assign('annotationTool', true);
         } else {


### PR DESCRIPTION
`sizeof` is an alias for `count`. Using `count` fixes warnings from Codacy:

    The use of function sizeof() is discouraged; use count() instead.