### PR TITLE
[MAINTENANCE] Use package softcreatr/jsonpath instead of flow/jsonpath

### DIFF
--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -581,9 +581,9 @@ final class IiifManifest extends AbstractDocument
                 $values = $iiifResource->jsonPath($resArray['xpath']);
                 if (is_string($values)) {
                     $metadata[$resArray['index_name']] = [trim((string) $values)];
-                } elseif ($values instanceof JSONPath && is_array($values->data()) && count($values->data()) > 1) {
+                } elseif ($values instanceof JSONPath && is_array($values->getData()) && count($values->getData()) > 1) {
                     $metadata[$resArray['index_name']] = [];
-                    foreach ($values->data() as $value) {
+                    foreach ($values->getData() as $value) {
                         $metadata[$resArray['index_name']][] = trim((string) $value);
                     }
                 }
@@ -598,9 +598,9 @@ final class IiifManifest extends AbstractDocument
                     $values = $iiifResource->jsonPath($resArray['xpath_sorting']);
                     if (is_string($values)) {
                         $metadata[$resArray['index_name'] . '_sorting'][0] = [trim((string) $values)];
-                    } elseif ($values instanceof JSONPath && is_array($values->data()) && count($values->data()) > 1) {
+                    } elseif ($values instanceof JSONPath && is_array($values->getData()) && count($values->getData()) > 1) {
                         $metadata[$resArray['index_name']] = [];
-                        foreach ($values->data() as $value) {
+                        foreach ($values->getData() as $value) {
                             $metadata[$resArray['index_name'] . '_sorting'][0] = trim((string) $value);
                         }
                     }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "slub/php-mods-reader": "^0.4",
     "ubl/php-iiif-prezi-reader": "0.3",
     "solarium/solarium": "^6.3",
+    "softcreatr/jsonpath": "^0.10.0",
     "symfony/process": "^6.4"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "slub/php-mods-reader": "^0.4",
     "ubl/php-iiif-prezi-reader": "0.3",
     "solarium/solarium": "^6.3",
-    "softcreatr/jsonpath": "^0.10.0",
+    "softcreatr/jsonpath": "^0.10",
     "symfony/process": "^6.4"
   },
   "require-dev": {


### PR DESCRIPTION
The installation with composer reported this warning:

    Package flow/jsonpath is abandoned, you should avoid using it.
    Use softcreatr/jsonpath instead.