### PR TITLE
[BUGFIX] Fix cache assignment in `ext_localconf.php` for arrays

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -82,7 +82,7 @@ if ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['dlf']['enableInternalProxy'] ?? f
     $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_dlf_pageview_proxy'] = \Kitodo\Dlf\Eid\PageViewProxy::class . '::main';
 }
 // Use Caching Framework for Solr queries
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr'])) {
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']) || !is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr'] = [];
 }
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['backend'])) {
@@ -92,7 +92,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_solr']['options']['defaultLifeTime'] = 86400; // 86400 seconds = 1 day
 }
 // Use Caching Framework for XML file caching
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc'])) {
+if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']) || !is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc'] = [];
 }
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_dlf_doc']['backend'])) {


### PR DESCRIPTION
Fix for errors:

```
Uncaught TYPO3 Exception #1476107295: PHP Warning: Undefined array key "tx_dlf_solr" in /var/www/extensions/kitodo-presentation/ext_localconf.php line 85
thrown in file /var/www/html/vendor/typo3/cms-core/Classes/Error/ErrorHandler.php
in line 137
```

```
Uncaught TYPO3 Exception #1476107295: PHP Warning: Undefined array key "tx_dlf_doc" in /var/www/extensions/kitodo-presentation/ext_localconf.php line 95
thrown in file /var/www/html/vendor/typo3/cms-core/Classes/Error/ErrorHandler.php
in line 137
```