### PR TITLE
[FEATURE] Seamless document browsing

### DIFF
--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -78,6 +78,14 @@ class NavigationController extends AbstractController
             $this->viewData['requestData'] = $this->requestData;
         }
 
+        // get the closest previous sibling or leaf node
+        $prevDocumentUid = $this->documentRepository->getPreviousDocumentUid($this->document->getUid());
+        $this->view->assign('documentBack', $prevDocumentUid);
+        
+        // get the closest next sibling or leaf node
+        $nextDocumentUid = $this->documentRepository->getNextDocumentUid($this->document->getUid());
+        $this->view->assign('documentForward', $nextDocumentUid);
+
         // Steps for X pages backward / forward. Double page view uses double steps.
         $pageSteps = $this->settings['pageStep'] * ($this->requestData['double'] + 1);
 

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -81,7 +81,7 @@ class NavigationController extends AbstractController
         // get the closest previous sibling or leaf node
         $prevDocumentUid = $this->documentRepository->getPreviousDocumentUid($this->document->getUid());
         $this->view->assign('documentBack', $prevDocumentUid);
-        
+
         // get the closest next sibling or leaf node
         $nextDocumentUid = $this->documentRepository->getNextDocumentUid($this->document->getUid());
         $this->view->assign('documentForward', $nextDocumentUid);

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -659,36 +659,38 @@ class DocumentRepository extends Repository
     public function getPreviousDocumentUid($uid)
     {
         $currentDocument = $this->findOneByUid($uid);
-        $currentVolume = '';
-        $parentId = $currentDocument->getPartof();
+        if ($currentDocument) {
+            $currentVolume = '';
+            $parentId = $currentDocument->getPartof();
 
-        if ($parentId) {
+            if ($parentId) {
 
-            $currentVolume = (string) $currentDocument->getVolumeSorting();
+                $currentVolume = (string) $currentDocument->getVolumeSorting();
 
-            $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-            $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_dlf_documents');
+                $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+                $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_dlf_documents');
 
-            // Grab previous volume
-            $prevDocument = $queryBuilder
-                ->select(
-                    'tx_dlf_documents.uid AS uid'
-                )
-                ->from('tx_dlf_documents')
-                ->where(
-                    $queryBuilder->expr()->eq('tx_dlf_documents.partof', (int) $parentId),
-                    'tx_dlf_documents.volume_sorting < \'' . $currentVolume . '\''
-                )
-                ->add('orderBy', 'volume_sorting desc')
-                ->addOrderBy('tx_dlf_documents.volume_sorting')
-                ->execute()
-                ->fetch();
+                // Grab previous volume
+                $prevDocument = $queryBuilder
+                    ->select(
+                        'tx_dlf_documents.uid AS uid'
+                    )
+                    ->from('tx_dlf_documents')
+                    ->where(
+                        $queryBuilder->expr()->eq('tx_dlf_documents.partof', (int) $parentId),
+                        'tx_dlf_documents.volume_sorting < \'' . $currentVolume . '\''
+                    )
+                    ->add('orderBy', 'volume_sorting desc')
+                    ->addOrderBy('tx_dlf_documents.volume_sorting')
+                    ->execute()
+                    ->fetch();
 
-            if (!empty($prevDocument)) {
-                return $prevDocument['uid'];
+                if (!empty($prevDocument)) {
+                    return $prevDocument['uid'];
+                }
+
+                return $this->getLastChild($this->getPreviousDocumentUid($parentId));
             }
-
-            return $this->getLastChild($this->getPreviousDocumentUid($parentId));
         }
 
         return null;
@@ -707,36 +709,38 @@ class DocumentRepository extends Repository
     public function getNextDocumentUid($uid)
     {
         $currentDocument = $this->findOneByUid($uid);
-        $currentVolume = '';
-        $parentId = $currentDocument->getPartof();
+        if ($currentDocument) {
+            $currentVolume = '';
+            $parentId = $currentDocument->getPartof();
 
-        if ($parentId) {
+            if ($parentId) {
 
-            $currentVolume = (string) $currentDocument->getVolumeSorting();
+                $currentVolume = (string) $currentDocument->getVolumeSorting();
 
-            $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-            $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_dlf_documents');
+                $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+                $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_dlf_documents');
 
-            // Grab next volume
-            $nextDocument = $queryBuilder
-                ->select(
-                    'tx_dlf_documents.uid AS uid'
-                )
-                ->from('tx_dlf_documents')
-                ->where(
-                    $queryBuilder->expr()->eq('tx_dlf_documents.partof', (int) $parentId),
-                    'tx_dlf_documents.volume_sorting > \'' . $currentVolume . '\''
-                )
-                ->add('orderBy', 'volume_sorting asc')
-                ->addOrderBy('tx_dlf_documents.volume_sorting')
-                ->execute()
-                ->fetch();
+                // Grab next volume
+                $nextDocument = $queryBuilder
+                    ->select(
+                        'tx_dlf_documents.uid AS uid'
+                    )
+                    ->from('tx_dlf_documents')
+                    ->where(
+                        $queryBuilder->expr()->eq('tx_dlf_documents.partof', (int) $parentId),
+                        'tx_dlf_documents.volume_sorting > \'' . $currentVolume . '\''
+                    )
+                    ->add('orderBy', 'volume_sorting asc')
+                    ->addOrderBy('tx_dlf_documents.volume_sorting')
+                    ->execute()
+                    ->fetch();
 
-            if (!empty($nextDocument)) {
-                return $nextDocument['uid'];
+                if (!empty($nextDocument)) {
+                    return $nextDocument['uid'];
+                }
+
+                return $this->getFirstChild($this->getNextDocumentUid($parentId));
             }
-
-            return $this->getFirstChild($this->getNextDocumentUid($parentId));
         }
 
         return null;

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -624,6 +624,29 @@ class DocumentRepository extends Repository
     }
 
     /**
+     * Find all documents with from Solr
+     *
+     * @access private
+     *
+     * @param array|QueryResultInterface $collections
+     * @param array $settings
+     * @param array $searchParams
+     * @param QueryResult $listedMetadata
+     *
+     * @return SolrSearch
+     */
+    private function findSolr($collections, $settings, $searchParams, $listedMetadata = null, $indexedMetadata = null): SolrSearch
+    {
+        // set settings global inside this repository
+        // (may be necessary when SolrSearch calls back)
+        $this->settings = $settings;
+
+        $search = new SolrSearch($this, $collections, $settings, $searchParams, $listedMetadata, $indexedMetadata);
+        $search->prepare();
+        return $search;
+    }
+
+    /**
      * Find the uid of the previous document relative to the current document uid.
      * Otherwise backtrack the closest previous leaf node.
      *

--- a/Configuration/FlexForms/Navigation.xml
+++ b/Configuration/FlexForms/Navigation.xml
@@ -72,16 +72,24 @@
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.rotation</numIndex>
                                         <numIndex index="1">rotation</numIndex>
                                     </numIndex>
-                                    <numIndex index="10">
+                                    <numIndex index="11">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.measureForward</numIndex>
                                         <numIndex index="1">measureForward</numIndex>
                                     </numIndex>
-                                    <numIndex index="11">
+                                    <numIndex index="12">
                                         <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.measureBack</numIndex>
                                         <numIndex index="1">measureBack</numIndex>
                                     </numIndex>
+                                    <numIndex index="13">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.documentBack</numIndex>
+                                        <numIndex index="1">documentBack</numIndex>
+                                    </numIndex>
+                                    <numIndex index="14">
+                                        <numIndex index="0">LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.navigation.flexform.features.documentForward</numIndex>
+                                        <numIndex index="1">documentForward</numIndex>
+                                    </numIndex>
                                 </items>
-                                <default>doublePage,pageFirst,pageBack,pageStepBack,pageSelect,pageForward,pageStepForward,pageLast,listView,zoom,rotation,measureForward,measureBack</default>
+                                <default>doublePage,pageFirst,pageBack,pageStepBack,pageSelect,pageForward,pageStepForward,pageLast,listView,zoom,rotation,measureForward,measureBack,documentBack,documentForward</default>
                                 <minitems>1</minitems>
                             </config>
                         </TCEforms>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -293,6 +293,14 @@
 				<source><![CDATA[Next Measure]]></source>
 				<target><![CDATA[Nächster Takt]]></target>
 			</trans-unit>
+			<trans-unit id="navigation.documentBack" approved="yes">
+				<source><![CDATA[Previous document]]></source>
+				<target><![CDATA[Vorheriges Dokument]]></target>
+			</trans-unit>
+			<trans-unit id="navigation.documentForward" approved="yes">
+				<source><![CDATA[Next document]]></source>
+				<target><![CDATA[Nächstes Dokument]]></target>
+			</trans-unit>
 			<trans-unit id="search.dateFrom" approved="yes">
 				<source><![CDATA[From]]></source>
 				<target><![CDATA[Von]]></target>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -309,6 +309,14 @@
 				<source><![CDATA[One measureBack back]]></source>
 				<target><![CDATA[Ein Takt zurück]]></target>
 			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.documentBack" approved="yes">
+				<source><![CDATA[Show previous document]]></source>
+				<target><![CDATA[Ein Dokument zurück]]></target>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.documentForward" approved="yes">
+				<source><![CDATA[Show next document]]></source>
+				<target><![CDATA[Ein Dokument vor]]></target>
+			</trans-unit>
 			<trans-unit id="plugins.navigation.title" approved="yes">
 				<source><![CDATA[Kitodo: Navigation]]></source>
 				<target><![CDATA[Kitodo: Navigation]]></target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -185,6 +185,12 @@
 			<trans-unit id="nextMeasure">
 				<source><![CDATA[Next Measure]]></source>
 			</trans-unit>
+			<trans-unit id="navigation.documentBack">
+				<source><![CDATA[Previous document]]></source>
+			</trans-unit>
+			<trans-unit id="navigation.documentForward">
+				<source><![CDATA[Next document]]></source>
+			</trans-unit>
 			<trans-unit id="selectPage">
 				<source><![CDATA[Page]]></source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -212,6 +212,12 @@
 			<trans-unit id="plugins.navigation.flexform.features.measureBack">
 				<source><![CDATA[One measureBack back]]></source>
 			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.documentBack">
+				<source><![CDATA[Show previous document]]></source>
+			</trans-unit>
+			<trans-unit id="plugins.navigation.flexform.features.documentForward">
+				<source><![CDATA[Show next document]]></source>
+			</trans-unit>
 			<trans-unit id="plugins.navigation.title">
 				<source><![CDATA[Kitodo: Navigation]]></source>
 			</trans-unit>

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -302,4 +302,38 @@
     </f:if>
 </f:section>
 
+<f:section name="render.documentBack">
+    <div class="tx-dlf-navigation-documentBack">
+        <f:if condition="{documentBack}">
+            <f:then>
+                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'1', 'tx_dlf[id]': '{documentBack}'}" title="{f:translate(key: 'navigation.documentBack')}">
+                    <f:translate key="navigation.documentBack"/>
+                </f:link.action>
+            </f:then>
+            <f:else>
+                <span title="{f:translate(key: 'navigation.documentBack')}">
+                    <f:translate key="navigation.documentBack"/>
+                </span>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
+
+<f:section name="render.documentForward">
+    <div class="tx-dlf-navigation-documentForward">
+        <f:if condition="{documentForward}">
+            <f:then>
+                <f:link.action addQueryString="1" addQueryStringMethod="GET" additionalParams="{'tx_dlf[page]':'1', 'tx_dlf[id]': '{documentForward}'}" title="{f:translate(key: 'navigation.documentForward')}">
+                    <f:translate key="navigation.documentForward"/>
+                </f:link.action>
+            </f:then>
+            <f:else>
+                <span title="{f:translate(key: 'navigation.documentForward')}">
+                    <f:translate key="navigation.documentForward"/>
+                </span>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
+
 </html>


### PR DESCRIPTION
This PR adds a feature to the navigation controller, that allows navigating to the prev/next document (volume/issue/etc) relative to the currently one viewed. It implements backtracking, so that it allows for overflowing to the next leafe node if necesseary, e.g. from the last newspaper issue of the current year to the first issue of the next year (and back). Since the backtracking is recursive, this allows backtracking any depths which will very well be necessary for complex document trees from Kalliope (inventories with subinventories with subinventories etc.).

This addresses the following issue: #760 