### PR TITLE
[BUGFIX] Fix null pointer exception when calling musial structure

### DIFF
--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -175,7 +175,7 @@ class PageViewController extends AbstractController
         $docNumPages = [];
         $i = 0;
         foreach ($this->documentArray as $document) {
-            if (is_null($document) || !array_key_exists($i, $this->requestData['docPage']) ) {
+            if ($document === null || !array_key_exists($i, $this->requestData['docPage'])) {
                 continue;
             }
 

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -175,7 +175,7 @@ class PageViewController extends AbstractController
         $docNumPages = [];
         $i = 0;
         foreach ($this->documentArray as $document) {
-            if (!array_key_exists($i, $this->requestData['docPage']) ) {
+            if (is_null($document) || !array_key_exists($i, $this->requestData['docPage']) ) {
                 continue;
             }
 


### PR DESCRIPTION
- Issue occurs when calling $document->musicalStructure https://github.com/kitodo/kitodo-presentation/blob/f462afc683034c294aab2891ddc2474b59382f9a/Classes/Controller/PageViewController.php#L270
- Suggest solution is to perform a null check on the $document before accessing its properties

