### PR TITLE
[MAINTENANCE] Replace `chr(31)` with `pack('C', 31)`

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -222,7 +222,7 @@ class BaseCommand extends Command
 
         // Remove appended "valueURI" from authors' names for storing in database.
         foreach ($metadata['author'] as $i => $author) {
-            $splitName = explode(chr(31), $author);
+            $splitName = explode(pack('C', 31), $author);
             $metadata['author'][$i] = $splitName[0];
         }
         $document->setAuthor($this->getAuthors($metadata['author']));

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -608,7 +608,7 @@ class Indexer
     {
         if (is_array($authors)) {
             foreach ($authors as $i => $author) {
-                $splitName = explode(chr(31), $author);
+                $splitName = explode(pack('C', 31), $author);
                 $authors[$i] = $splitName[0];
             }
         }

--- a/Classes/Format/Mods.php
+++ b/Classes/Format/Mods.php
@@ -177,7 +177,7 @@ class Mods implements MetadataInterface
         }
         // Append "valueURI" to name using Unicode unit separator.
         if (isset($authors[$i]['valueURI'])) {
-            $this->metadata['author'][$i] .= chr(31) . (string) $authors[$i]['valueURI'];
+            $this->metadata['author'][$i] .= pack('C', 31) . (string) $authors[$i]['valueURI'];
         }
     }
 
@@ -265,7 +265,7 @@ class Mods implements MetadataInterface
         $this->getHolderFromXmlDisplayForm($holders, $i);
         // Append "valueURI" to name using Unicode unit separator.
         if (isset($holders[$i]['valueURI'])) {
-            $this->metadata['holder'][$i] .= chr(31) . (string) $holders[$i]['valueURI'];
+            $this->metadata['holder'][$i] .= pack('C', 31) . (string) $holders[$i]['valueURI'];
         }
     }
 


### PR DESCRIPTION
Codacy warning about usage of `chr()`