### PR TITLE
[BUGFIX] Fix adding empty xpath results to metadata array

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -850,7 +850,9 @@ final class MetsDocument extends AbstractDocument
                     }
                 }
             } elseif (!($values instanceof DOMNodeList)) {
-                $metadata[$resArray['index_name']] = [trim((string) $values)];
+                if (!empty($values)) {
+                    $metadata[$resArray['index_name']] = [trim((string) $values)];
+                }
             }
         }
     }


### PR DESCRIPTION
There are certain XPATH 1.0 expressions, that would return an empty value even when no nodes have matched, like `concat()` or `substring()`. This results in empty values in the metadata array and subsequently empty fields in the indexed documents. In the case of facets this manifests for example as just the hit count (without any actual value).