### PR TITLE
[BUGFIX] Fix search word highlighting

### DIFF
--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -655,8 +655,8 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, optOffs
 dlfUtils.searchFeatureCollectionForCoordinates = function (featureCollection, coordinates) {
     var features = [];
     featureCollection.forEach(function (ft) {
-        if (ft.get('fulltext') !== undefined) {
-            if (ft.getId() === coordinates) {
+        if (ft.values_.fulltext !== undefined) {
+            if (ft.values_.fulltext === coordinates) {
                 features.push(ft);
             }
         }

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -656,7 +656,7 @@ dlfUtils.searchFeatureCollectionForCoordinates = function (featureCollection, co
     var features = [];
     featureCollection.forEach(function (ft) {
         if (ft.values_.fulltext !== undefined) {
-            if (ft.values_.fulltext === coordinates) {
+            if (ft.values_.fulltext.includes(coordinates)) {
                 features.push(ft);
             }
         }


### PR DESCRIPTION
See #1127

In addition to fixing the search word highlighting, I changed the way toe strings are compared. Because the search shows results for substring matches (e.g: `Mannheim` in `Mannheim.`), but the search word highlighting does not (in the example because of the dot `.`). There is a downside and a upsite.

- Downside: Searching for `Mann` does not deliver `Mannheim`, but the search word highlighting would still mark `Mannheim`.
- Upsite: Searching with a wildcard for `Mann*` does deliver `Mannheim`, and now the search word highlighting would marks `Mannheim` too.

I could programme the comparison more precisely, but that would require more code. What do you think?

Last but not least: We should consider renaming the function and its parameters. e.g: `coordinates` ist misleading. As far as I see `searchFeatureCollectionForCoordinates()` gets only called in [PageView.js](https://github.com/kitodo/kitodo-presentation/blob/master/Resources/Public/JavaScript/PageView/PageView.js#L508) when there are highlight words. 