### PR TITLE
[BUGFIX] Correctly check if `storagePid` key exists in array

### DIFF
--- a/Classes/Common/AbstractDocument.php
+++ b/Classes/Common/AbstractDocument.php
@@ -574,7 +574,7 @@ abstract class AbstractDocument
         }
 
         // Sanitize input.
-        $pid = $settings['storagePid'] ? max((int) $settings['storagePid'], 0) : 0;
+        $pid = array_key_exists('storagePid', $settings) ? max((int) $settings['storagePid'], 0) : 0;
         if ($documentFormat == 'METS') {
             $instance = new MetsDocument($pid, $location, $xml, $settings);
         } elseif ($documentFormat == 'IIIF') {


### PR DESCRIPTION
This was previously updated but it turned out that null check here is not enough, it needs to check directly for key existence