### PR TITLE
[BUGFIX] Get issue title from the day if the issue itself doesn't contain correct date

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -489,10 +489,8 @@ class CalendarController extends AbstractController
             foreach ($year['children'] as $month) {
                 foreach ($month['children'] as $day) {
                     foreach ($day['children'] as $issue) {
-                        $title = $issue['label'] ?: $issue['orderlabel'];
-                        if (strtotime($title) !== false) {
-                            $title = strftime('%x', strtotime($title));
-                        }
+                        $label = $issue['label'] ?: $issue['orderlabel'];
+                        $title = $this->getIssueTitle($day['orderlabel'], $label);
 
                         yield [
                             'uid' => $issue['points'],
@@ -503,6 +501,29 @@ class CalendarController extends AbstractController
                 }
             }
         }
+    }
+
+    /**
+     * Get the issue title from issue label if this one is actually
+     * longer than the day label.
+     *
+     * @param string $dayLabel
+     * @param string $issueLabel
+     *
+     * @return string
+     */
+    private function getIssueTitle($dayLabel, $issueLabel): string {
+        if (strlen($dayLabel) > strlen($issueLabel)) {
+            if (strtotime($dayLabel) !== false) {
+                return strftime('%x', strtotime($dayLabel));
+            }
+        }
+
+        if (strtotime($issueLabel) !== false) {
+            return strftime('%x', strtotime($issueLabel));
+        }
+
+        return $issueLabel;
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/slub/dfg-viewer/issues/306

Problem here is actually a bit more complicated. This fix corrects the error introduced into the METS file. The _issue_ elements don't have correct date in the `orderlabel` attribute and then when casting to date happens it always cast to the first day of the given month. Previous version of kitodo had this 'fix' to correct the wrong data in file.


Example:
https://digital.slub-dresden.de/data/kitodo/TheDarea_416971482-1910/TheDarea_416971482-1910_mets.xml

```
<mets:div ID="uuid-5c2f6124-bbd4-4a26-a18f-e9d6842ebac3" TYPE="day" ORDER="4" ORDERLABEL="1910-01-06">
    <mets:div ID="uuid-96f00ace-c398-41e2-9fa9-b5a7b811d8e0" TYPE="issue" ORDER="1" ORDERLABEL="1910-01">
        <mets:mptr LOCTYPE="URL" xlink:href="https://digital.slub-dresden.de/data/kitodo/TheDarea_416971482-19100106/TheDarea_416971482-19100106_mets.xml"/>
    </mets:div>
</mets:div>
```

@sebastian-meyer @MarcMoschSLUB should we include this fix or just accept that produced data was wrong and display it as such?