### PR TITLE
[MAINTENANCE] Change log level to INFO

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -336,7 +336,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     {
         if (!array_key_exists($setting, $this->settings) || empty($this->settings[$setting])) {
             $this->settings[$setting] = $value;
-            $this->logger->info('Setting "' . $setting . '" not set, using default value "' . $value . ' in "' . get_class($this) . '".');
+            $this->logger->info('Setting "' . $setting . '" not set, using default value "' . $value . '" in ' . get_class($this) . '.');
         } else {
             $this->settings[$setting] = (int) $this->settings[$setting];
         }

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -336,7 +336,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     {
         if (!array_key_exists($setting, $this->settings) || empty($this->settings[$setting])) {
             $this->settings[$setting] = $value;
-            $this->logger->warning('Setting "' . $setting . '" not set, using default value "' . $value . '". Probably FlexForm for controller "' . get_class($this) . '" is not read.');
+            $this->logger->info('Setting "' . $setting . '" not set, using default value "' . $value . ' in "' . get_class($this) . '".');
         } else {
             $this->settings[$setting] = (int) $this->settings[$setting];
         }


### PR DESCRIPTION
Using default should not be a warning because it signals a problem and distracts from actual issues.

The following warning will be shown in the log.
```
Setting "displayIiifDescription" not set, using default value "1". Probably FlexForm for controller "Kitodo\Dlf\Controller\MetadataController" is not read. 
```
I think it's useful to inform about configuration decisions without signaling a problem. I'll adjust the message accordingly.
