### PR TITLE
[MAINTENANCE] Format XML output of OAI-PMH

### DIFF
--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -307,7 +307,7 @@ class OaiPmhController extends AbstractController
         $xmlOutput = $this->view->render();
 
         // Format the XML.
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->preserveWhiteSpace = false;
         // Here we could also choose `false` for a minimized XML.
         $dom->formatOutput = true;

--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -11,6 +11,7 @@
 
 namespace Kitodo\Dlf\Controller;
 
+use DOMDocument;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Kitodo\Dlf\Common\Solr\Solr;
 use Kitodo\Dlf\Domain\Model\Token;
@@ -302,7 +303,19 @@ class OaiPmhController extends AbstractController
         $this->view->assign('parameters', $this->parameters);
         $this->view->assign('error', $this->error);
 
-        return $this->htmlResponse();
+        // Generate the XML output.
+        $xmlOutput = $this->view->render();
+
+        // Format the XML.
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        // Here we could also choose `false` for a minimized XML.
+        $dom->formatOutput = true;
+        $dom->loadXML($xmlOutput);
+        $formattedXmlOutput = trim($dom->saveXML());
+
+        // Return the formatted XML.
+        return $this->htmlResponse($formattedXmlOutput);
     }
 
     /**


### PR DESCRIPTION
The current XML output is generated with a Fluid template. Therefore it is badly formatted with lots of empty lines and unnecessary whitespace.