### PR TITLE
[MAINTENANCE] Fix Typo3 v11 TCA migration warning 89672

### DIFF
--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -44,7 +44,6 @@ return [
         ],
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_dlf_libraries.php
+++ b/Configuration/TCA/tx_dlf_libraries.php
@@ -38,7 +38,6 @@ return [
         ],
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -41,7 +41,6 @@ return [
         ],
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',

--- a/Configuration/TCA/tx_dlf_structures.php
+++ b/Configuration/TCA/tx_dlf_structures.php
@@ -41,7 +41,6 @@ return [
         ],
         'l18n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',


### PR DESCRIPTION
There are still TCA migration warnings in Typo3 v11, see [Changelog-89672](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.3/Important-89672-TransOrigPointerFieldIsNotLongerAllowedToBeExcluded.html). 

> The 'tx_dlf_collections' TCA tables transOrigPointerField 'l18n_parent' is defined as excluded field which is no longer needed and should therefore be removed.
> The 'tx_dlf_libraries' TCA tables transOrigPointerField 'l18n_parent' is defined as excluded field which is no longer needed and should therefore be removed.
> The 'tx_dlf_metadata' TCA tables transOrigPointerField 'l18n_parent' is defined as excluded field which is no longer needed and should therefore be removed.
> The 'tx_dlf_structures' TCA tables transOrigPointerField 'l18n_parent' is defined as excluded field which is no longer needed and should therefore be removed. 

This pull request removes the respective `exclude` option. 

There are currently problems with translations in the master branch (see #1365), which makes this difficult to test. However, it looks like this change doesn't make things worse.