### PR TITLE
[BUGFIX] Fix passing page id in ToolboxController - but keep viewArray Key

### DIFF
--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -480,7 +480,7 @@ class ToolboxController extends AbstractController
             'labelHighlightWord' => $this->settings['highlightWordInputName'],
             'labelEncrypted' => $this->settings['encryptedInputName'],
             'documentId' => $this->getCurrentDocumentId(),
-            'documentPageId' => $this->document->getPid(),
+            'documentPageId' => $this->request->getAttribute('routing')->getPageId(),
             'solrEncrypted' => $this->getEncryptedCoreName() ? : ''
         ];
 


### PR DESCRIPTION
non breaking change for Templates of passing page id in `ToolboxController`

This is a Backport of #1372 for `5.0.x` Branch

Fixes this Request: https://github.com/kitodo/kitodo-presentation/pull/1372#issuecomment-2578048219