### PR TITLE
[BUGFIX] fix incomplete renaming reindexing option "index-start" to "index-begin"

### DIFF
--- a/Classes/Command/ReindexCommand.php
+++ b/Classes/Command/ReindexCommand.php
@@ -159,7 +159,7 @@ class ReindexCommand extends BaseCommand
             $documents = $this->documentRepository->findAll();
         } elseif (
             !empty($input->getOption('index-limit'))
-            && $input->getOption('index-start') >= 0
+            && $input->getOption('index-begin') >= 0
         ) {
             // Get all documents for given limit and start.
             $documents = $this->documentRepository->findAll()


### PR DESCRIPTION
Without this fix, an error message is displayed when using the new reindexing options -b and -l (or --index-begin and --index-limit):
```
[Symfony\Component\Console\Exception\InvalidArgumentException]  
The "index-start" option does not exist.   
```