### PR TITLE
[MAINTENANCE] Drop support for PHP 7.4 and 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variants: [ {typo3: 11.5, php: 7.4}, {typo3: 12.4, php: 8.1} ]
+        variants: [ {typo3: 11.5, php: 8.1}, {typo3: 12.4, php: 8.1} ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Build/Test/runTests.sh
+++ b/Build/Test/runTests.sh
@@ -65,7 +65,7 @@ a recent docker compose (tested >=2.27.1) is needed.
 
 Usage: $0 [options] [file]
 
-No arguments: Run all unit tests with PHP 7.4
+No arguments: Run all unit tests with PHP 8.1
 
 Options:
     -s <...>
@@ -113,10 +113,8 @@ Options:
             - 5.7
             - 8.0 (default)
 
-    -p <7.4|8.0|8.1|8.2|8.3>
+    -p <8.1|8.2|8.3>
         Specifies the PHP minor version to be used
-            - 7.4: use PHP 7.4
-            - 8.0: use PHP 8.0
             - 8.1: use PHP 8.1 (default)
             - 8.2: use PHP 8.2
             - 8.3: use PHP 8.3
@@ -220,7 +218,7 @@ while getopts ":a:s:t:d:i:j:p:e:xy:whuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2|8.3)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3)$ ]]; then
                 INVALID_OPTIONS+=("${OPTARG}")
             fi
             ;;
@@ -266,7 +264,7 @@ if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
     exit 1
 fi
 
-# Move "7.4" to "php74", the latter is the docker container name
+# Move "8.x" to "php8x", the latter is the docker container name
 DOCKER_PHP_IMAGE=$(echo "php${PHP_VERSION}" | sed -e 's/\.//')
 
 # Set $1 to first mass argument, this is the optional test file or test directory to execute

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 Before running any of the tests, please install the project dependencies. Choose which version of TYPO3 you would like to test against.
 
 ```bash
-# If you use PHP 7.4 (supported by Kitodo)
+# If you use PHP 8.1 (supported by Kitodo)
 composer update --with=typo3/cms-core:^11.5
 
 # If you use PHP 8

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "docs": "https://docs.typo3.org/p/kitodo/presentation/main/en-us/"
   },
   "require": {
-    "php": "7.4 - 8.3",
+    "php": "8.1 - 8.3",
     "ext-curl": "*",
     "ext-dom": "*",
     "ext-json": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'misc',
     'constraints' => [
         'depends' => [
-            'php' => '7.4.0-8.3.99',
+            'php' => '8.1.0-8.3.99',
             'typo3' => '11.5.0-12.4.99'
         ],
         'conflicts' => [],


### PR DESCRIPTION
Both PHP releases had their end of life long ago.