### PR TITLE
[BUGFIX] Fix logger for score file groups

### DIFF
--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -416,7 +416,7 @@ class PageViewController extends AbstractController
         }
 
         if (empty($score)) {
-            $this->logger->notice('No score file found for page "' . $page . '" in fileGrps "' . ($this->settings['fileGrpScore'] ?? '') . '"');
+            $this->logger->notice('No score file found for page "' . $page . '" in fileGrps "' . ($this->extConf['files']['fileGrpScore'] ?? '') . '"');
         }
         return $score;
     }


### PR DESCRIPTION
`fileGrpScore` comes from the extension config instead of the plugin settings