### PR TITLE
[BUGFIX] Implement display of single collection in `CollectionController`

### DIFF
--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -86,17 +86,21 @@ class CollectionController extends AbstractController
 
         // Sort collections according to order in plugin flexform configuration
         if ($this->settings['collections']) {
-            $sortedCollections = [];
             foreach (GeneralUtility::intExplode(',', $this->settings['collections']) as $uid) {
-                $sortedCollections[$uid] = $this->collectionRepository->findByUid($uid);
+                $collections[$uid] = $this->collectionRepository->findByUid($uid);
             }
-            $collections = $sortedCollections;
         } else {
             $collections = $this->collectionRepository->findAll();
         }
 
-        if (count($collections) == 1 && empty($this->settings['dont_show_single']) && is_array($collections)) {
-            $this->forward('show', null, null, ['collection' => array_pop($collections)]);
+        if ($this->settings['showSingle'] == 1) {
+            if (count($collections) == 1 && is_array($collections)) {
+                $this->forward('show', null, null, ['collection' => array_pop($collections)]);
+            } else {
+                $searchParams = $this->getParametersSafely('searchParameter');
+                $collection = $this->collectionRepository->findByUid($searchParams['collection']);
+                $this->forward('show', null, null, ['collection' => $collection]);
+            }
         }
 
         $processedCollections = $this->processCollections($collections, $solr);

--- a/Configuration/FlexForms/Collection.xml
+++ b/Configuration/FlexForms/Collection.xml
@@ -82,16 +82,16 @@
                             </config>
                         </TCEforms>
                     </settings.show_userdefined>
-                    <settings.dont_show_single>
+                    <settings.showSingle>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.collection.flexform.dont_show_single</label>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:plugins.collection.flexform.showSingle</label>
                             <config>
                                 <type>check</type>
                                 <default>0</default>
                             </config>
                         </TCEforms>
-                    </settings.dont_show_single>
+                    </settings.showSingle>
                     <settings.randomize>
                         <TCEforms>
                             <exclude>1</exclude>
@@ -105,7 +105,7 @@
                     <settings.targetPid>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:flexform.targetPidListView</label>
+                            <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:flexform.targetPidCollection</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -267,7 +267,7 @@ The collection plugin shows one collection, all collections or selected collecti
    :Default:
 
  - :Property:
-       dont_show_single
+       showSingle
    :Data Type:
        :ref:`t3tsref:data-type-boolean`
    :Default:

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -49,6 +49,10 @@
 				<source><![CDATA[Target page (with "DLF: Basket" plugin)]]></source>
 				<target><![CDATA[Zielseite (mit Plugin "DLF: Warenkorb")]]></target>
 			</trans-unit>
+            <trans-unit id="flexform.targetPidCollection" approved="yes">
+                <source><![CDATA[Target page (with "Kitodo: Collection" plugin)]]></source>
+                <target><![CDATA[Zielseite (mit Plugin "Kitodo: Kollektion")]]></target>
+            </trans-unit>
 			<trans-unit id="flexform.targetPidFeed" approved="yes">
 				<source><![CDATA[Target page (with "Kitodo: Feeds" plugin)]]></source>
 				<target><![CDATA[Zielseite (mit Plugin "Kitodo: Feeds")]]></target>
@@ -141,7 +145,7 @@
 				<source><![CDATA[Show only these collections]]></source>
 				<target><![CDATA[Nur diese Kollektionen anzeigen]]></target>
 			</trans-unit>
-			<trans-unit id="plugins.collection.flexform.dont_show_single" approved="yes">
+            <trans-unit id="plugins.collection.flexform.showSingle" approved="yes">
 				<source><![CDATA[Show single collection in overview?]]></source>
 				<target><![CDATA[Einzelne Kollektion in Übersicht anzeigen?]]></target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -32,6 +32,9 @@
 			<trans-unit id="flexform.targetBasket">
 				<source><![CDATA[Target page (with "DLF: Basket" plugin)]]></source>
 			</trans-unit>
+            <trans-unit id="flexform.targetPidCollection">
+                <source><![CDATA[Target page (with "Kitodo: Collection" plugin)]]></source>
+            </trans-unit>
 			<trans-unit id="flexform.targetPidPageView">
 				<source><![CDATA[Target page (with "Kitodo: Page View" plugin)]]></source>
 			</trans-unit>
@@ -365,7 +368,7 @@
 			<trans-unit id="plugins.collection.flexform.show_userdefined.exclusive">
 				<source><![CDATA[exclusively]]></source>
 			</trans-unit>
-			<trans-unit id="plugins.collection.flexform.dont_show_single">
+            <trans-unit id="plugins.collection.flexform.showSingle">
 				<source><![CDATA[Show single collection in overview?]]></source>
 			</trans-unit>
 			<trans-unit id="plugins.collection.flexform.randomize">

--- a/Resources/Private/Templates/Collection/Show.html
+++ b/Resources/Private/Templates/Collection/Show.html
@@ -32,7 +32,6 @@
         <f:variable name="action" value="showSorted" />
         <f:variable name="controller" value="Collection" />
         <f:render partial="ListView/SortingForm" arguments="{_all}" />
-
         <f:render partial="ListView/Results" arguments="{_all}" />
 
     </div>


### PR DESCRIPTION
`Collection` plugin should display a single collection view if `showSingle` setting is checked.

- setting name adjusted (it was contradicting its description)
- redirect to `pid` of `Collection` plugin instead of `ListView` plugin (it contains list of documents)
- handle two options:
    1. there is one configured collection and then display overview of this collection
    2. there is none configured and then display overview of collection passed in the search parameters