### PR TITLE
[BUGFIX] Add missing `useGroupsConfiguration` initialization in `AbstractController`

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -128,6 +128,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         // Get extension configuration.
         $this->extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('dlf');
 
+        $this->useGroupsConfiguration = UseGroupsConfiguration::getInstance();
+
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
 
         $this->viewData = [


### PR DESCRIPTION
It was only initialized in `AbstractDocument` class, but should be also initialized in `AbstractController` class