### PR TITLE
[CONFIGURATION] Do not run the GitHub action deploy job in forks

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
       # Add a dependency to the build job
       needs: build
 
-      if: github.ref == 'refs/heads/main'
+      if: github.repository_owner == 'kitodo' && github.ref == 'refs/heads/main'
 
       # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
       permissions:


### PR DESCRIPTION
Forks cannot deploy the documentation, so this action always failed for the main branch of forks.