### PR TITLE
[MAINTENANCE] fix nested extension configuration for metadataFormats

### DIFF
--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -473,7 +473,7 @@
 			<trans-unit id="tt_content.dlf_toolbox">
 				<source>DLF: Toolbox</source>
 			</trans-unit>
-			<trans-unit id="config.metadataFormats">
+			<trans-unit id="config.general.metadataFormats">
 				<source>Default metadata namespaces</source>
 			</trans-unit>
 			<trans-unit id="config.general.enableInternalProxy">

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -8,6 +8,8 @@ general.forceAbsoluteUrl = 0
 general.forceAbsoluteUrlHttps = 0
 # cat=General; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.general.caching
 general.caching = 0
+# cat=General; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.general.metadataFormats
+general.metadataFormats = 0
 # cat=General; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.general.publishNewCollections
 general.publishNewCollections = 1
 # cat=General; type=boolean; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.general.unhideOnIndex


### PR DESCRIPTION
update nesting according to translation file "de.locallang_labels.xlf"