### PR TITLE
[BUGFIX] Enable suggester before action exits with empty search parameters

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -114,6 +114,8 @@ class SearchController extends AbstractController
         // Get additional fields for extended search.
         $this->addExtendedSearch();
 
+        $this->enableSuggester();
+
         // if search was triggered, get search parameters from POST variables
         $this->searchParams = $this->getParametersSafely('searchParameter');
         // if search was triggered by the ListView plugin, get the parameters from GET variables
@@ -208,11 +210,6 @@ class SearchController extends AbstractController
         if (isset($this->requestData['id'])) {
             $currentDocument = $this->documentRepository->findByUid($this->requestData['id']);
             $this->view->assign('currentDocument', $currentDocument);
-        }
-
-        // Add uHash parameter to suggest parameter to make a basic protection of this form.
-        if ($this->settings['suggest']) {
-            $this->view->assign('uHash', GeneralUtility::hmac((string) (new Typo3Version()) . Environment::getExtensionsPath(), 'SearchSuggest'));
         }
 
         $this->view->assign('viewData', $this->viewData);
@@ -577,5 +574,20 @@ class SearchController extends AbstractController
         $this->view->assign('extendedFields', $this->settings['extendedFields']);
         $this->view->assign('operators', ['AND', 'OR', 'NOT']);
         $this->view->assign('searchFields', $searchFields);
+    }
+
+    /**
+     * Enables suggester if setting is set.
+     *
+     * @access private
+     *
+     * @return void
+     */
+    private function enableSuggester(): void
+    {
+        // Add uHash parameter to suggest parameter to make a basic protection of this form.
+        if ($this->settings['suggest']) {
+            $this->view->assign('uHash', GeneralUtility::hmac((string) (new Typo3Version()) . Environment::getExtensionsPath(), 'SearchSuggest'));
+        }
     }
 }


### PR DESCRIPTION
`uHash` is not set for cases when there was no prior search