### PR TITLE
[BUGFIX] Remove constrain to display `pageStep` setting

### DIFF
--- a/Configuration/FlexForms/Navigation.xml
+++ b/Configuration/FlexForms/Navigation.xml
@@ -89,7 +89,6 @@
                     <settings.pageStep>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <displayCond>FIELD:settings.features:IN:pagestep</displayCond>
                             <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.pageStep</label>
                             <config>
                                 <type>input</type>


### PR DESCRIPTION
There is no `pagestep` in `features` setting list.

It is related to https://github.com/kitodo/kitodo-presentation/pull/1252. Actually setting was not missing, just hidden as condition to display it was always false.