### PR TITLE
[BUGFIX] Correctly get pageId from request in AbstractController in TYPO3 v12

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -121,7 +121,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     {
         /** @var Request $request */
         $this->requestData = $request->getQueryParams()['tx_dlf'] ?? [];
-        $this->pageUid = !($this instanceof OaiPmhController) ? $request->getAttribute('routing')->getPageId() : 0;
+        $this->pageUid = (int) GeneralUtility::_GET('id');
         $this->requestData['page'] = $this->requestData['page'] ?? 1;
 
         // Sanitize user input to prevent XSS attacks.

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -121,7 +121,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     {
         /** @var Request $request */
         $this->requestData = $request->getQueryParams()['tx_dlf'] ?? [];
-        $this->pageUid = !($this instanceof OaiPmhController) ? $this->request->getAttribute('routing')->getPageId() : 0;
+        $this->pageUid = !($this instanceof OaiPmhController) ? $request->getAttribute('routing')->getPageId() : 0;
         $this->requestData['page'] = $this->requestData['page'] ?? 1;
 
         // Sanitize user input to prevent XSS attacks.


### PR DESCRIPTION
`$this->request` was being accessed in the `initialize()` method before it was properly initialized, causing a typed property initialization error.