### PR TITLE
[BUGFIX] Explicitly declare nullable function parameters

### DIFF
--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -312,7 +312,7 @@ class PageViewController extends AbstractController
      * @param int|null $docNumber
      * @return array
      */
-    protected function getMeasures(int $page, MetsDocument $specificDoc = null, $docNumber = null): array
+    protected function getMeasures(int $page, ?MetsDocument $specificDoc = null, $docNumber = null): array
     {
         if ($specificDoc) {
             $doc = $specificDoc;
@@ -380,7 +380,7 @@ class PageViewController extends AbstractController
      *
      * @return array URL and MIME type of fulltext file
      */
-    protected function getScore(int $page, MetsDocument $specificDoc = null)
+    protected function getScore(int $page, ?MetsDocument $specificDoc = null)
     {
         $score = [];
         $loc = '';
@@ -638,7 +638,7 @@ class PageViewController extends AbstractController
      *
      * @return array URL and MIME type of image file
      */
-    protected function getImage(int $page, MetsDocument $specificDoc = null): array
+    protected function getImage(int $page, ?MetsDocument $specificDoc = null): array
     {
         $image = [];
         // Get @USE value of METS fileGrp.

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -312,7 +312,7 @@ class PageViewController extends AbstractController
      * @param int|null $docNumber
      * @return array
      */
-    protected function getMeasures(int $page, ?MetsDocument $specificDoc = null, $docNumber = null): array
+    protected function getMeasures(int $page, ?MetsDocument $specificDoc = null, ?int $docNumber = null): array
     {
         if ($specificDoc) {
             $doc = $specificDoc;


### PR DESCRIPTION
PHP 7.1 added support for nullable types, but they could be declared implicitly. PHP 8.4 deprecates implicitly nullable types.

Using an explicit declaration avoids several warnings with PHP 8.4.