### PR TITLE
[MAINTENANCE] Adjust compability with PHP 8 for XML loading

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -249,12 +249,19 @@ class Helper
 
         // Turn off libxml's error logging.
         $libxmlErrors = libxml_use_internal_errors(true);
-        // Disables the functionality to allow external entities to be loaded when parsing the XML, must be kept
-        $previousValueOfEntityLoader = libxml_disable_entity_loader(true);
+
+        if (\PHP_VERSION_ID < 80000) {
+            // Disables the functionality to allow external entities to be loaded when parsing the XML, must be kept
+            $previousValueOfEntityLoader = libxml_disable_entity_loader(true);
+        }
+
         // Try to load XML from file.
         $xml = simplexml_load_string($content);
-        // reset entity loader setting
-        libxml_disable_entity_loader($previousValueOfEntityLoader);
+
+        if (\PHP_VERSION_ID < 80000) {
+            // reset entity loader setting
+            libxml_disable_entity_loader($previousValueOfEntityLoader);
+        }
         // Reset libxml's error logging.
         libxml_use_internal_errors($libxmlErrors);
         return $xml;


### PR DESCRIPTION
On code that only runs on PHP 8.0 and later, it is now safe to remove all function calls.
For versions prior to PHP 8, a conditional call.

https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation