### PR TITLE
[BUGFIX] Fix thumbnail reference being always from toplevelId

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -456,7 +456,7 @@ final class MetsDocument extends AbstractDocument
         ) {
             // Link logical structure to the first corresponding physical page/track.
             $details['points'] = max((int) array_search($this->smLinks['l2p'][$details['id']][0], $this->physicalStructure, true), 1);
-            $details['thumbnailId'] = $this->getThumbnail();
+            $details['thumbnailId'] = $this->getThumbnail($details['id']);
             // Get page/track number of the first page/track related to this structure element.
             $details['pagination'] = $this->physicalStructureInfo[$this->smLinks['l2p'][$details['id']][0]]['orderlabel'];
             $details['videoChapter'] = $this->getTimecode($details);


### PR DESCRIPTION
Fixes an issue, where all logical units got the toplevels thumbnail reference instead the one belonging to them. Now they get the thumbnail for the corresponding first page of the logical unit.