### PR TITLE
[BUGFIX] Fix runtime exception while running `kitodo:index`

### DIFF
--- a/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
+++ b/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
@@ -106,7 +106,7 @@ class DocumentTypeFunctionProvider implements ExpressionFunctionProviderInterfac
             {
                 /** @var RequestWrapper $requestWrapper */
                 $requestWrapper = $arguments['request'];
-                $queryParams = $requestWrapper->getQueryParams();
+                $queryParams = $requestWrapper ? $requestWrapper->getQueryParams() : [];
 
                 $type = 'undefined';
 


### PR DESCRIPTION
The commit fixes this runtime exception:

    # /var/customers/webs/weil/viewer/vendor/bin/typo3 kitodo:index

    Index single document into database and Solr.
    =============================================

    Uncaught TYPO3 Exception Call to a member function getQueryParams() on null
    thrown in file vendor/kitodo/presentation/Classes/ExpressionLanguage/DocumentTypeFunctionProvider.php
    in line 109