### PR TITLE
[BUGFIX] Refactor type casting for pid in SearchInDocument

### DIFF
--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -93,7 +93,7 @@ class SearchInDocument implements MiddlewareInterface
             $highlighting = $data['ocrHighlighting'];
 
             $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-            $site = $siteFinder->getSiteByPageId($parameters['pid']);
+            $site = $siteFinder->getSiteByPageId((int)$parameters['pid']);
 
             // @phpstan-ignore-next-line
             foreach ($result as $record) {

--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -93,7 +93,7 @@ class SearchInDocument implements MiddlewareInterface
             $highlighting = $data['ocrHighlighting'];
 
             $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-            $site = $siteFinder->getSiteByPageId((int)$parameters['pid']);
+            $site = $siteFinder->getSiteByPageId((int) $parameters['pid']);
 
             // @phpstan-ignore-next-line
             foreach ($result as $record) {

--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -479,7 +479,7 @@
 			<trans-unit id="tt_content.dlf_toolbox">
 				<source>DLF: Toolbox</source>
 			</trans-unit>
-			<trans-unit id="config.metadataFormats">
+			<trans-unit id="config.general.metadataFormats">
 				<source>Default metadata namespaces</source>
 			</trans-unit>
 			<trans-unit id="config.general.enableInternalProxy">


### PR DESCRIPTION
and use nested extension configuration in language labels