### PR TITLE
[MAINTENANCE] Sanitize settings from FlexForm

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -277,6 +277,55 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     }
 
     /**
+     * Sanitize settings from FlexForm.
+     *
+     * @access protected
+     *
+     * @return void
+     */
+    protected function sanitizeSettings(): void
+    {
+        $this->setDefaultIntSetting('storagePid', 0);
+
+        if ($this instanceof MetadataController) {
+            $this->setDefaultIntSetting('rootline', 0);
+            $this->setDefaultIntSetting('originalIiifMetadata', 0);
+            $this->setDefaultIntSetting('displayIiifDescription', 1);
+            $this->setDefaultIntSetting('displayIiifRights', 1);
+            $this->setDefaultIntSetting('displayIiifLinks', 1);
+        }
+
+        if ($this instanceof OaiPmhController) {
+            $this->setDefaultIntSetting('limit', 5);
+            $this->setDefaultIntSetting('solr_limit', 50000);
+        }
+
+        if ($this instanceof PageViewController) {
+            $this->setDefaultIntSetting('useInternalProxy', 0);
+        }
+    }
+
+    /**
+     * Sets default value for setting if not yet set.
+     *
+     * @access protected
+     *
+     * @param string $setting name of setting
+     * @param int $value for being set if empty
+     *
+     * @return void
+     */
+    protected function setDefaultIntSetting(string $setting, int $value): void
+    {
+        if (empty($this->settings[$setting])) {
+            $this->settings[$setting] = $value;
+            $this->logger->warning('Setting "' . $setting . '" not set, using default value "' . $value . '". Probably FlexForm for controller "' . get_class($this) . '" is not read.');
+        } else {
+            $this->settings[$setting] = (int) $this->settings[$setting];
+        }
+    }
+
+    /**
      * Sets page value.
      *
      * @access protected
@@ -533,7 +582,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
             // Make sure configuration PID is set when applicable
             if ($doc->cPid == 0) {
-                $doc->cPid = max((int) $this->settings['storagePid'], 0);
+                $doc->cPid = max($this->settings['storagePid'], 0);
             }
 
             $this->document->setLocation($documentId);

--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -107,15 +107,9 @@ class MetadataController extends AbstractController
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return;
-        } else {
-            // Set default values if not set.
-            $this->setDefault('rootline', 0);
-            $this->setDefault('originalIiifMetadata', 0);
-            $this->setDefault('displayIiifDescription', 1);
-            $this->setDefault('displayIiifRights', 1);
-            $this->setDefault('displayIiifLinks', 1);
-            $this->setPage();
         }
+
+        $this->setPage();
 
         $this->currentDocument = $this->document->getCurrentDocument();
         $this->useOriginalIiifManifestMetadata = $this->settings['originalIiifMetadata'] == 1 && $this->currentDocument instanceof IiifManifest;
@@ -528,22 +522,5 @@ class MetadataController extends AbstractController
             }
         }
         return $metadata;
-    }
-
-    /**
-     * Sets default value for setting if not yet set.
-     *
-     * @access private
-     *
-     * @param string $setting name of setting
-     * @param int $value 0 or 1
-     *
-     * @return void
-     */
-    private function setDefault(string $setting, int $value): void
-    {
-        if (!isset($this->settings[$setting])) {
-            $this->settings[$setting] = $value;
-        }
     }
 }

--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -645,8 +645,8 @@ class OaiPmhController extends AbstractController
             $this->logger->error('Apache Solr not available');
             return $documentSet;
         }
-        if ((int) $this->settings['solr_limit'] > 0) {
-            $solr->limit = (int) $this->settings['solr_limit'];
+        if ($this->settings['solr_limit'] > 0) {
+            $solr->limit = $this->settings['solr_limit'];
         }
         // We only care about the UID in the results and want them sorted
         $parameters = [
@@ -785,7 +785,7 @@ class OaiPmhController extends AbstractController
      */
     protected function generateOutputForDocumentList(array $documentListSet)
     {
-        $documentsToProcess = array_splice($documentListSet['elements'], 0, (int) $this->settings['limit']);
+        $documentsToProcess = array_splice($documentListSet['elements'], 0, $this->settings['limit']);
         if (empty($documentsToProcess)) {
             $this->error = 'noRecordsMatch';
             return [];

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -503,7 +503,7 @@ class PageViewController extends AbstractController
                         'score' => $docScore,
                         'annotationContainers' => $docAnnotationContainers,
                         'measureCoords' => $docMeasures['measureCoordsCurrentSite'],
-                        'useInternalProxy' => $this->settings['useInternalProxy'] ? 1 : 0,
+                        'useInternalProxy' => $this->settings['useInternalProxy'],
                         'currentMeasureId' => $currentMeasureId,
                         'measureIdLinks' => $docMeasures['measureLinks']
                     ];
@@ -539,7 +539,7 @@ class PageViewController extends AbstractController
                 'score' => $this->scores,
                 'annotationContainers' => $this->annotationContainers,
                 'measureCoords' => $docMeasures['measureCoordsCurrentSite'],
-                'useInternalProxy' => $this->settings['useInternalProxy'] ? 1 : 0,
+                'useInternalProxy' => $this->settings['useInternalProxy'],
                 'verovioAnnotations' => $this->verovioAnnotations,
                 'currentMeasureId' => $currentMeasureId,
                 'measureIdLinks' => $docMeasures['measureLinks']


### PR DESCRIPTION
Avoid necessity of int casting in the places where missing setting is used and log the cases of missing FlexForm setting (it can also point that the FlexForm is actually not read).