### PR TITLE
[BUGFIX] Remove double assignment for `extendedFields`

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -574,7 +574,6 @@ class SearchController extends AbstractController
         $extendedSlotCount = range(0, (int) $this->settings['extendedSlotCount'] - 1);
 
         $this->view->assign('extendedSlotCount', $extendedSlotCount);
-        $this->view->assign('extendedFields', $this->settings['extendedFields']);
         $this->view->assign('operators', ['AND', 'OR', 'NOT']);
         $this->view->assign('searchFields', $searchFields);
     }


### PR DESCRIPTION
Field is assigned two times:

<img width="500" alt="double" src="https://github.com/user-attachments/assets/578db123-c3ee-422f-a4a8-30ebc35ae905" />
