### PR TITLE
[MAINTENANCE] Use Dotenv for accessing environmental variables

### DIFF
--- a/Build/Test/docker-compose.yml
+++ b/Build/Test/docker-compose.yml
@@ -85,7 +85,8 @@ services:
       typo3DatabaseUsername: root
       typo3DatabasePassword: funcp
       typo3DatabaseHost: ${DBMS}
-      dlfTestingSolrHost: solr
+    env_file:
+      - ./test.env
     working_dir: ${DLF_ROOT}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/Build/Test/test.env
+++ b/Build/Test/test.env
@@ -1,0 +1,1 @@
+dlfTestingSolrHost=solr

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Tests\Functional;
 
+use Dotenv\Dotenv;
 use GuzzleHttp\Client as HttpClient;
 use Kitodo\Dlf\Common\Solr\Solr;
 use Symfony\Component\Yaml\Yaml;
@@ -121,6 +122,9 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
 
     protected function getDlfConfiguration()
     {
+        $dotenv = Dotenv::createImmutable('/home/runner/work/kitodo-presentation/kitodo-presentation/Build/Test/', 'test.env');
+        $dotenv->load();
+
         return [
             'useExternalApisForMetadata' => 0,
             'fileGrpImages' => 'DEFAULT,MAX',

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     "typo3/cms-fluid": "^10.4.37|^11.5.35",
     "typo3/cms-fluid-styled-content": "^10.4.37|^11.5.35",
     "typo3/cms-frontend": "^10.4.37|^11.5.35",
-    "typo3/testing-framework": "^6.16.9"
+    "typo3/testing-framework": "^6.16.9",
+    "vlucas/phpdotenv": "^5.6.0"
   },
   "replace": {
     "typo3-ter/dlf": "self.version"


### PR DESCRIPTION
Use vlucas/phpdotenv to manage environment variables more securely and robustly.