### PR TITLE
[BUGFIX]  ExpressionLanguage function `getDocumentType` of `DocumentTypeFunctionProvider` does not work correctly

### DIFF
--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -23,7 +23,6 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 use TYPO3\CMS\Core\ExpressionLanguage\RequestWrapper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 /**
@@ -59,16 +58,6 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
     protected ?Document $document;
 
     /**
-     * @var ConfigurationManager
-     */
-    protected $configurationManager;
-
-    public function injectConfigurationManager(ConfigurationManager $configurationManager): void
-    {
-        $this->configurationManager = $configurationManager;
-    }
-
-    /**
      * @var DocumentRepository
      */
     protected $documentRepository;
@@ -91,9 +80,10 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
      */
     protected function initializeRepositories(int $storagePid): void
     {
-        $frameworkConfiguration = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
-        $frameworkConfiguration['persistence']['storagePid'] = MathUtility::forceIntegerInRange((int) $storagePid, 0);
-        $this->configurationManager->setConfiguration($frameworkConfiguration);
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
+        $frameworkConfiguration = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
+        $frameworkConfiguration['persistence']['storagePid'] = MathUtility::forceIntegerInRange($storagePid, 0);
+        $configurationManager->setConfiguration($frameworkConfiguration);
         $this->documentRepository = GeneralUtility::makeInstance(DocumentRepository::class);
     }
 


### PR DESCRIPTION
- After the Typo3 12 update commit the `DocumentTypeFunctionProvider` does not work correctly
- Provider is used to get document type via Expression Language function over `getDocumentType` in Typoscript https://github.com/slub/dfg-viewer/blob/a8598f790814246242d75424199717bcd1f11993/Configuration/TypoScript/Plugins/kitodo.typoscript#L213
- Retrieve the configuration manager using GeneralUtility now