### PR TITLE
[BUGFIX] Remove old code relict which creates wrong log entries

### DIFF
--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -394,10 +394,6 @@ class OaiPmhController extends AbstractController
 
         $oaiIdentifyInfo = [];
 
-        if (!$oaiIdentifyInfo) {
-            $this->logger->notice('Incomplete plugin configuration');
-        }
-
         $oaiIdentifyInfo['oai_label'] = $library ? $library->getOaiLabel() : '';
         // Use default values for an installation with incomplete plugin configuration.
         if (empty($oaiIdentifyInfo['oai_label'])) {


### PR DESCRIPTION
The conditional statement is always true which does not make sense and which can result in a log message "Incomplete plugin configuration".