### PR TITLE
[BUGFIX] Use the document cache in `getDocumentByUid()`

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -548,7 +548,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         $this->document = $this->documentRepository->findOneByIdAndSettings($documentId);
 
         if ($this->document) {
-            $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings, true);
+            $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings, false);
             // fix for count(): Argument #1 ($value) must be of type Countable|array, null given
             $this->documentArray[] = $doc;
         } else {


### PR DESCRIPTION
Several controllers rely on the retrieval of the document via `loadDocument()`. The function `getDocumentByUid()` in the `AbstractController.php` calls `AbstractDocument::getInstance()` with the `$forceReload` parameter being `true`. With this we never get the actually cached document, but instead force loading the METS-File every time.

I have tracked execution time and the change dropped the 400ms for `loadDocument()` to about 80ms on a typical document with several hundred pages. Since we use multiple controllers in a details page (pageview, navigation, etc.) this adds up pretty fast.

I believe this is just an oversight, or is there a good reason why this parameter was set to true?