### PR TITLE
[BUGFIX] Check for undefined array key for fileGrp in mets:fileSec

### DIFF
--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -321,14 +321,18 @@ class ToolboxController extends AbstractController
     private function getFile(int $page, array $fileGrps): array
     {
         $file = [];
+        $physicalStructureInfo = $this->currentDocument->physicalStructureInfo[$this->currentDocument->physicalStructure[$page]] ?? null;
         while ($fileGrp = @array_pop($fileGrps)) {
-            $physicalStructureInfo = $this->currentDocument->physicalStructureInfo[$this->currentDocument->physicalStructure[$page]];
-            $fileId = $physicalStructureInfo['files'][$fileGrp];
-            if (!empty($fileId)) {
-                $file['url'] = $this->currentDocument->getDownloadLocation($fileId);
-                $file['mimetype'] = $this->currentDocument->getFileMimeType($fileId);
+            if (isset($physicalStructureInfo['files'][$fileGrp])) {
+                $fileId = $physicalStructureInfo['files'][$fileGrp];
+                if (!empty($fileId)) {
+                    $file['url'] = $this->currentDocument->getDownloadLocation($fileId);
+                    $file['mimetype'] = $this->currentDocument->getFileMimeType($fileId);
+                } else {
+                    $this->logger->warning('File not found in fileGrp "' . $fileGrp . '"');
+                }
             } else {
-                $this->logger->warning('File not found in fileGrp "' . $fileGrp . '"');
+                $this->logger->warning('fileGrp "' . $fileGrp . '" not found in Document mets:fileSec');
             }
         }
         return $file;


### PR DESCRIPTION
If a fileGrp is set in the config but is missing in the mets:fileSec.