### PR TITLE
[BUGFIX] Sync listview with facets and fix wrong hitcount

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -402,7 +402,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
             }
             $params['fulltext'] = true;
         } else {
-            $params['filterquery'][]['query'] = "-type:page";
+            $params['filterquery'][]['query'] = '-type:page';
             // Retain given search field if valid.
             if (!empty($this->searchParams['query'])) {
                 $query = Solr::escapeQueryKeepField(trim($this->searchParams['query']), $this->settings['storagePid']);

--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -402,9 +402,12 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
             }
             $params['fulltext'] = true;
         } else {
+            $params['filterquery'][]['query'] = "-type:page";
             // Retain given search field if valid.
             if (!empty($this->searchParams['query'])) {
                 $query = Solr::escapeQueryKeepField(trim($this->searchParams['query']), $this->settings['storagePid']);
+            } else {
+                $query = '*';
             }
         }
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -285,6 +285,7 @@ class SearchController extends AbstractController
                 $search['query'] = $fields['fulltext'] . ':(' . Solr::escapeQuery(trim($searchParams['query'])) . ')';
             }
         } else {
+            $search['params']['filterquery'][]['query'] = "-type:page";
             // Retain given search field if valid.
             if (!empty($searchParams['query'])) {
                 $search['query'] = Solr::escapeQueryKeepField(trim($searchParams['query']), $this->settings['storagePid']);

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -285,7 +285,7 @@ class SearchController extends AbstractController
                 $search['query'] = $fields['fulltext'] . ':(' . Solr::escapeQuery(trim($searchParams['query'])) . ')';
             }
         } else {
-            $search['params']['filterquery'][]['query'] = "-type:page";
+            $search['params']['filterquery'][]['query'] = '-type:page';
             // Retain given search field if valid.
             if (!empty($searchParams['query'])) {
                 $search['query'] = Solr::escapeQueryKeepField(trim($searchParams['query']), $this->settings['storagePid']);


### PR DESCRIPTION
This fixes issues related to the facets in combination with the listview:
* removes fulltext pages from the facet count in metadata searches
* does actually a wildcard search when entering a collection (or performing an empty search), so that the facets and listview are in sync now, as the facets are already wildcard in that case.

Fixes: [BUG] Number of hits for facets incorrect #1189