### PR TITLE
[BUGFIX] Filter `null` collections

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -781,6 +781,9 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
     {
         $collectionsQueryString = '';
         $virtualCollectionsQueryString = '';
+
+        $this->filterCollections();
+
         foreach ($this->collections as $collection) {
             // check for virtual collections query string
             if ($collection->getIndexSearch()) {
@@ -806,6 +809,18 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
 
         // combine both query strings into a single filterquery via OR if both are given, otherwise pass either of those
         return implode(' OR ', array_filter([$collectionsQueryString, $virtualCollectionsQueryString]));
+    }
+
+    /**
+     * Filter collections to avoid null values.
+     *
+     * @return void
+     */
+    private function filterCollections(): void
+    {
+        if (is_array($this->collections)) {
+            array_filter($this->collections, fn($value) => $value !== null);
+        }
     }
 
     /**


### PR DESCRIPTION
`Core: Exception handler (WEB): Uncaught TYPO3 Exception: Call to a member function getIndexSearch() on null | Error thrown in file /var/www/webroot/releases/15/public/typo3conf/ext/dlf/Classes/Common/Solr/SolrSearch.php in line 745.`