### PR TITLE
[BUGFIX] Children without links should be enclosed in span element with class a

### DIFF
--- a/Resources/Private/Partials/TableOfContents/Children.html
+++ b/Resources/Private/Partials/TableOfContents/Children.html
@@ -36,7 +36,9 @@
 
     <f:if condition="{child.doNotLinkIt}">
         <f:then>
-            <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+            <span class="a">
+                <f:render partial="TableOfContents/Title" arguments="{child: child}"/>
+            </span>
         </f:then>
         <f:else>
             <f:link.action


### PR DESCRIPTION
It ensures correct indentation in TableOfContents plugin

It fixes https://github.com/slub/dfg-viewer/issues/288