### PR TITLE
[BUGFIX] Removal of () around link of the Solr OCR Highlighting plugin

### DIFF
--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -185,7 +185,7 @@ To setup Apache Solr, perform the following steps:
 
 3. Get the Solr OCR Highlighting plugin and put it into contrib-directory.
 
-   The plugin is available on GitHub (https://github.com/dbmdz/solr-ocrhighlighting/releases).
+   The plugin is available on GitHub: https://github.com/dbmdz/solr-ocrhighlighting/releases.
    The documentation can be found here: https://dbmdz.github.io/solr-ocrhighlighting/.
 
    The Solr OCR Highlighting plugin is required for full text search as of Kitodo.Presentation 3.3.


### PR DESCRIPTION
corrects the generated link in docs.typo3.org

The generated link is displayed on the page https://docs.typo3.org/p/kitodo/presentation/main/en-us/Configuration/Index.html#system-setup