### PR TITLE
[BUGFIX] Check if array is not null before checking for the existence of the key

### DIFF
--- a/Classes/Controller/ListViewController.php
+++ b/Classes/Controller/ListViewController.php
@@ -81,7 +81,7 @@ class ListViewController extends AbstractController
 
         // extract collection(s) from collection parameter
         $collections = [];
-        if (array_key_exists('collection', $this->searchParams)) {
+        if (is_array($this->searchParams) && array_key_exists('collection', $this->searchParams)) {
             foreach(explode(',', $this->searchParams['collection']) as $collectionEntry) {
                 $collections[] = $this->collectionRepository->findByUid((int) $collectionEntry);
             }


### PR DESCRIPTION
Fix for

`PHP Warning: array_key_exists() expects parameter 2 to be array, null given in /var/www/webroot/public/typo3conf/ext/dlf/Classes/Controller/ListViewController.php line 84`