### PR TITLE
[MAINTENANCE] Fix some typos in configuration, documentation and code comments

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1508,7 +1508,7 @@ final class MetsDocument extends AbstractDocument
                 }
             }
 
-            // Get track info wtih begin end extent time for later assignment with musical
+            // Get track info with begin end extent time for later assignment with musical
             if ((string) $elementNode['TYPE'] === 'track') {
                 foreach ($elementNode->children('http://www.loc.gov/METS/')->fptr as $fptr) {
                     if (isset($fptr->area) &&  ((string) $fptr->area->attributes()->BETYPE === 'TIME')) {

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1510,7 +1510,7 @@ final class MetsDocument extends AbstractDocument
                 }
             }
 
-            // Get track info with begin end extent time for later assignment with musical
+            // Get track info with begin and extent time for later assignment with musical
             if ((string) $elementNode['TYPE'] === 'track') {
                 foreach ($elementNode->children('http://www.loc.gov/METS/')->fptr as $fptr) {
                     if (isset($fptr->area) &&  ((string) $fptr->area->attributes()->BETYPE === 'TIME')) {

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -469,7 +469,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
                 $lastStartRecordNumberGrid = $startRecordNumber; // save last $startRecordNumber for LastPage button
 
                 // array with label as screen/pagination page number
-                // and startRecordNumer for correct structure of the link
+                // and startRecordNumber for correct structure of the link
                 //<f:link.action action="{action}"
                 //      addQueryString="true"
                 //      argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}"

--- a/Classes/Task/BaseTask.php
+++ b/Classes/Task/BaseTask.php
@@ -367,11 +367,11 @@ class BaseTask extends AbstractTask
     }
 
     /**
-     * Generates and adds flash messages based on a string seperated by PHP_EOL.
+     * Generates and adds flash messages based on a string separated by PHP_EOL.
      *
      * @access protected
      *
-     * @param string $message Messages seperated by PHP_EOL
+     * @param string $message Messages separated by PHP_EOL
      * @param int $severity
      *
      * @return void

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -35,7 +35,7 @@ services:
   Kitodo\Dlf\Command\SuggestBuildCommand:
     tags:
       - name: console.command
-        command: 'kitodo:suggestBuld'
+        command: 'kitodo:suggestBuild'
 
   Kitodo\Dlf\Validation\DOMDocumentValidationStack:
     autowire: false

--- a/Documentation/Developers/Embedded3DViewer.rst
+++ b/Documentation/Developers/Embedded3DViewer.rst
@@ -95,8 +95,8 @@ Placeholders can be used within the file which is define under the ``base`` key 
      :description:              The fileserver where your resource is hosted. For example "https://example.com/my-model.glb".
 
    - :field:                    modelPath
-     :description:              Part of the ``modelUrl`` where your resource is hosted. For example, if your resource ist hosted at "https://example.com/my-model.glb", the value would be "https://example.com/static/models/".
+     :description:              Part of the ``modelUrl`` where your resource is hosted. For example, if your resource is hosted at "https://example.com/my-model.glb", the value would be "https://example.com/static/models/".
 
    - :field:                    modelResource
-     :description:              Resource part of the ``modelUrl`` with the filename to be loaded from the endpoint. For example, if your resource ist hosted at "https://example.com/my-model.glb", the value would be "my-model.glb".
+     :description:              Resource part of the ``modelUrl`` with the filename to be loaded from the endpoint. For example, if your resource is hosted at "https://example.com/my-model.glb", the value would be "my-model.glb".
 


### PR DESCRIPTION
Most of them were found using `codespell` and `typos`.