### PR TITLE
[BUGFIX] Fix displaying for missing title

### DIFF
--- a/Classes/Common/SolrPaginator.php
+++ b/Classes/Common/SolrPaginator.php
@@ -42,7 +42,9 @@ class SolrPaginator extends AbstractPaginator
     protected function updatePaginatedItems(int $itemsPerPage, int $offset): void
     {
         $this->solrSearch->submit($offset, $itemsPerPage);
-        $this->paginatedItems = $this->solrSearch->toArray();
+        foreach ($this->solrSearch as $item) {
+            $this->paginatedItems[] = $item;
+        }
     }
 
     protected function getTotalAmountOfItems(): int

--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -172,7 +172,6 @@ class CollectionController extends AbstractController
         $sortableMetadata = $this->metadataRepository->findByIsSortable(true);
 
         $solrResults = $this->documentRepository->findSolrByCollection($collection, $this->settings, $this->searchParams, $listedMetadata);
-        $numResults = $solrResults->getNumFound();
 
         $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'] ?? 25;
 
@@ -183,8 +182,8 @@ class CollectionController extends AbstractController
         $this->view->assignMultiple([ 'pagination' => $pagination, 'paginator' => $solrPaginator ]);
 
         $this->view->assign('viewData', $this->viewData);
-        $this->view->assign('documents', !empty($solrResults) ? $solrResults : []);
-        $this->view->assign('numResults', $numResults);
+        $this->view->assign('countDocuments', $solrResults->count());
+        $this->view->assign('countResults', $solrResults->getNumFound());
         $this->view->assign('collection', $collection);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $this->searchParams);

--- a/Classes/Controller/ListViewController.php
+++ b/Classes/Controller/ListViewController.php
@@ -101,10 +101,8 @@ class ListViewController extends AbstractController
         // get all metadata records to be shown in results
         $listedMetadata = $this->metadataRepository->findByIsListed(true);
 
-        $numResults = 0;
         if (!empty($this->searchParams)) {
             $solrResults = $this->documentRepository->findSolrWithoutCollection($this->settings, $this->searchParams, $listedMetadata);
-            $numResults = $solrResults->getNumFound();
 
             $itemsPerPage = $this->settings['list']['paginate']['itemsPerPage'] ?? 25;
 
@@ -116,8 +114,8 @@ class ListViewController extends AbstractController
         }
 
         $this->view->assign('viewData', $this->viewData);
-        $this->view->assign('documents', !empty($solrResults) ? $solrResults : []);
-        $this->view->assign('numResults', $numResults);
+        $this->view->assign('countDocuments', !empty($solrResults) ? $solrResults->count() : 0);
+        $this->view->assign('countResults', !empty($solrResults) ? $solrResults->getNumFound() : 0);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $this->searchParams);
         $this->view->assign('sortableMetadata', $sortableMetadata);

--- a/Resources/Private/Partials/ListView/SearchHits.html
+++ b/Resources/Private/Partials/ListView/SearchHits.html
@@ -13,6 +13,6 @@
       data-namespace-typo3-fluid="true">
 
     <p class="tx-dlf-search-numHits">
-        <f:translate key="listview.hits" arguments="{0: '{numResults}', 1: '{documents->f:count()}'}" />
+        <f:translate key="listview.hits" arguments="{0: '{countResults}', 1: '{countDocuments}'}" />
     </p>
 </html>

--- a/Resources/Private/Templates/ListView/Main.html
+++ b/Resources/Private/Templates/ListView/Main.html
@@ -27,7 +27,7 @@
         <f:variable name="action" value="main" />
         <f:variable name="controller" value="ListView" />
 
-        <f:if condition="{numResults} > 0">
+        <f:if condition="{countResults} > 0">
             <f:render partial="ListView/SortingForm" arguments="{_all}" />
             <f:render partial="ListView/Results" arguments="{_all}" />
         </f:if>

--- a/Resources/Private/Templates/Search/Main.html
+++ b/Resources/Private/Templates/Search/Main.html
@@ -118,7 +118,7 @@
         <f:render partial="ListView/SearchHits" arguments="{_all}" />
         <f:variable name="action" value="search" />
         <f:variable name="controller" value="Search" />
-        <f:if condition="{numResults} > 0">
+        <f:if condition="{countResults} > 0">
             <f:render partial="ListView/SortingForm" arguments="{_all}" />
             <f:render partial="ListView/Results" arguments="{_all}" />
         </f:if>


### PR DESCRIPTION
Changes:
- send only one list of documents to the view
- send to the view count for results and documents
- force iteration over SOLR results to call `getTitle()` function placed in `offsetGet()` function

Depends on https://github.com/kitodo/kitodo-presentation/pull/1526