### PR TITLE
[FEATURE] Add MIME type filter to ensure only supported image files are downloaded

### DIFF
--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -296,8 +296,7 @@ class ToolboxController extends AbstractController
         "image/x-portable-anymap",
         "image/x-portable-bitmap",
         "image/x-portable-graymap",
-        "image/x-portable-pixmap",
-        "application/pdf"
+        "image/x-portable-pixmap"
     ];
 
     /**

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -269,6 +269,38 @@ class ToolboxController extends AbstractController
     }
 
     /**
+     * List of common web image mimetypes
+     * The MIMETYPE attribute must specify the media type of the digital representation. All web-compatible formats as per RFC2046 are allowed.
+     */
+    private const IMAGE_MIMETYPES = [
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/gif",
+        "image/bmp",
+        "image/tiff",
+        "image/x-tiff",
+        "image/webp",
+        "image/svg+xml",
+        "image/vnd.microsoft.icon",
+        "image/x-icon",
+        "image/heif",
+        "image/heic",
+        "image/vnd.adobe.photoshop",
+        "image/x-xbitmap",
+        "image/x-xpixmap",
+        "image/jp2",
+        "image/jpx",
+        "image/jpm",
+        "image/mj2",
+        "image/x-portable-anymap",
+        "image/x-portable-bitmap",
+        "image/x-portable-graymap",
+        "image/x-portable-pixmap",
+        "application/pdf"
+    ];
+
+    /**
      * Renders the image download tool
      * Renders the image download tool (used in template)
      * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
@@ -291,12 +323,37 @@ class ToolboxController extends AbstractController
 
         $imageArray = [];
         // Get left or single page download.
-        $imageArray[0] = $this->getImage($this->requestData['page']);
+        $image = $this->getImage($this->requestData['page']);
+        if ($this->filterImageFiles($image)) {
+            $imageArray[0] = $image;
+        }
+
         if ($this->requestData['double'] == 1) {
-            $imageArray[1] = $this->getImage($this->requestData['page'] + 1);
+            $image = $this->getImage($this->requestData['page'] + 1);
+            if ($this->filterImageFiles($image)) {
+                $imageArray[1] = $image;
+            }
         }
 
         $this->view->assign('imageDownload', $imageArray);
+    }
+
+    /**
+     * Filters an image file based on its mimetype.
+     *
+     * This method checks if the provided image array contains a 'mimetype' key and
+     * verifies if the mimetype is one of the supported image types defined in the class constant IMAGE_MIMETYPES.
+     *
+     * @param mixed $image The image array to filter
+     *
+     * @return bool True if the image mimetype is supported, false otherwise
+     */
+    private function filterImageFiles($image): bool
+    {
+        if (is_array($image) && isset($image['mimetype'])) {
+            return in_array($image['mimetype'], self::IMAGE_MIMETYPES);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
The filter is necessary because the method would otherwise let the user download any file present in mets:fileGrp DEFAULT.