### PR TITLE
[BUGFIX] Check if given array element is set and if its value is true

### DIFF
--- a/Classes/Domain/Repository/MetadataRepository.php
+++ b/Classes/Domain/Repository/MetadataRepository.php
@@ -41,11 +41,11 @@ class MetadataRepository extends Repository
 
         $constraints = [];
 
-        if (isset($settings['is_listed'])) {
+        if (isset($settings['is_listed']) && $settings['is_listed'] == true) {
             $constraints[] = $query->equals('is_listed', 1);
         }
 
-        if (isset($settings['is_sortable'])) {
+        if (isset($settings['is_sortable']) && $settings['is_sortable'] == true) {
             $constraints[] = $query->equals('is_sortable', 1);
         }
 


### PR DESCRIPTION
This function is called as default with empty array, but there is possibility that one or both keys (`is_listed` and `is_sortable`) are used with assigned value `true`.