### PR TITLE
[BUGFIX] Display correct error message for indexing

### DIFF
--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -211,7 +211,7 @@ class IndexCommand extends BaseCommand
                 return BaseCommand::SUCCESS;
             }
 
-            $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on Solr core ' . $solrCoreUid . '. There are missing mandatory fields (at least one of those: ' . $this->extConf['general']['requiredMetadataFields'] . ') in this document.');
+            $io->error('ERROR: Document with UID "' . $document->getUid() . '" could not be indexed on Solr core ' . $solrCoreUid . '. Check TYPO3 log for more details.');
             $io->info('INFO: Document with UID "' . $document->getUid() . '" is already in database. If you want to keep the database and index consistent you need to remove it.');
             return BaseCommand::FAILURE;
         }

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -397,7 +397,8 @@ class Indexer
                     return false;
                 }
             } else {
-                Helper::log('There are missing mandatory fields (at least one of those: ' . $extConf['requiredMetadataFields'] . ') in this document', LOG_SEVERITY_ERROR);
+                Helper::error('There are missing mandatory fields (at least one of those: ' . $extConf['requiredMetadataFields'] . ') in this document');
+                Helper::notice('Tip: If "record_id" field is missing then there is possibility that METS file still contains it but with the wrong source type attribute in "recordIdentifier" element');
                 return false;
             }
         }

--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -397,7 +397,7 @@ class Indexer
                     return false;
                 }
             } else {
-                Helper::log('Tip: If "record_id" field is missing then there is possibility that METS file still contains it but with the wrong source type attribute in "recordIdentifier" element', LOG_SEVERITY_NOTICE);
+                Helper::log('There are missing mandatory fields (at least one of those: ' . $extConf['requiredMetadataFields'] . ') in this document', LOG_SEVERITY_ERROR);
                 return false;
             }
         }


### PR DESCRIPTION
The error message for field validation should be displayed if save to database was not successful as this validation. 

Fail on save to index can be causes by many reasons. Those reasons should be verified in error log, validation can be one of them. The other one can be fail to connect with SOLR Index. Actually it was the case in which I was getting this error message. In the TYPO3 log was other error: `Could not connect to Apache Solr server`

It could be related to #1550