### PR TITLE
[FEATURE] Include facets from all associated metadata sections for fulltext pages

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -590,11 +590,7 @@ class Indexer
 
         // write all facet values of associated metadata to the page (self & ancestors)
         foreach ($facets as $indexName => $data) {
-            if (
-                !empty($data)
-            ) {
-                $solrDoc->setField($indexName . '_faceting', $data);
-            }
+            $solrDoc->setField($indexName . '_faceting', $data);
         }
 
         // add sorting information

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -455,13 +455,7 @@ class Indexer
             if (is_array($doc->metadataArray[$doc->toplevelId])) {
                 self::addFaceting($doc, $solrDoc, $physicalUnit);
             }
-            // Add collection information to physical sub-elements if applicable.
-            if (
-                in_array('collection', self::$fields['facets'])
-                && !empty($doc->metadataArray[$doc->toplevelId]['collection'])
-            ) {
-                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->toplevelId]['collection']);
-            }
+
             try {
                 $updateQuery->addDocument($solrDoc);
                 self::$solr->service->update($updateQuery);

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -453,7 +453,7 @@ class Indexer
 
             $solrDoc->setField('fulltext', $fullText);
             if (is_array($doc->metadataArray[$doc->toplevelId])) {
-                self::addFaceting($doc, $solrDoc);
+                self::addFaceting($doc, $solrDoc, $physicalUnit);
             }
             // Add collection information to physical sub-elements if applicable.
             if (
@@ -549,27 +549,56 @@ class Indexer
      *
      * @param AbstractDocument $doc
      * @param DocumentInterface &$solrDoc
+     * @param array $physicalUnit Array of the physical unit to process
      *
      * @return void
      */
-    private static function addFaceting($doc, &$solrDoc): void
+    private static function addFaceting($doc, &$solrDoc, $physicalUnit): void
     {
-        // TODO: Include also subentries if available.
-        foreach ($doc->metadataArray[$doc->toplevelId] as $indexName => $data) {
-            if (
-                !empty($data)
-                && substr($indexName, -8) !== '_sorting'
-            ) {
-
-                if (in_array($indexName, self::$fields['facets'])) {
-                    // Remove appended "valueURI" from authors' names for indexing.
-                    if ($indexName == 'author') {
-                        $data = self::removeAppendsFromAuthor($data);
+        // this variable holds all possible facet-values for the index names
+        $facets = [];
+        // use the structlink information
+        foreach ($doc->smLinks['l2p'] as $logicalId => $physicalId) {
+            // find page in structlink
+            if (in_array($physicalUnit['id'], $physicalId)) {
+                // for each associated metadata of structlink
+                foreach ($doc->metadataArray[$logicalId] as $indexName => $data) {
+                    if (
+                        !empty($data)
+                        && substr($indexName, -8) !== '_sorting'
+                    ) {
+                        if (in_array($indexName, self::$fields['facets'])) {
+                            // Remove appended "valueURI" from authors' names for indexing.
+                            if ($indexName == 'author') {
+                                $data = self::removeAppendsFromAuthor($data);
+                            }
+                            // Add facets to facet-array and flatten the values
+                            if (is_array($data)) {
+                                foreach ($data as $value) {
+                                    if (!empty($value)) {
+                                        $facets[$indexName][] = $value;
+                                    }
+                                }
+                            } else {
+                                $facets[$indexName][] = $data;
+                            }
+                        }
                     }
-                    // Add facets to index.
-                    $solrDoc->setField($indexName . '_faceting', $data);
                 }
             }
+        }
+
+        // write all facet values of associated metadata to the page (self & ancestors)
+        foreach ($facets as $indexName => $data) {
+            if (
+                !empty($data)
+            ) {
+                $solrDoc->setField($indexName . '_faceting', $data);
+            }
+        }
+
+        // add sorting information
+        foreach ($doc->metadataArray[$doc->toplevelId] as $indexName => $data) {
             // Add sorting information to physical sub-elements if applicable.
             if (
                 !empty($data)


### PR DESCRIPTION
**Problem:** Previously, full-text pages only indexed facets from the top-level element (e.g., Type: Monograph, Volume), which meant that additional metadata in other metadata sections were not utilized, even though pages were explicitly associated with these through the StructLink/structMap-Logical. Basically all extensive efforts made in Kitodo.Production to structure the document internally (apart from the bibliographic record) were not even used on the page-level.

**Solution:** This PR extends the indexing to include facets from all DMD sections associated with the page through the StructLink and StructMap-Logical as well as the corresponding (structure) type. As a result, full-text hits can now be filtered down to more granular structural elements they have been associated with (Table, Illustration, Article, Index, Entry, etc.). Additionally, any deeper metadata beneath the top-level element (bibliographic record) is now included in the indexing process as well, expanding the possibilities to filter fulltext-results further - e.g. filtering for Authors of journal-articles instead of only the editor/publisher of a journal.