### PR TITLE
[BUGFIX] Add missing label for tx_dlf_tokens

### DIFF
--- a/Resources/Private/Language/de.locallang_labels.xlf
+++ b/Resources/Private/Language/de.locallang_labels.xlf
@@ -549,6 +549,10 @@
 				<source>Name</source>
 				<target>Name</target>
 			</trans-unit>
+			<trans-unit id="tx_dlf_tokens">
+				<source>Tokens</source>
+				<target>Token</target>
+			</trans-unit>
 			<trans-unit id="tx_dlf_toolbox.fulltexttool">
 				<source>Fulltext</source>
 				<target>Volltext</target>

--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -413,6 +413,9 @@
 			<trans-unit id="tx_dlf_mail.name">
 				<source>Name</source>
 			</trans-unit>
+			<trans-unit id="tx_dlf_tokens">
+				<source>Tokens</source>
+			</trans-unit>
 			<trans-unit id="tx_dlf_toolbox.fulltexttool">
 				<source>Fulltext</source>
 			</trans-unit>


### PR DESCRIPTION
This fixes the currently empty record name when a new Kitodo.Presentation record is added in the TYPO3 backend.