### PR TITLE
[MAINTENANCE] Restrict GitHub CI to use Solr 9.6 due to issues with 9.7

### DIFF
--- a/Build/Test/docker-compose.yml
+++ b/Build/Test/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       "
 
   solr:
-    image: docker.io/solr:9
+    image: docker.io/solr:9.6
     volumes:
       - ${DLF_ROOT}/Configuration/ApacheSolr/configsets:/var/solr/data/configsets
       - ./solr/modules/ocrsearch:/opt/solr/modules/ocrsearch


### PR DESCRIPTION
There is an issue with Solr 9.7, see https://github.com/dbmdz/solr-ocrhighlighting/issues/457. Until this problem is fixed, I suggest to restrict automated GitHub CI tests to Solr 9.6.