### PR TITLE
[BUGFIX] Trim id for full text element

### DIFF
--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -612,7 +612,7 @@ dlfViewerFullTextControl.prototype.showFulltext = function(features) {
     if (fullTextScrollElementId.substr(0,1) === '#') {
         fullTextScrollElementId = fullTextScrollElementId.substr(1);
     }
-    var target = document.getElementById(fullTextScrollElementId);
+    var target = document.getElementById(fullTextScrollElementId.trim());
     if (target !== null) {
         target.innerHTML = "";
         for (var feature of features) {


### PR DESCRIPTION
<img width="800" alt="fulltext_id" src="https://github.com/user-attachments/assets/74a5998c-3ae7-4d17-bfa4-9b19ef6f27fd" />
