### PR TITLE
[FEATURE] Implement IntlDateFormatter for SolrCoreStatus timestamps

### DIFF
--- a/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
+++ b/Classes/Hooks/Form/FieldInformation/SolrCoreStatus.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Hooks\Form\FieldInformation;
 
+use IntlDateFormatter;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr\Solr;
 use TYPO3\CMS\Backend\Form\AbstractNode;
@@ -37,6 +38,14 @@ class SolrCoreStatus extends AbstractNode
     public function render(): array
     {
         $result = $this->initializeResultArray();
+
+        // Get date formatter
+        $dateFormatter = new IntlDateFormatter(
+            Helper::getLanguageService()->lang, // locale
+            IntlDateFormatter::MEDIUM,          // dateType
+            IntlDateFormatter::MEDIUM           // timeType
+        );
+
         // Show only when editing existing records.
         if ($this->data['command'] !== 'new') {
             $core = $this->data['databaseRow']['index_name'];
@@ -57,8 +66,9 @@ class SolrCoreStatus extends AbstractNode
                     $dateTimeTo = new \DateTime("@$uptimeInSeconds");
                     $uptime = $dateTimeFrom->diff($dateTimeTo)->format('%a ' . Helper::getLanguageService()->getLL('flash.days') . ', %H:%I:%S');
                     $numDocuments = $response->getNumberOfDocuments();
-                    $startTime = $response->getStartTime() ? strftime('%c', $response->getStartTime()->getTimestamp()) : 'N/A';
-                    $lastModified = $response->getLastModified() ? strftime('%c', $response->getLastModified()->getTimestamp()) : 'N/A';
+                    $startTime = $response->getStartTime() ? $dateFormatter->format($response->getStartTime()) : 'N/A';
+                    $lastModified = $response->getLastModified() ? $dateFormatter->format($response->getLastModified()) : 'N/A';
+
                     // Create flash message.
                     Helper::addMessage(
                         sprintf(Helper::getLanguageService()->getLL('flash.coreStatus'), $startTime, $uptime, $lastModified, $numDocuments),

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -579,7 +579,7 @@
                 <target><![CDATA[Fehler!]]></target>
             </trans-unit>
             <trans-unit id="flash.coreStatus" approved="yes">
-                <source><![CDATA[Start Time: %s<br />Uptime: %s<br />Last Modified: %ss<br />Number of Documents: %u]]></source>
+                <source><![CDATA[Start Time: %s<br />Uptime: %s<br />Last Modified: %s<br />Number of Documents: %u]]></source>
                 <target><![CDATA[Startzeit: %s<br />Laufzeit: %s<br />Letzte Änderung: %s<br />Anzahl Dokumente: %u]]></target>
             </trans-unit>
             <trans-unit id="flash.days" approved="yes">

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -450,7 +450,7 @@
                 <source><![CDATA[Error!]]></source>
             </trans-unit>
             <trans-unit id="flash.coreStatus" approved="yes">
-                <source><![CDATA[Start Time: %s<br />Uptime: %s<br />Last Modified: %ss<br />Number of Documents: %u]]></source>
+                <source><![CDATA[Start Time: %s<br />Uptime: %s<br />Last Modified: %s<br />Number of Documents: %u]]></source>
             </trans-unit>
             <trans-unit id="flash.days" approved="yes">
                 <source><![CDATA[days]]></source>


### PR DESCRIPTION
Due to the deprecation of `strftime()` in PHP 8.1, we are transitioning to the `IntlDateFormatter` class. This change ensures compatibility with TYPO3 v12 for the SolrCoreStatus view in the backend.