### PR TITLE
[BUGFIX] Trim id for full text element

### DIFF
--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -612,7 +612,7 @@ dlfViewerFullTextControl.prototype.showFulltext = function(features) {
     if (fullTextScrollElementId.substr(0,1) === '#') {
         fullTextScrollElementId = fullTextScrollElementId.substr(1);
     }
-    var target = document.getElementById(fullTextScrollElementId);
+    var target = document.getElementById(fullTextScrollElementId.trim());
     if (target !== null) {
         target.innerHTML = "";
         for (var feature of features) {


### PR DESCRIPTION
<img width="850" alt="fulltext_id" src="https://github.com/user-attachments/assets/917e3fe7-5f2f-4b7f-ae6e-4aaffeb73e12" />
