### PR TITLE
[MAINTENANCE] Use camelCase names in navigation configuration

### DIFF
--- a/Configuration/FlexForms/Navigation.xml
+++ b/Configuration/FlexForms/Navigation.xml
@@ -29,8 +29,8 @@
                                 <renderType>selectMultipleSideBySide</renderType>
                                 <items>
                                     <numIndex index="0">
-                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.doublepage</numIndex>
-                                        <numIndex index="1">doublepage</numIndex>
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.doublePage</numIndex>
+                                        <numIndex index="1">doublePage</numIndex>
                                     </numIndex>
                                     <numIndex index="1">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageFirst</numIndex>
@@ -45,8 +45,8 @@
                                         <numIndex index="1">pageStepBack</numIndex>
                                     </numIndex>
                                     <numIndex index="4">
-                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageselect</numIndex>
-                                        <numIndex index="1">pageselect</numIndex>
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageSelect</numIndex>
+                                        <numIndex index="1">pageSelect</numIndex>
                                     </numIndex>
                                     <numIndex index="5">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.pageForward</numIndex>
@@ -61,8 +61,8 @@
                                         <numIndex index="1">pageLast</numIndex>
                                     </numIndex>
                                     <numIndex index="8">
-                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.listview</numIndex>
-                                        <numIndex index="1">listview</numIndex>
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.listView</numIndex>
+                                        <numIndex index="1">listView</numIndex>
                                     </numIndex>
                                     <numIndex index="9">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.zoom</numIndex>
@@ -81,7 +81,7 @@
                                         <numIndex index="1">measureBack</numIndex>
                                     </numIndex>
                                 </items>
-                                <default>doublepage,pageFirst,pageBack,pageStepBack,pageselect,pageForward,pageStepForward,pageLast,listview,zoom,rotation,measureForward,measureBack</default>
+                                <default>doublePage,pageFirst,pageBack,pageStepBack,pageSelect,pageForward,pageStepForward,pageLast,listView,zoom,rotation,measureForward,measureBack</default>
                                 <minitems>1</minitems>
                             </config>
                         </TCEforms>
@@ -101,7 +101,7 @@
                     <settings.targetPid>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <displayCond>FIELD:settings.features:IN:listview</displayCond>
+                            <displayCond>FIELD:settings.features:IN:listView</displayCond>
                             <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:flexform.targetPidListView</label>
                             <config>
                                 <type>group</type>

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -542,7 +542,7 @@ Navigation
    :Default:
       By default all features are activated. The selection is stored as comma separated list.
 
-       doublepage,pageFirst,pageBack,pageStepBack,pageselect,pageForward,pageStepForward,pageLast,listview,zoom,rotation,measureForward,measureBack
+       doublePage,pageFirst,pageBack,pageStepBack,pageSelect,pageForward,pageStepForward,pageLast,litView,zoom,rotation,measureForward,measureBack
 
  - :Property:
        pageStep

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -253,11 +253,11 @@
 				<source><![CDATA[Show selected navigation features]]></source>
 				<target><![CDATA[Zeige ausgewählte Navigations-Funktionen]]></target>
 			</trans-unit>
-			<trans-unit id="plugins.navigation.flexform.features.doublepage" approved="yes">
+			<trans-unit id="plugins.navigation.flexform.features.doublePage" approved="yes">
 				<source><![CDATA[Buttons for double page mode and recto/verso adjustment]]></source>
 				<target><![CDATA[Buttons für Doppelseitenansicht und Recto/Verso-Korrektur]]></target>
 			</trans-unit>
-			<trans-unit id="plugins.navigation.flexform.features.listview" approved="yes">
+			<trans-unit id="plugins.navigation.flexform.features.listView" approved="yes">
 				<source><![CDATA[Link to page with listview plugin]]></source>
 				<target><![CDATA[Link zur Listenansicht]]></target>
 			</trans-unit>
@@ -285,7 +285,7 @@
 				<source><![CDATA[Forward X pages]]></source>
 				<target><![CDATA[X Seiten vor]]></target>
 			</trans-unit>
-			<trans-unit id="plugins.navigation.flexform.features.pageselect" approved="yes">
+			<trans-unit id="plugins.navigation.flexform.features.pageSelect" approved="yes">
 				<source><![CDATA[Page navigation menu]]></source>
 				<target><![CDATA[Seitennavigation]]></target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -197,13 +197,13 @@
 			<trans-unit id="plugins.navigation.flexform.features.zoom">
 				<source><![CDATA[Buttons for zoom-in, zoom-out and full screen]]></source>
 			</trans-unit>
-			<trans-unit id="plugins.navigation.flexform.features.doublepage">
+			<trans-unit id="plugins.navigation.flexform.features.doublePage">
 				<source><![CDATA[Buttons for double page mode and recto/verso adjustment]]></source>
 			</trans-unit>
-			<trans-unit id="plugins.navigation.flexform.features.pageselect">
+			<trans-unit id="plugins.navigation.flexform.features.pageSelect">
 				<source><![CDATA[Page navigation menu]]></source>
 			</trans-unit>
-			<trans-unit id="plugins.navigation.flexform.features.listview">
+			<trans-unit id="plugins.navigation.flexform.features.listView">
 				<source><![CDATA[Link to page with listview plugin]]></source>
 			</trans-unit>
 			<trans-unit id="plugins.navigation.flexform.features.measureForward">

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -20,7 +20,7 @@
 </f:for>
 
 <f:comment>One section for each feature.</f:comment>
-<f:section name="render.doublepage">
+<f:section name="render.doublePage">
     <f:if condition="{numPages} > 0">
         <f:then>
             <f:if condition="{viewData.requestData.double}">
@@ -122,7 +122,7 @@
     </div>
 </f:section>
 
-<f:section name="render.pageselect">
+<f:section name="render.pageSelect">
     <li class="pages">
         <f:form method="post" action="pageSelect" controller="Navigation" name="pageSelectForm" object="{pageSelectForm}" addQueryString="1">
             <f:if condition="{viewData.requestData.id}">
@@ -200,7 +200,7 @@
     </div>
 </f:section>
 
-<f:section name="render.listview">
+<f:section name="render.listView">
         <div class="tx-dlf-navigation-listview">
             <f:link.page pageUid="{settings.targetPid}" additionalParams="{lastSearchParams}">
                 <f:translate key="linkToList"/>


### PR DESCRIPTION
Some names of features use camelCase, some don't. This PR unifies the naming.