### PR TITLE
[BUGFIX] Initialize new document even if record id is not there

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -538,14 +538,13 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         $doc = AbstractDocument::getInstance($documentId, $this->settings, true);
 
         if ($doc !== null) {
+            $this->document = GeneralUtility::makeInstance(Document::class);
+
             if ($doc->recordId) {
                 // find document from repository by recordId
                 $docFromRepository = $this->documentRepository->findOneByRecordId($doc->recordId);
                 if ($docFromRepository !== null) {
                     $this->document = $docFromRepository;
-                } else {
-                    // create new dummy Document object
-                    $this->document = GeneralUtility::makeInstance(Document::class);
                 }
             }
 


### PR DESCRIPTION
Fix for error:
`Call to a member function setLocation() on null`

Currently document is created only if document record id exists. If not than document is not created but the location is set up anyway. Added creation o document even if there is no record id.