### PR TITLE
[BUGFIX] MIME Type Filter

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -26,6 +26,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\Resource\MimeTypeCollection;
+use TYPO3\CMS\Core\Resource\MimeTypeDetector;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -990,7 +990,7 @@ class Helper
         ];
 
         // Apply filtering to the custom dlf MIME type array
-        $filteredDlfMimeTypes = match(true) {
+        $filteredDlfMimeTypes = match (true) {
             $dlfMimeTypes === null => [],
             $dlfMimeTypes === true => $dlfMimeTypeArray,
             is_array($dlfMimeTypes) => array_intersect_key($dlfMimeTypeArray, array_flip($dlfMimeTypes)),
@@ -1001,9 +1001,10 @@ class Helper
         if (is_array($file) && isset($file[$mimeTypeKey])) {
             return in_array($file[$mimeTypeKey], $allowedMimeTypes) ||
                    in_array($file[$mimeTypeKey], $filteredDlfMimeTypes);
+        } else {
+            self::log('MIME type validation failed: File array is invalid or MIME type key is not set. File array: ' . json_encode($file) . ', mimeTypeKey: ' . $mimeTypeKey, LOG_SEVERITY_WARNING);
+            return false;
         }
-
-        return false;
     }
 
     /**

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -1002,7 +1002,7 @@ class Helper
             return in_array($file[$mimeTypeKey], $allowedMimeTypes) ||
                    in_array($file[$mimeTypeKey], $filteredDlfMimeTypes);
         } else {
-            self::log('MIME type validation failed: File array is invalid or MIME type key is not set. File array: ' . json_encode($file) . ', mimeTypeKey: ' . $mimeTypeKey, LOG_SEVERITY_WARNING);
+            self::log('MIME type validation failed: File array is invalid or MIME type key is not set. File array: ' . json_encode($file) . ', mimeTypeKey: ' . $mimeTypeKey, 2);
             return false;
         }
     }

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -30,7 +30,6 @@ use TYPO3\CMS\Core\Resource\MimeTypeDetector;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
@@ -947,21 +946,6 @@ class Helper
     }
 
     /**
-     * Extracts the file extension from a file path or URL
-     *
-     * @param string $path File path or URL
-     * @return string|null File extension in lowercase or null if not found
-     */
-    private static function getFileExtension(string $path): ?string
-    {
-        $pathInfo = GeneralUtility::makeInstance(PathUtility::class)->pathinfo($path);
-
-        return isset($pathInfo['extension'])
-            ? strtolower($pathInfo['extension'])
-            : null;
-    }
-
-    /**
      * Filters a file based on its mimetype.
      *
      * This method checks if the provided file array contains a specified mimetype key and
@@ -1004,11 +988,7 @@ class Helper
 
         // Filter file based on its MIME type
         if (!empty($fileUrl)) {
-            $fileExtension = self::getFileExtension($fileUrl);
-            if ($fileExtension === null) {
-                self::log('No file extension found in File URL for MIME type check', LOG_SEVERITY_WARNING);
-                return false;
-            }
+            $fileExtension = pathinfo($fileUrl, PATHINFO_EXTENSION);
             $assumedMimeTypesOfFile = GeneralUtility::makeInstance(MimeTypeDetector::class)->getMimeTypesForFileExtension($fileExtension);
             $mergedMimeTypes = array_merge($filteredDlfMimeTypes, $allowedMimeTypes);
 

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -952,14 +952,15 @@ class Helper
      *
      * @param mixed $file The file array to filter
      * @param array $allowedCategories The allowed MIME type categories to filter by (e.g., ['audio'], ['video'] or ['image', 'application'])
-     * @param array|null $dlfMimeTypes Optional array of custom DLF mimetype keys to filter by. Default is null.
-     *                   Pass null to use all available custom DLF mimetype keys
-     *                   Pass array of keys to use only specific types - Accepted values: 'IIIF', 'IIP', 'ZOOMIFY', 'JPG'
+     * @param null|bool|array $dlfMimeTypes Optional array of custom dlf mimetype keys to filter by. Default is null.
+     *                      - null: use no custom dlf mimetypes
+     *                      - true: use all custom dlf mimetypes
+     *                      - array: use only specific types - Accepted values: 'IIIF', 'IIP', 'ZOOMIFY', 'JPG'
      * @param string $mimeTypeKey The key used to access the mimetype in the file array (default is 'mimetype')
      *
      * @return bool True if the file mimetype belongs to any of the allowed mimetypes or matches any custom dlf mimetypes, false otherwise
      */
-    public static function filterFilesByMimeType($file, array $allowedCategories, ?array $dlfMimeTypes = null, string $mimeTypeKey = 'mimetype'): bool
+    public static function filterFilesByMimeType($file, array $allowedCategories, null|bool|array $dlfMimeTypes = null, string $mimeTypeKey = 'mimetype'): bool
     {
         if (empty($allowedCategories) && empty($dlfMimeTypes)) {
             return false;
@@ -988,9 +989,12 @@ class Helper
         ];
 
         // Apply filtering to the custom dlf MIME type array
-        $filteredDlfMimeTypes = $dlfMimeTypes === null
-            ? $dlfMimeTypeArray
-            : array_intersect_key($dlfMimeTypeArray, array_flip($dlfMimeTypes));
+        $filteredDlfMimeTypes = match(true) {
+            $dlfMimeTypes === null => [],
+            $dlfMimeTypes === true => $dlfMimeTypeArray,
+            is_array($dlfMimeTypes) => array_intersect_key($dlfMimeTypeArray, array_flip($dlfMimeTypes)),
+            default => []
+        };
 
         // Actual filtering to check if the file's MIME type is allowed
         if (is_array($file) && isset($file[$mimeTypeKey])) {

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -30,6 +30,7 @@ use TYPO3\CMS\Core\Resource\MimeTypeDetector;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
@@ -946,6 +947,21 @@ class Helper
     }
 
     /**
+     * Extracts the file extension from a file path or URL
+     *
+     * @param string $path File path or URL
+     * @return string|null File extension in lowercase or null if not found
+     */
+    private static function getFileExtension(string $path): ?string
+    {
+        $pathInfo = GeneralUtility::makeInstance(PathUtility::class)->pathinfo($path);
+
+        return isset($pathInfo['extension'])
+            ? strtolower($pathInfo['extension'])
+            : null;
+    }
+
+    /**
      * Filters a file based on its mimetype.
      *
      * This method checks if the provided file array contains a specified mimetype key and
@@ -988,7 +1004,11 @@ class Helper
 
         // Filter file based on its MIME type
         if (!empty($fileUrl)) {
-            $fileExtension = pathinfo($fileUrl, PATHINFO_EXTENSION);
+            $fileExtension = self::getFileExtension($fileUrl);
+            if ($fileExtension === null) {
+                self::log('No file extension found in File URL for MIME type check', LOG_SEVERITY_WARNING);
+                return false;
+            }
             $assumedMimeTypesOfFile = GeneralUtility::makeInstance(MimeTypeDetector::class)->getMimeTypesForFileExtension($fileExtension);
             $mergedMimeTypes = array_merge($filteredDlfMimeTypes, $allowedMimeTypes);
 

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -635,14 +635,15 @@ class PageViewController extends AbstractController
 
         foreach ($useGroups as $useGroup) {
             // Get file info for the specific page and file group
-            $file = $this->fetchFileInfo($page, $useGroup, $specificDoc);
-            if ($file && Helper::filterFilesByMimeType($file, ['image', 'application'], ['IIIF', 'IIP', 'ZOOMIFY'], 'mimeType')) {
+            $file = $this->fetchFileInfo($page, $fileGrpImages, $specificDoc);
+
+            if ($file && Helper::filterFilesByMimeType($file['location'], ['image'], ['IIIF', 'IIP', 'ZOOMIFY'])) {
                 $image['url'] = $file['location'];
                 $image['mimetype'] = $file['mimeType'];
 
                 // Only deliver static images via the internal PageViewProxy.
                 // (For IIP and IIIF, the viewer needs to build and access a separate metadata URL, see `getMetadataURL` in `OLSources.js`.)
-                if ($this->settings['useInternalProxy'] && !Helper::filterFilesByMimeType($file, ['application'], ['IIIF', 'IIP', 'ZOOMIFY'], 'mimeType')) {
+                if ($this->settings['useInternalProxy'] && !Helper::filterFilesByMimeType($file['location'], ['application'], ['IIIF', 'IIP', 'ZOOMIFY'])) {
                     $this->configureProxyUrl($image['url']);
                 }
                 break;

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -635,7 +635,7 @@ class PageViewController extends AbstractController
 
         foreach ($useGroups as $useGroup) {
             // Get file info for the specific page and file group
-            $file = $this->fetchFileInfo($page, $fileGrpImages, $specificDoc);
+            $file = $this->fetchFileInfo($page, $useGroup, $specificDoc);
 
             if ($file && Helper::filterFilesByMimeType($file, ['image'], true, 'mimeType')) {
                 $image['url'] = $file['location'];

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -637,7 +637,7 @@ class PageViewController extends AbstractController
             // Get file info for the specific page and file group
             $file = $this->fetchFileInfo($page, $fileGrpImages, $specificDoc);
 
-            if ($file && Helper::filterFilesByMimeType($file, ['image'], null, 'mimeType')) {
+            if ($file && Helper::filterFilesByMimeType($file, ['image'], true, 'mimeType')) {
                 $image['url'] = $file['location'];
                 $image['mimetype'] = $file['mimeType'];
 

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -637,13 +637,13 @@ class PageViewController extends AbstractController
             // Get file info for the specific page and file group
             $file = $this->fetchFileInfo($page, $fileGrpImages, $specificDoc);
 
-            if ($file && Helper::filterFilesByMimeType($file['location'], ['image'], ['IIIF', 'IIP', 'ZOOMIFY'])) {
+            if ($file && Helper::filterFilesByMimeType($file, ['image'], null, 'mimeType')) {
                 $image['url'] = $file['location'];
                 $image['mimetype'] = $file['mimeType'];
 
                 // Only deliver static images via the internal PageViewProxy.
                 // (For IIP and IIIF, the viewer needs to build and access a separate metadata URL, see `getMetadataURL` in `OLSources.js`.)
-                if ($this->settings['useInternalProxy'] && !Helper::filterFilesByMimeType($file['location'], ['application'], ['IIIF', 'IIP', 'ZOOMIFY'])) {
+                if ($this->settings['useInternalProxy'] && !Helper::filterFilesByMimeType($image, ['application'], ['IIIF', 'IIP', 'ZOOMIFY'])) {
                     $this->configureProxyUrl($image['url']);
                 }
                 break;

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -283,13 +283,13 @@ class ToolboxController extends AbstractController
         $imageArray = [];
         // Get left or single page download.
         $image = $this->getImage($page);
-        if (Helper::filterFilesByMimeType($image, ['image'])) {
+        if (Helper::filterFilesByMimeType($image['url'], ['image'])) {
             $imageArray[0] = $image;
         }
 
         if ($this->requestData['double'] == 1) {
             $image = $this->getImage($page + 1);
-            if (Helper::filterFilesByMimeType($image, ['image'])) {
+            if (Helper::filterFilesByMimeType($image['url'], ['image'])) {
                 $imageArray[1] = $image;
             }
         }

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -145,7 +145,11 @@ class ToolboxController extends AbstractController
         $image = $this->getFile($page, $this->useGroupsConfiguration->getImage());
         if (isset($image['mimetype'])) {
             $fileExtension = Helper::getFileExtensionsForMimeType($image['mimetype']);
-            $image['mimetypeLabel'] = !empty($fileExtension) ? ' (' . strtoupper($fileExtension[0]) . ')' : '';
+            if ($image['mimetype'] == 'image/jpg') {
+                $image['mimetypeLabel'] = ' (JPG)'; // "image/jpg" is not a valid MIME type, so we need to handle it separately.
+            } else {
+                $image['mimetypeLabel'] = !empty($fileExtension) ? ' (' . strtoupper($fileExtension[0]) . ')' : '';
+            }
         }
         return $image;
     }

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -283,13 +283,13 @@ class ToolboxController extends AbstractController
         $imageArray = [];
         // Get left or single page download.
         $image = $this->getImage($page);
-        if (Helper::filterFilesByMimeType($image['url'], ['image'])) {
+        if (isset($image['url']) && Helper::filterFilesByMimeType($image['url'], ['image'])) {
             $imageArray[0] = $image;
         }
 
         if ($this->requestData['double'] == 1) {
             $image = $this->getImage($page + 1);
-            if (Helper::filterFilesByMimeType($image['url'], ['image'])) {
+            if (isset($image['url']) && Helper::filterFilesByMimeType($image['url'], ['image'])) {
                 $imageArray[1] = $image;
             }
         }

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -283,13 +283,13 @@ class ToolboxController extends AbstractController
         $imageArray = [];
         // Get left or single page download.
         $image = $this->getImage($page);
-        if (isset($image['url']) && Helper::filterFilesByMimeType($image['url'], ['image'])) {
+        if (Helper::filterFilesByMimeType($image, ['image'])) {
             $imageArray[0] = $image;
         }
 
         if ($this->requestData['double'] == 1) {
             $image = $this->getImage($page + 1);
-            if (isset($image['url']) && Helper::filterFilesByMimeType($image['url'], ['image'])) {
+            if (Helper::filterFilesByMimeType($image, ['image'])) {
                 $imageArray[1] = $image;
             }
         }

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -283,13 +283,13 @@ class ToolboxController extends AbstractController
         $imageArray = [];
         // Get left or single page download.
         $image = $this->getImage($page);
-        if (Helper::filterFilesByMimeType($image, ['image'])) {
+        if (Helper::filterFilesByMimeType($image, ['image'], true)) {
             $imageArray[0] = $image;
         }
 
         if ($this->requestData['double'] == 1) {
             $image = $this->getImage($page + 1);
-            if (Helper::filterFilesByMimeType($image, ['image'])) {
+            if (Helper::filterFilesByMimeType($image, ['image'], true)) {
                 $imageArray[1] = $image;
             }
         }

--- a/Tests/Unit/Common/HelperTest.php
+++ b/Tests/Unit/Common/HelperTest.php
@@ -23,27 +23,27 @@ class HelperTest extends UnitTestCase
 {
     /**
      * @var bool
-    */
+     */
     protected bool $resetSingletonInstances = true;
 
     /**
      * @var LogManager|MockObject
-    */
+     */
     protected $logManagerMock;
 
     /**
      * @var Logger|MockObject
-    */
+     */
     protected $loggerMock;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        // Logger Mock erstellen
+        // create Logger Mock
         $this->loggerMock = $this->createMock(Logger::class);
 
-        // LogManager Mock erstellen
+        // create LogManager Mock
         $this->logManagerMock = $this->createMock(LogManager::class);
         $this->logManagerMock->method('getLogger')->willReturn($this->loggerMock);
 
@@ -286,14 +286,14 @@ XML;
             $imageFile,
             ['image'],
             null
-            ), 'Standard image type should be accepted when DLF types are null'
+        ), 'Standard image type should be accepted when DLF types are null'
         );
 
         self::assertFalse(Helper::filterFilesByMimeType(
             $iiifFile,
             ['image'],
             null
-            ), 'DLF type should be rejected when DLF types are null'
+        ), 'DLF type should be rejected when DLF types are null'
         );
 
         // Test: All DLF MIME Types
@@ -301,14 +301,14 @@ XML;
             $iiifFile,
             ['image'],
             true
-            ), 'IIIF should be accepted when all DLF types are enabled'
+        ), 'IIIF should be accepted when all DLF types are enabled'
         );
 
         self::assertTrue(Helper::filterFilesByMimeType(
             $iipFile,
             ['image'],
             true
-            ), 'IIP should be accepted when all DLF types are enabled'
+        ), 'IIP should be accepted when all DLF types are enabled'
         );
 
         // Test: Spezific DLF MIME Types
@@ -316,14 +316,14 @@ XML;
             $iiifFile,
             ['image'],
             ['IIIF']
-            ), 'IIIF should be accepted when specifically allowed'
+        ), 'IIIF should be accepted when specifically allowed'
         );
 
         self::assertFalse(Helper::filterFilesByMimeType(
             $iipFile,
             ['image'],
             ['IIIF']
-            ), 'IIP should be rejected when not in allowed DLF types'
+        ), 'IIP should be rejected when not in allowed DLF types'
         );
     }
 }

--- a/Tests/Unit/Common/HelperTest.php
+++ b/Tests/Unit/Common/HelperTest.php
@@ -13,10 +13,49 @@
 namespace Kitodo\Dlf\Tests\Unit\Common;
 
 use Kitodo\Dlf\Common\Helper;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Log\Logger;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class HelperTest extends UnitTestCase
 {
+    /**
+     * @var bool
+    */
+    protected bool $resetSingletonInstances = true;
+
+    /**
+     * @var LogManager|MockObject
+    */
+    protected $logManagerMock;
+
+    /**
+     * @var Logger|MockObject
+    */
+    protected $loggerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Logger Mock erstellen
+        $this->loggerMock = $this->createMock(Logger::class);
+
+        // LogManager Mock erstellen
+        $this->logManagerMock = $this->createMock(LogManager::class);
+        $this->logManagerMock->method('getLogger')->willReturn($this->loggerMock);
+
+        GeneralUtility::setSingletonInstance(LogManager::class, $this->logManagerMock);
+    }
+
+    protected function tearDown(): void
+    {
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
     public function assertInvalidXml($xml)
     {
         $result = Helper::getXmlFileAsString($xml);
@@ -55,7 +94,6 @@ XML;
         self::assertIsObject($node);
         self::assertEquals('root', $node->getName());
     }
-
 
     /**
      * @test

--- a/Tests/Unit/Common/HelperTest.php
+++ b/Tests/Unit/Common/HelperTest.php
@@ -206,7 +206,7 @@ XML;
      * @test
      * @group filterFilesByMimeType
      */
-    public function filterFilesByMimeTypeHandlesWrongJPG(): void
+    public function filterFilesByMimeTypeHandlesWrongJpg(): void
     {
         $wrongJpg = ['mimetype' => 'image/jpg'];
 
@@ -248,38 +248,44 @@ XML;
             $imageFile,
             ['image'],
             null
-        ), 'Standard image type should be accepted when DLF types are null');
+            ), 'Standard image type should be accepted when DLF types are null'
+        );
 
         self::assertFalse(Helper::filterFilesByMimeType(
             $iiifFile,
             ['image'],
             null
-        ), 'DLF type should be rejected when DLF types are null');
+            ), 'DLF type should be rejected when DLF types are null'
+        );
 
         // Test: All DLF MIME Types
         self::assertTrue(Helper::filterFilesByMimeType(
             $iiifFile,
             ['image'],
             true
-        ), 'IIIF should be accepted when all DLF types are enabled');
+            ), 'IIIF should be accepted when all DLF types are enabled'
+        );
 
         self::assertTrue(Helper::filterFilesByMimeType(
             $iipFile,
             ['image'],
             true
-        ), 'IIP should be accepted when all DLF types are enabled');
+            ), 'IIP should be accepted when all DLF types are enabled'
+        );
 
         // Test: Spezific DLF MIME Types
         self::assertTrue(Helper::filterFilesByMimeType(
             $iiifFile,
             ['image'],
             ['IIIF']
-        ), 'IIIF should be accepted when specifically allowed');
+            ), 'IIIF should be accepted when specifically allowed'
+        );
 
         self::assertFalse(Helper::filterFilesByMimeType(
             $iipFile,
             ['image'],
             ['IIIF']
-        ), 'IIP should be rejected when not in allowed DLF types');
+            ), 'IIP should be rejected when not in allowed DLF types'
+        );
     }
 }

--- a/Tests/Unit/Common/HelperTest.php
+++ b/Tests/Unit/Common/HelperTest.php
@@ -55,4 +55,231 @@ XML;
         self::assertIsObject($node);
         self::assertEquals('root', $node->getName());
     }
+
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeHandlesInvalidInput(): void
+    {
+        // Empty categories and types
+        self::assertFalse(Helper::filterFilesByMimeType(
+            ['mimetype' => 'image/jpeg'],
+            [],
+            null
+        ));
+
+        // Invalid file input
+        self::assertFalse(Helper::filterFilesByMimeType(
+            null,
+            ['image'],
+            null
+        ));
+
+        // Missing mime type key
+        self::assertFalse(Helper::filterFilesByMimeType(
+            ['wrong_key' => 'image/jpeg'],
+            ['image'],
+            null
+        ));
+    }
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeAcceptsStandardMimeTypes(): void
+    {
+        $file = ['mimetype' => 'image/jpeg'];
+
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $file,
+            ['image']
+        ));
+
+        self::assertFalse(Helper::filterFilesByMimeType(
+            $file,
+            ['video']
+        ));
+
+        // Test multiple categories
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $file,
+            ['video', 'image']
+        ));
+    }
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeHandlesCustomDlfTypes(): void
+    {
+        $testCases = [
+            ['mimetype' => 'application/vnd.kitodo.iiif'],
+            ['mimetype' => 'application/vnd.netfpx'],
+            ['mimetype' => 'application/vnd.kitodo.zoomify'],
+            ['mimetype' => 'image/jpg']
+        ];
+
+        foreach ($testCases as $file) {
+            self::assertTrue(Helper::filterFilesByMimeType(
+                $file,
+                [],
+                true
+            ));
+        }
+
+        foreach ($testCases as $file) {
+            self::assertTrue(Helper::filterFilesByMimeType(
+                $file,
+                [],
+                ['IIIF', 'IIP', 'ZOOMIFY', 'JPG']
+            ));
+        }
+
+        // Test specific DLF type filtering
+        $file = ['mimetype' => 'application/vnd.kitodo.iiif'];
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $file,
+            [],
+            true
+        ));
+        self::assertFalse(Helper::filterFilesByMimeType(
+            $file,
+            [],
+            ['IIP']
+        ));
+    }
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeHandlesCustomMimeTypeKey(): void
+    {
+        $file = ['customKey' => 'image/jpeg'];
+
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $file,
+            ['image'],
+            null,
+            'customKey'
+        ));
+
+        self::assertFalse(Helper::filterFilesByMimeType(
+            $file,
+            ['image']
+        ));
+    }
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeHandlesMixedScenarios(): void
+    {
+        // Standard mime type with DLF types enabled
+        self::assertTrue(Helper::filterFilesByMimeType(
+            ['mimetype' => 'image/jpeg'],
+            ['image'],
+            ['IIIF', 'IIP']
+        ));
+
+        // DLF mime type with matching category
+        self::assertTrue(Helper::filterFilesByMimeType(
+            ['mimetype' => 'application/vnd.kitodo.iiif'],
+            ['application'],
+            ['IIIF']
+        ));
+
+        // DLF mime type with non-matching category but allowed DLF type
+        self::assertTrue(Helper::filterFilesByMimeType(
+            ['mimetype' => 'application/vnd.kitodo.iiif'],
+            ['image'],
+            ['IIIF']
+        ));
+    }
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeHandlesWrongJPG(): void
+    {
+        $wrongJpg = ['mimetype' => 'image/jpg'];
+
+        // file with wrong JPG mime type and no custom dlf mime type key
+        self::assertFalse(Helper::filterFilesByMimeType(
+            $wrongJpg,
+            ['image'],
+            []
+        ));
+
+        // file with wrong JPG mime type and custom dlf mime type key
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $wrongJpg,
+            [],
+            ['JPG']
+        ));
+
+        // file with wrong JPG mime type in allowed key and custom dlf mime type key
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $wrongJpg,
+            ['image'],
+            ['JPG']
+        ));
+    }
+
+    /**
+     * @test
+     * @group filterFilesByMimeType
+     */
+    public function filterFilesByMimeTypeHandlesDifferentDlfModeTypes(): void
+    {
+        // Test-Setup
+        $imageFile = ['mimetype' => 'image/jpeg'];
+        $iiifFile = ['mimetype' => 'application/vnd.kitodo.iiif'];
+        $iipFile = ['mimetype' => 'application/vnd.netfpx'];
+
+        // Test: No DLF MIME Types (only Standard-Types)
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $imageFile,
+            ['image'],
+            null
+        ), 'Standard image type should be accepted when DLF types are null');
+
+        self::assertFalse(Helper::filterFilesByMimeType(
+            $iiifFile,
+            ['image'],
+            null
+        ), 'DLF type should be rejected when DLF types are null');
+
+        // Test: All DLF MIME Types
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $iiifFile,
+            ['image'],
+            true
+        ), 'IIIF should be accepted when all DLF types are enabled');
+
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $iipFile,
+            ['image'],
+            true
+        ), 'IIP should be accepted when all DLF types are enabled');
+
+        // Test: Spezific DLF MIME Types
+        self::assertTrue(Helper::filterFilesByMimeType(
+            $iiifFile,
+            ['image'],
+            ['IIIF']
+        ), 'IIIF should be accepted when specifically allowed');
+
+        self::assertFalse(Helper::filterFilesByMimeType(
+            $iipFile,
+            ['image'],
+            ['IIIF']
+        ), 'IIP should be rejected when not in allowed DLF types');
+    }
 }


### PR DESCRIPTION
Fix Mime Type Filter using File Extension instead of mimetype description out of METS/MODS.
Because of inconsistent use of MIME Type description in METS mets:fileSec. 
For Example: `image/jpg` - which is not an allowed MIME Type according to iana [(www.iana.org)](https://www.iana.org/assignments/media-types/media-types.xhtml#image)

see: [https://api.deutsche-digitale-bibliothek.de/items/72OLPWCWDFDG7AVAYDDVJGMYRMZWBHDR/source/record](https://api.deutsche-digitale-bibliothek.de/items/72OLPWCWDFDG7AVAYDDVJGMYRMZWBHDR/source/record)