### PR TITLE
[BUGFIX] Re-introduce search for coordinates in ol.Feature Array

### DIFF
--- a/Resources/Public/JavaScript/PageView/PageView.js
+++ b/Resources/Public/JavaScript/PageView/PageView.js
@@ -440,6 +440,18 @@ dlfViewer.prototype.createControl = function(controlName, layers) {
 };
 
 /**
+ * Forwards the search to dlfUtils.searchFeatureCollectionForWords
+ *
+ * @param {Array.<ol.Feature>} stringFeatures - Array of features containing text information
+ * @param {string} value - Search term
+ * @returns {Array.<ol.Feature>|undefined} Array of OpenLayers features containing found words
+ * @see dlfUtils.searchFeatureCollectionForWords
+ */
+dlfViewer.prototype.searchFeatures = function(stringFeatures, value) {
+  return dlfUtils.searchFeatureCollectionForWords(stringFeatures, value);
+};
+
+/**
  * Displays highlight words
  */
 dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
@@ -491,23 +503,23 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
     }
 
     if (this.highlightWords !== null) {
-        var self = this;
-        var values = decodeURIComponent(this.highlightWords).split(';');
+        const self = this;
+        const values = decodeURIComponent(this.highlightWords).split(';');
 
         $.when.apply($, this.fulltextsLoaded_)
-            .done(function (fulltextData, fulltextDataImageTwo) {
-                var stringFeatures = [];
+            .done((fulltextData, fulltextDataImageTwo) => {
+                const stringFeatures = [];
 
-                [fulltextData, fulltextDataImageTwo].forEach(function (data) {
+                [fulltextData, fulltextDataImageTwo].forEach(data => {
                     if (data !== undefined) {
                         Array.prototype.push.apply(stringFeatures, data.getStringFeatures());
                     }
                 });
 
-                values.forEach(function(value) {
-                    var features = dlfUtils.searchFeatureCollectionForCoordinates(stringFeatures, value);
+                values.forEach((value) => {
+                    const features = this.searchFeatures(stringFeatures, value);
                     if (features !== undefined) {
-                        for (var i = 0; i < features.length; i++) {
+                        for (let i = 0; i < features.length; i++) {
                             self.highlightLayer.getSource().addFeatures([features[i]]);
                         }
                     }

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -649,8 +649,8 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, optOffs
 /**
  * Search a feature collection for a feature with the given coordinates
  * @param {Array.<ol.Feature>} featureCollection
- * @param {string} coordinates
- * @return {Array.<ol.Feature>|undefined}
+ * @param {string} coordinates for highlighting
+ * @returns {Array.<ol.Feature>|undefined}
  */
 dlfUtils.searchFeatureCollectionForCoordinates = function (featureCollection, coordinates) {
     var features = [];

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -647,12 +647,30 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, optOffs
 };
 
 /**
+ * Search a feature collection for a feature with the given coordinates
+ * @param {Array.<ol.Feature>} featureCollection
+ * @param {string} coordinates
+ * @return {Array.<ol.Feature>|undefined}
+ */
+dlfUtils.searchFeatureCollectionForCoordinates = function (featureCollection, coordinates) {
+    var features = [];
+    featureCollection.forEach(function (ft) {
+        if (ft.get('fulltext') !== undefined) {
+            if (ft.getId() === coordinates) {
+                features.push(ft);
+            }
+        }
+    });
+    return features.length > 0 ? features : undefined;
+};
+
+/**
  * Search a feature collection for a feature with the given word in its fulltext
  * @param {Array.<ol.Feature>} featureCollection
  * @param {string} word for highlighting
  * @returns {Array.<ol.Feature>|undefined}
  */
-dlfUtils.searchFeatureCollectionForCoordinates = function (featureCollection, word) {
+dlfUtils.searchFeatureCollectionForWords = function (featureCollection, word) {
     var features = [];
     featureCollection.forEach(function (ft) {
         if (ft.values_.fulltext !== undefined) {


### PR DESCRIPTION
Backport to [v5.0.x ](https://github.com/kitodo/kitodo-presentation/tree/5.0.x)
Rewrite displayHighlightWord to represent overwritable forward-function to utility.js
fixes: [slub#20](https://github.com/slub/ddb_kitodo_zeitungsportal/issues/20)