### PR TITLE
[BUGFIX] Remove Score Filegroup out of configKeys

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1165,7 +1165,7 @@ final class MetsDocument extends AbstractDocument
                 'fileGrpThumbs',
                 'fileGrpDownload',
                 'fileGrpFulltext',
-                'fileGrpScore'
+                'fileGrpAudio'
             ];
 
             foreach ($configKeys as $key) {


### PR DESCRIPTION
Because Score is not present in Branch v5.0.x.
Reintroduced missing Filegroup Audio as it was before. But was removed by Maintenance in this commit: https://github.com/kitodo/kitodo-presentation/commit/8427b4142c9ad6c2ab1dceb770c2f49d7169127d
