### PR TITLE
[BUGFIX] Replace magic getter for `toplevelId` property

### DIFF
--- a/Classes/Common/AbstractDocument.php
+++ b/Classes/Common/AbstractDocument.php
@@ -54,7 +54,6 @@ use Ubl\Iiif\Tools\IiifHelper;
  * @property bool $tableOfContentsLoaded flag with information if the table of contents is loaded
  * @property-read string $thumbnail this holds the document's thumbnail location
  * @property bool $thumbnailLoaded flag with information if the thumbnail is loaded
- * @property-read string $toplevelId this holds the toplevel structure's "@ID" (METS) or the manifest's "@id" (IIIF)
  * @property \SimpleXMLElement $xml this holds the whole XML file as \SimpleXMLElement object
  */
 abstract class AbstractDocument
@@ -454,13 +453,13 @@ abstract class AbstractDocument
     /**
      * This returns the ID of the toplevel logical structure node
      *
-     * @access protected
+     * @access public
      *
      * @abstract
      *
      * @return string The logical structure node's ID
      */
-    abstract protected function magicGetToplevelId(): string;
+    abstract public function getToplevelId(): string;
 
     /**
      * This sets some basic class properties
@@ -809,10 +808,10 @@ abstract class AbstractDocument
      */
     public function getToplevelMetadata(int $cPid = 0): array
     {
-        $toplevelMetadata = $this->getMetadata($this->magicGetToplevelId(), $cPid);
+        $toplevelMetadata = $this->getMetadata($this->getToplevelId(), $cPid);
         // Add information from METS structural map to toplevel metadata array.
         if ($this instanceof MetsDocument) {
-            $this->addMetadataFromMets($toplevelMetadata, $this->magicGetToplevelId());
+            $this->addMetadataFromMets($toplevelMetadata, $this->getToplevelId());
         }
         // Set record identifier for METS file / IIIF manifest if not present.
         if (array_key_exists('record_id', $toplevelMetadata)) {

--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -65,7 +65,6 @@ use Ubl\Iiif\Tools\IiifHelper;
  * @property bool $tableOfContentsLoaded flag with information if the table of contents is loaded
  * @property-read string $thumbnail this holds the document's thumbnail location
  * @property bool $thumbnailLoaded flag with information if the thumbnail is loaded
- * @property-read string $toplevelId this holds the toplevel structure's "@ID" (METS) or the manifest's "@id" (IIIF)
  * @property \SimpleXMLElement $xml this holds the whole XML file as \SimpleXMLElement object
  * @property string $asJson this holds the manifest file as string for serialization purposes
  * @property ManifestInterface $iiif a PHP object representation of a IIIF manifest
@@ -73,7 +72,7 @@ use Ubl\Iiif\Tools\IiifHelper;
  * @property bool $hasFulltextSet flag if document has already been analyzed for presence of the fulltext for the Solr index
  * @property array $originalMetadataArray this holds the original manifest's parsed metadata array with their corresponding resource (Manifest / Sequence / Range) ID as array key
  * @property array $mimeTypes this holds the mime types of linked resources in the manifest (extracted during parsing) for later us
- * 
+ *
  */
 final class IiifManifest extends AbstractDocument
 {
@@ -472,7 +471,7 @@ final class IiifManifest extends AbstractDocument
         $details['volume'] = '';
         $details['pagination'] = '';
         $cPid = ($this->cPid ? $this->cPid : $this->pid);
-        if ($details['id'] == $this->magicGetToplevelId()) {
+        if ($details['id'] == $this->getToplevelId()) {
             $metadata = $this->getMetadata($details['id'], $cPid);
             if (!empty($metadata['type'][0])) {
                 $details['type'] = $metadata['type'][0];
@@ -700,7 +699,7 @@ final class IiifManifest extends AbstractDocument
      * @access private
      *
      * @param RangeInterface $range Current range whose canvases shall be linked
-     * 
+     *
      * @return void
      */
     private function smLinkRangeCanvasesRecursively(RangeInterface $range): void
@@ -726,7 +725,7 @@ final class IiifManifest extends AbstractDocument
      *
      * @param CanvasInterface $canvas
      * @param IiifResourceInterface $resource
-     * 
+     *
      * @return void
      */
     private function smLinkCanvasToResource(CanvasInterface $canvas, IiifResourceInterface $resource): void
@@ -898,9 +897,9 @@ final class IiifManifest extends AbstractDocument
     }
 
     /**
-     * @see AbstractDocument::magicGetToplevelId()
+     * @see AbstractDocument::getToplevelId()
      */
-    protected function magicGetToplevelId(): string
+    public function getToplevelId(): string
     {
         if (empty($this->toplevelId)) {
             if (isset($this->iiif)) {

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -310,13 +310,13 @@ class Indexer
             if (MathUtility::canBeInterpretedAsInteger($logicalUnit['points'])) {
                 $solrDoc->setField('page', $logicalUnit['points']);
             }
-            if ($logicalUnit['id'] == $doc->toplevelId) {
+            if ($logicalUnit['id'] == $doc->getToplevelId()) {
                 $solrDoc->setField('thumbnail', $doc->thumbnail);
             } elseif (!empty($logicalUnit['thumbnailId'])) {
                 $solrDoc->setField('thumbnail', $doc->getFileLocation($logicalUnit['thumbnailId']));
             }
             // There can be only one toplevel unit per UID, independently of backend configuration
-            $solrDoc->setField('toplevel', $logicalUnit['id'] == $doc->toplevelId ? true : false);
+            $solrDoc->setField('toplevel', $logicalUnit['id'] == $doc->getToplevelId());
             $solrDoc->setField('title', $metadata['title'][0], self::$fields['fieldboost']['title']);
             $solrDoc->setField('volume', $metadata['volume'][0], self::$fields['fieldboost']['volume']);
             // verify date formatting
@@ -347,9 +347,9 @@ class Indexer
             if (
                 in_array('collection', self::$fields['facets'])
                 && empty($metadata['collection'])
-                && !empty($doc->metadataArray[$doc->toplevelId]['collection'])
+                && !empty($doc->metadataArray[$doc->getToplevelId()]['collection'])
             ) {
-                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->toplevelId]['collection']);
+                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->getToplevelId()]['collection']);
             }
             try {
                 $updateQuery->addDocument($solrDoc);
@@ -406,19 +406,19 @@ class Indexer
             }
             $solrDoc->setField('toplevel', false);
             $solrDoc->setField('type', $physicalUnit['type'], self::$fields['fieldboost']['type']);
-            $solrDoc->setField('collection', $doc->metadataArray[$doc->toplevelId]['collection']);
+            $solrDoc->setField('collection', $doc->metadataArray[$doc->getToplevelId()]['collection']);
             $solrDoc->setField('location', $document->getLocation());
 
             $solrDoc->setField('fulltext', $fullText);
-            if (is_array($doc->metadataArray[$doc->toplevelId])) {
+            if (is_array($doc->metadataArray[$doc->getToplevelId()])) {
                 self::addFaceting($doc, $solrDoc);
             }
             // Add collection information to physical sub-elements if applicable.
             if (
                 in_array('collection', self::$fields['facets'])
-                && !empty($doc->metadataArray[$doc->toplevelId]['collection'])
+                && !empty($doc->metadataArray[$doc->getToplevelId()]['collection'])
             ) {
-                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->toplevelId]['collection']);
+                $solrDoc->setField('collection_faceting', $doc->metadataArray[$doc->getToplevelId()]['collection']);
             }
             try {
                 $updateQuery->addDocument($solrDoc);
@@ -511,7 +511,7 @@ class Indexer
      */
     private static function addFaceting($doc, &$solrDoc): void
     {
-        foreach ($doc->metadataArray[$doc->toplevelId] as $indexName => $data) {
+        foreach ($doc->metadataArray[$doc->getToplevelId()] as $indexName => $data) {
             if (
                 !empty($data)
                 && substr($indexName, -8) !== '_sorting'
@@ -531,7 +531,7 @@ class Indexer
                 !empty($data)
                 && substr($indexName, -8) == '_sorting'
             ) {
-                $solrDoc->setField($indexName, $doc->metadataArray[$doc->toplevelId][$indexName]);
+                $solrDoc->setField($indexName, $doc->metadataArray[$doc->getToplevelId()][$indexName]);
             }
         }
     }
@@ -561,7 +561,7 @@ class Indexer
         $solrDoc->setField('root', $document->getCurrentDocument()->rootId);
         $solrDoc->setField('sid', $unit['id']);
         $solrDoc->setField('type', $unit['type'], self::$fields['fieldboost']['type']);
-        $solrDoc->setField('collection', $document->getCurrentDocument()->metadataArray[$document->getCurrentDocument()->toplevelId]['collection']);
+        $solrDoc->setField('collection', $document->getCurrentDocument()->metadataArray[$document->getCurrentDocument()->getToplevelId()]['collection']);
         $solrDoc->setField('fulltext', $fullText);
         return $solrDoc;
     }

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -55,7 +55,6 @@ use Ubl\Iiif\Services\AbstractImageService;
  * @property bool $tableOfContentsLoaded flag with information if the table of contents is loaded
  * @property-read string $thumbnail this holds the document's thumbnail location
  * @property bool $thumbnailLoaded flag with information if the thumbnail is loaded
- * @property-read string $toplevelId this holds the toplevel structure's "@ID" (METS) or the manifest's "@id" (IIIF)
  * @property SimpleXMLElement $xml this holds the whole XML file as SimpleXMLElement object
  * @property-read array $mdSec associative array of METS metadata sections indexed by their IDs.
  * @property bool $mdSecLoaded flag with information if the array of METS metadata sections is loaded
@@ -408,7 +407,7 @@ final class MetsDocument extends AbstractDocument
             $details['thumbnailId'] = $this->getThumbnail();
             // Get page/track number of the first page/track related to this structure element.
             $details['pagination'] = $this->physicalStructureInfo[$this->smLinks['l2p'][$details['id']][0]]['orderlabel'];
-        } elseif ($details['id'] == $this->magicGetToplevelId()) {
+        } elseif ($details['id'] == $this->getToplevelId()) {
             // Point to self if this is the toplevel structure.
             $details['points'] = 1;
             $details['thumbnailId'] = $this->getThumbnail();
@@ -545,15 +544,15 @@ final class MetsDocument extends AbstractDocument
         if (!empty($this->mdSec)) {
             foreach ($mdIds as $dmdId) {
                 $mdSectionType = $this->mdSec[$dmdId]['section'];
-    
+
                 if ($this->hasMetadataSection($metadataSections, $mdSectionType, 'dmdSec')) {
                     continue;
                 }
-    
+
                 if (!$this->extractAndProcessMetadata($dmdId, $mdSectionType, $metadata, $cPid, $metadataSections)) {
                     continue;
                 }
-    
+
                 $metadataSections[] = $mdSectionType;
             }
         }
@@ -1373,7 +1372,7 @@ final class MetsDocument extends AbstractDocument
                 $this->thumbnailLoaded = true;
                 return $this->thumbnail;
             }
-            $strctId = $this->magicGetToplevelId();
+            $strctId = $this->getToplevelId();
             $metadata = $this->getToplevelMetadata($cPid);
 
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
@@ -1433,9 +1432,9 @@ final class MetsDocument extends AbstractDocument
     }
 
     /**
-     * @see AbstractDocument::magicGetToplevelId()
+     * @see AbstractDocument::getToplevelId()
      */
-    protected function magicGetToplevelId(): string
+    public function getToplevelId(): string
     {
         if (empty($this->toplevelId)) {
             // Get all logical structure nodes with metadata, but without associated METS-Pointers.

--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -115,7 +115,7 @@ class MetadataController extends AbstractController
         $this->useOriginalIiifManifestMetadata = $this->settings['originalIiifMetadata'] == 1 && $this->currentDocument instanceof IiifManifest;
 
         $metadata = $this->getMetadata();
-        $topLevelId = $this->currentDocument->toplevelId;
+        $topLevelId = $this->currentDocument->getToplevelId();
         // Get toplevel metadata?
         if (!$metadata || ($this->settings['rootline'] == 1 && $metadata[0]['_id'] != $topLevelId)) {
             $data = [];

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -432,7 +432,7 @@ class ToolboxController extends AbstractController
                 $workLink = $this->currentDocument->getFileLocation($fileGroupDownload);
                 break;
             } else {
-                $details = $this->currentDocument->getLogicalStructure($this->currentDocument->toplevelId);
+                $details = $this->currentDocument->getLogicalStructure($this->currentDocument->getToplevelId());
                 if (!empty($details['files'][$fileGrpDownload])) {
                     $workLink = $this->currentDocument->getFileLocation($details['files'][$fileGrpDownload]);
                     break;


### PR DESCRIPTION
This magic function is actually not magic as it only works when it is called directly, otherwise the property is empty