### PR TITLE
[BUGFIX] Remove `uid` from serialization

### DIFF
--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -1023,6 +1023,6 @@ final class IiifManifest extends AbstractDocument
         // TODO implement serialization in IIIF library
         $jsonArray = $this->iiif->getOriginalJsonArray();
         $this->asJson = json_encode($jsonArray);
-        return ['uid', 'pid', 'recordId', 'parentId', 'asJson'];
+        return ['pid', 'recordId', 'parentId', 'asJson'];
     }
 }

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1402,7 +1402,7 @@ final class MetsDocument extends AbstractDocument
     {
         // \SimpleXMLElement objects can't be serialized, thus save the XML as string for serialization
         $this->asXML = $this->xml->asXML();
-        return ['uid', 'pid', 'recordId', 'parentId', 'asXML'];
+        return ['pid', 'recordId', 'parentId', 'asXML'];
     }
 
     /**


### PR DESCRIPTION
`AbstractDocument` nor its children contains property `uid`