### PR TITLE
[BUGFIX] Fix exception on not existing 3dviewer configuration path

### DIFF
--- a/Classes/Middleware/Embedded3dViewer.php
+++ b/Classes/Middleware/Embedded3dViewer.php
@@ -177,7 +177,7 @@ class Embedded3dViewer implements MiddlewareInterface
                 }
             }
         } catch (Exception $exception) {
-            $this->logger->error($exception->getMessage());
+            $this->logger->debug($exception->getMessage());
         }
         return $extConf['defaultViewer'] ?? "";
     }

--- a/Classes/Middleware/Embedded3dViewer.php
+++ b/Classes/Middleware/Embedded3dViewer.php
@@ -163,9 +163,8 @@ class Embedded3dViewer implements MiddlewareInterface
      */
     private function getViewerByExtensionConfiguration(string $modelFormat): string
     {
-        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
         try {
-            $extConf = $extensionConfiguration->get(self::EXT_KEY, '3dviewer');
+            $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::EXT_KEY, '3dviewer');
             $viewerModelFormatMappings = explode(";", $extConf['viewerModelFormatMapping']);
             foreach ($viewerModelFormatMappings as $viewerModelFormatMapping) {
                 $explodedViewerModelMapping = explode(":", $viewerModelFormatMapping);

--- a/Classes/Middleware/Embedded3dViewer.php
+++ b/Classes/Middleware/Embedded3dViewer.php
@@ -161,7 +161,7 @@ class Embedded3dViewer implements MiddlewareInterface
      * @param $modelFormat string The model format
      * @return string The 3D viewer
      */
-    private function getViewerByExtensionConfiguration($modelFormat): string
+    private function getViewerByExtensionConfiguration(string $modelFormat): string
     {
         $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
         try {


### PR DESCRIPTION
Handles the exception where, with a fresh DFG-Viewer installation and no saved dlf extension configuration, the `3dviewer` configuration key does not exist.

Reported problem: https://github.com/slub/dfg-viewer/pull/295#issuecomment-2286547643