### PR TITLE
[BUGFIX] Reverse sort the keys in JSON array

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -370,7 +370,11 @@ class Indexer
                 $solrDoc->setField('restrictions', $metadata['restrictions']);
                 $coordinates = json_decode($metadata['coordinates'][0]);
                 if (is_object($coordinates)) {
-                    $solrDoc->setField('geom', json_encode($coordinates->features[0]));
+                    $feature = (array) $coordinates->features[0];
+                    $geometry = (array) $feature['geometry'];
+                    krsort($geometry);
+                    $feature['geometry'] = $geometry;
+                    $solrDoc->setField('geom', json_encode($feature));
                 }
                 $autocomplete = self::processMetadata($document, $metadata, $solrDoc);
                 // Add autocomplete values to index.


### PR DESCRIPTION
Adjustment so `type` key is first, `coordinates` key is second.

It is actually not a problem with Kitodo but with the SOLR itself. This adjustment solves error:

```
Apache Solr threw exception: "Solr HTTP error: Bad Request (400)
{
  "responseHeader":{
    "status":400,
    "QTime":2305},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",
      "root-error-class","java.text.ParseException"],
    "msg":"ERROR: [doc=20452uuid-6613d542-b888-44b3-8496-91283a8267e2] Error adding field 'geom'='{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"coordinates\":[[[12.979074171786522,51.35455355187656],[12.742678165549023,51.30187234125975],[12.614561448882142,51.23774698707524],[12.610428651570203,51.195810322507896],[12.946838352754384,51.19322038765756],[13.019575585442539,51.24136935014246],[13.07247539103443,51.26361475158893],[13.193979632002566,51.26154586591673],[13.190673394153208,51.30445616429853],[12.980727290711684,51.31840629529299],[12.979074171786522,51.35455355187656]]],\"type\":\"Polygon\"}}' msg=Unable to parse shape given formats \"lat,lon\", \"x y\" or as GeoJSON because java.text.ParseException: Unable to make shape type: Feature input: {\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"coordinates\":[[[12.979074171786522,51.35455355187656],[12.742678165549023,51.30187234125975],[12.614561448882142,51.23774698707524],[12.610428651570203,51.195810322507896],[12.946838352754384,51.19322038765756],[13.019575585442539,51.24136935014246],[13.07247539103443,51.26361475158893],[13.193979632002566,51.26154586591673],[13.190673394153208,51.30445616429853],[12.980727290711684,51.31840629529299],[12.979074171786522,51.35455355187656]]],\"type\":\"Polygon\"}}",
    "code":400}}
```

