### PR TITLE
[BUGFIX] Return response instead of throwing an exception

### DIFF
--- a/Classes/Middleware/SearchSuggest.php
+++ b/Classes/Middleware/SearchSuggest.php
@@ -56,7 +56,8 @@ class SearchSuggest implements MiddlewareInterface
         $solrCore = (string) $parameters['solrcore'];
         $uHash = (string) $parameters['uHash'];
         if (hash_equals(GeneralUtility::hmac((string) (new Typo3Version()) . Environment::getExtensionsPath(), 'SearchSuggest'), $uHash) === false) {
-            throw new \InvalidArgumentException('No valid parameter passed!', 1580585079);
+            // 'uHash' is invalid or missing so suggester should not be called
+            return $response;
         }
         // Perform Solr query.
         $solr = Solr::getInstance($solrCore);


### PR DESCRIPTION
Parameter `uHash` is created if the `suggest` setting is set to 1. In case it is 0, no parameter is given and the exception is thrown. It enforces that `suggest` is always set up to 1, otherwise the exception appears. Return `$response` looks here as more feasible solution.