### PR TITLE
[BUGFIX] Fix validator for mandatory fields

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -361,7 +361,7 @@ class Indexer
                 if(strtotime($metadata['date'][0])) {
                     $solrDoc->setField('date', self::getFormattedDate($metadata['date'][0]));
                 }
-                $solrDoc->setField('record_id', $metadata['record_id'][0]);
+                $solrDoc->setField('record_id', $metadata['record_id'][0] ?? '');
                 $solrDoc->setField('purl', $metadata['purl'][0] ?? '');
                 $solrDoc->setField('location', $document->getLocation());
                 $solrDoc->setField('urn', $metadata['urn']);
@@ -703,8 +703,9 @@ class Indexer
     {
         if (is_array($authors)) {
             foreach ($authors as $i => $author) {
-                $splitName = explode(pack('C', 31), $author);
-                $authors[$i] = $splitName[0];
+                if (is_array($author)) {
+                    $authors[$i] = $author['name'];
+                }
             }
         }
         return $authors;

--- a/Classes/Validation/DocumentValidator.php
+++ b/Classes/Validation/DocumentValidator.php
@@ -80,10 +80,13 @@ class DocumentValidator
      */
     public function hasAllMandatoryMetadataFields(): bool
     {
-        foreach ($this->requiredMetadataFields as $requiredMetadataField) {
-            if (empty($this->metadata[$requiredMetadataField][0])) {
-                $this->logger->error('Missing required metadata field "' . $requiredMetadataField . '".');
-                return false;
+        //TODO: add the list of types that do not require mandatory metadata fields
+        if ($this->metadata['type'][0] !== 'chapter' && $this->metadata['type'][0] !== 'page') {
+            foreach ($this->requiredMetadataFields as $requiredMetadataField) {
+                if (empty($this->metadata[$requiredMetadataField][0])) {
+                    $this->logger->error('Missing required metadata field "' . $requiredMetadataField . '".');
+                    return false;
+                }
             }
         }
         return true;

--- a/Tests/Unit/Validation/DocumentValidatorTest.php
+++ b/Tests/Unit/Validation/DocumentValidatorTest.php
@@ -30,8 +30,25 @@ class DocumentValidatorTest extends UnitTestCase
     public function passesHasAllMandatoryMetadataFields()
     {
         $metadata = [
+            'type' => [
+                'newspaper'
+            ],
             'record_id' => [
                 'xyz'
+            ]
+        ];
+        $documentValidator = new DocumentValidator($metadata, $this->getRequiredMetadataFields());
+        self::assertTrue($documentValidator->hasAllMandatoryMetadataFields());
+    }
+
+    /**
+     * @test
+     */
+    public function passesHasNotMandatoryMetadataFieldsButType()
+    {
+        $metadata = [
+            'type' => [
+                'chapter'
             ]
         ];
         $documentValidator = new DocumentValidator($metadata, $this->getRequiredMetadataFields());
@@ -46,6 +63,9 @@ class DocumentValidatorTest extends UnitTestCase
         $metadata = [
             'document_format' => [
                 'METS'
+            ],
+            'type' => [
+                'newspaper'
             ]
         ];
         $documentValidator = new DocumentValidator($metadata, $this->getRequiredMetadataFields());


### PR DESCRIPTION
There is necessary to define list of the types which do not need to have `record_id`, eg. `chapter` and `page`.

Closes https://github.com/kitodo/kitodo-presentation/issues/1550