### PR TITLE
[OPTIMIZATION] Speed up pagegrid generation

### DIFF
--- a/Classes/Common/AbstractDocument.php
+++ b/Classes/Common/AbstractDocument.php
@@ -336,7 +336,7 @@ abstract class AbstractDocument
      * @abstract
      *
      * @param string $id The "@ID" attribute of the file node (METS) or the "@id" property of the IIIF resource
-     * 
+     *
      * @param string $useGroup The "@USE" attribute of the fileGrp node (METS)
      *
      * @return string The file's location as URL

--- a/Classes/Common/AbstractDocument.php
+++ b/Classes/Common/AbstractDocument.php
@@ -329,6 +329,21 @@ abstract class AbstractDocument
     abstract public function getFileLocation(string $id): string;
 
     /**
+     * This gets the location of a file representing a physical page or track
+     *
+     * @access public
+     *
+     * @abstract
+     *
+     * @param string $id The "@ID" attribute of the file node (METS) or the "@id" property of the IIIF resource
+     * 
+     * @param string $useGroup The "@USE" attribute of the fileGrp node (METS)
+     *
+     * @return string The file's location as URL
+     */
+    abstract public function getFileLocationInUsegroup(string $id, string $useGroup): string;
+
+    /**
      * This gets the MIME type of a file representing a physical page or track
      *
      * @access public

--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -342,6 +342,15 @@ final class IiifManifest extends AbstractDocument
     }
 
     /**
+     * @see AbstractDocument::getFileLocationInUsegroup()
+     */
+    public function getFileLocationInUsegroup(string $id, string $useGroup): string
+    {
+        $fileLocation = $this->getFileLocation($id);
+        return $fileLocation;
+    }
+
+    /**
      * @see AbstractDocument::getFileMimeType()
      */
     public function getFileMimeType(string $id): string

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -279,6 +279,23 @@ final class MetsDocument extends AbstractDocument
     }
 
     /**
+     * @see AbstractDocument::getFileLocationInUsegroup()
+     */
+    public function getFileLocationInUsegroup(string $id, string $useGroup): string
+    {
+        $location = $this->mets->xpath('./mets:fileSec/mets:fileGrp[@USE="' . $useGroup . '"]/mets:file[@ID="' . $id . '"]/mets:FLocat[@LOCTYPE="URL"]');
+        if (
+            !empty($id)
+            && !empty($location)
+        ) {
+            return (string) $location[0]->attributes('http://www.w3.org/1999/xlink')->href;
+        } else {
+            $this->logger->warning('There is no file node with @ID "' . $id . '"');
+            return '';
+        }
+    }
+
+    /**
      * This gets the measure beginning of a page
      */
     public function getPageBeginning($pageId, $fileId)

--- a/Classes/Controller/PageGridController.php
+++ b/Classes/Controller/PageGridController.php
@@ -108,7 +108,7 @@ class PageGridController extends AbstractController
             if (array_intersect($useGroups, array_keys($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'])) !== []) {
                 while ($useGroup = array_shift($useGroups)) {
                     if (!empty($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'][$useGroup])) {
-                        $entry['thumbnail'] = $this->document->getCurrentDocument()->getFileLocation($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'][$useGroup]);
+                        $entry['thumbnail'] = $this->document->getCurrentDocument()->getFileLocationInUsegroup($this->document->getCurrentDocument()->physicalStructureInfo[$this->document->getCurrentDocument()->physicalStructure[$number]]['files'][$useGroup], $useGroup);
                         break;
                     }
                 }


### PR DESCRIPTION
The pagegrids initial loading time is very slow on very large documents and/or those with many filegroups. On a document with several thousand pages (e.g. Adressbücher, Realkataloge, Plenarprotokolle, Staatsstatistik) and seven filegroups the initial generation of the pagegrid took > 60 seconds resulting in script abortion. This is because the functions `getFileLocation()` xpath does not differentiate which filegroup to check, resulting in traversing through all filegroups, even though they are not of interest for the pagegrid. While we potentially only need to check one filegroup, the xpath actually checks all seven.

This PR introduces a new function `getFileLocationInUsegroup()`, where the xpath considers the `@USE` attribute, which reduces exection time for this function to roughly 1/number_of_filegroups (when compared to `getFileLocation()`), and applies it to the pagegrid controller. This will speed up execution time significantly for all documents and (except for maybe really extreme document sizes) prevent script timeouts.