### PR TITLE
[BUGFIX] Remove redundant `useInternalProxy` setting from the TS config

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -5,7 +5,6 @@ plugin.tx_dlf {
     }
     settings {
         storagePid = {$plugin.tx_dlf.persistence.storagePid}
-        useInternalProxy = 1
     }
 }
 


### PR DESCRIPTION
It is already configured in PageView FlexForm.

Related to https://github.com/kitodo/kitodo-presentation/pull/1252.