### PR TITLE
[BUGFIX] Fix GEO JSON in 4.x

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -359,7 +359,11 @@ class Indexer
             $solrDoc->setField('restrictions', $metadata['restrictions']);
             $coordinates = json_decode($metadata['coordinates'][0]);
             if (is_object($coordinates)) {
-                $solrDoc->setField('geom', json_encode($coordinates->features[0]));
+                $feature = (array) $coordinates->features[0];
+                $geometry = (array) $feature['geometry'];
+                krsort($geometry);
+                $feature['geometry'] = $geometry;
+                $solrDoc->setField('geom', json_encode($feature));
             }
             $autocomplete = [];
             foreach ($metadata as $index_name => $data) {


### PR DESCRIPTION
`type` should be first, `coordinates` should be second