### PR TITLE
[BUGFIX] Trim id for full text element

### DIFF
--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -612,7 +612,7 @@ dlfViewerFullTextControl.prototype.showFulltext = function(features) {
     if (fullTextScrollElementId.substr(0,1) === '#') {
         fullTextScrollElementId = fullTextScrollElementId.substr(1);
     }
-    var target = document.getElementById(fullTextScrollElementId);
+    var target = document.getElementById(fullTextScrollElementId.trim());
     if (target !== null) {
         target.innerHTML = "";
         for (var feature of features) {


### PR DESCRIPTION
<img width="850" alt="fulltext_id" src="https://github.com/user-attachments/assets/9f3465db-a9e9-4bf3-8284-2e80cbc3643e" />
