### PR TITLE
[BUGFIX] Fix warnings for undefined keys in `$settings` array

### DIFF
--- a/Classes/Domain/Repository/MetadataRepository.php
+++ b/Classes/Domain/Repository/MetadataRepository.php
@@ -41,11 +41,11 @@ class MetadataRepository extends Repository
 
         $constraints = [];
 
-        if ($settings['is_listed']) {
+        if (isset($settings['is_listed'])) {
             $constraints[] = $query->equals('is_listed', 1);
         }
 
-        if ($settings['is_sortable']) {
+        if (isset($settings['is_sortable'])) {
             $constraints[] = $query->equals('is_sortable', 1);
         }
 


### PR DESCRIPTION
`PHP Warning: Undefined array key "is_listed" in /var/www/extensions/kitodo-presentation/Classes/Domain/Repository/MetadataRepository.php line 44`

`PHP Warning: Undefined array key "is_sortable" in /var/www/extensions/kitodo-presentation/Classes/Domain/Repository/MetadataRepository.php line 48`