### PR TITLE
[FEATURE] Handle TEI fulltexts

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -70,6 +70,7 @@ page {
     kitodo-pageView-syncControl = EXT:dlf/Resources/Public/JavaScript/PageView/SyncControl.js
     kitodo-pageView-searchInDocument = EXT:dlf/Resources/Public/JavaScript/PageView/SearchInDocument.js
     kitodo-pageView-pageView = EXT:dlf/Resources/Public/JavaScript/PageView/PageView.js
+    kitodo-pageView-teiParser = EXT:dlf/Resources/Public/JavaScript/PageView/TeiParser.js
     kitodo-search-suggest = EXT:dlf/Resources/Public/JavaScript/Search/Suggester.js
   }
 }

--- a/Resources/Public/JavaScript/PageView/FullTextUtility.js
+++ b/Resources/Public/JavaScript/PageView/FullTextUtility.js
@@ -41,10 +41,10 @@ dlfFullTextUtils.isFeatureEqual = function(element, feature){
 
 /**
  * Method fetches the fulltext data from the server
- * @param {Object} fulltext
- * @param {Object} image
+ * @param {object} fulltext
+ * @param {object} image
  * @param {number=} optOffset
- * @return {FullTextFeature | undefined}
+ * @returns {FullTextFeature | undefined}
  * @static
  */
 dlfFullTextUtils.fetchFullTextDataFromServer = function(fulltext, image, optOffset) {
@@ -52,19 +52,19 @@ dlfFullTextUtils.fetchFullTextDataFromServer = function(fulltext, image, optOffs
     var url = fulltext.url;
     $.ajax({ url }).done(function (data, status, jqXHR) {
         try {
-            var data;
-            if(fulltext.mimetype == 'application/tei+xml') {
+            var fulltextResult;
+            if(fulltext.mimetype === 'application/tei+xml') {
               const params = new URLSearchParams(window.location.search);
               const pageId = params.get("tx_dlf[page]");
-              data = dlfFullTextUtils.parseTeiData(pageId, jqXHR);
+              fulltextResult = dlfFullTextUtils.parseTeiData(pageId, jqXHR);
             } else {
-              data = dlfFullTextUtils.parseAltoData(image, optOffset, jqXHR);
+              fulltextResult = dlfFullTextUtils.parseAltoData(image, optOffset, jqXHR);
             }
 
             if (data === undefined) {
                 result.reject();
             } else {
-                result.resolve(data);
+                result.resolve(fulltextResult);
             }
         } catch (e) {
             console.error(e); // eslint-disable-line no-console

--- a/Resources/Public/JavaScript/PageView/FullTextUtility.js
+++ b/Resources/Public/JavaScript/PageView/FullTextUtility.js
@@ -10,6 +10,8 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
+/* global dlfTeiParser */
+
  /**
  * Base namespace for utility functions used by the dlf module.
  *
@@ -94,12 +96,12 @@ dlfFullTextUtils.parseAltoData = function(image, offset, request){
 /**
  * Method parses TEI data
  * @param {string=} pageId
- * @param {Object} request
- * @return {Object}
+ * @param {object} request
+ * @returns {object}
  * @static
  */
 dlfFullTextUtils.parseTeiData = function(pageId, request){
-  var parser = new dlfTeiParser(pageId),
+  let parser = new dlfTeiParser(pageId),
   result = request.responseXML ? parser.parse(request.responseXML) :
       request.responseText ? parser.parse(request.responseText) : [];
   return result;

--- a/Resources/Public/JavaScript/PageView/FullTextUtility.js
+++ b/Resources/Public/JavaScript/PageView/FullTextUtility.js
@@ -101,8 +101,7 @@ dlfFullTextUtils.parseAltoData = function(image, offset, request){
  * @static
  */
 dlfFullTextUtils.parseTeiData = function(pageId, request){
-  let parser = new dlfTeiParser(pageId),
-  result = request.responseXML ? parser.parse(request.responseXML) :
+  const parser = new dlfTeiParser(pageId);
+  return request.responseXML ? parser.parse(request.responseXML) :
       request.responseText ? parser.parse(request.responseText) : [];
-  return result;
 };

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -264,7 +264,7 @@ dlfViewerFullTextControl.prototype.getFullTextScrollElementId = function() {
 dlfViewerFullTextControl.prototype.loadFulltextData = function (fulltextData) {
 
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type == 'tei') {
-      document.getElementById(this.getFullTextScrollElementId()).innerHTML = fulltextData.fulltext;
+      document.getElementById(this.getFullTextScrollElementId()).innerHTML = fulltextData.fulltextHtml;
       return;
     }
     // add features to fulltext layer

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -256,7 +256,7 @@ dlfViewerFullTextControl.prototype.getFullTextScrollElementId = function() {
       fullTextScrollElementId = fullTextScrollElementId.substr(1);
     }
     return fullTextScrollElementId.trim();
-}
+};
 
 /**
  * @param {FullTextFeature} fulltextData

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -264,7 +264,7 @@ dlfViewerFullTextControl.prototype.getFullTextScrollElementId = function() {
 dlfViewerFullTextControl.prototype.loadFulltextData = function (fulltextData) {
 
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type == 'tei') {
-      document.getElementById(this.getFullTextScrollElementId()).innerHTML = fulltextData.fulltextHtml;
+      document.getElementById(this.getFullTextScrollElementId()).innerHTML = fulltextData.fulltext;
       return;
     }
     // add features to fulltext layer

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -247,10 +247,26 @@ var dlfViewerFullTextControl = function(map) {
     this.changeActiveBehaviour();
 };
 
+
+dlfViewerFullTextControl.prototype.getFullTextScrollElementId = function() {
+    // in getElementById no '#' is necessary / allowed at the beginning
+    // of the string. Therefor remove '#' if pre
+    let fullTextScrollElementId = this.fullTextScrollElement;
+    if (fullTextScrollElementId.substr(0,1) === '#') {
+      fullTextScrollElementId = fullTextScrollElementId.substr(1);
+    }
+    return fullTextScrollElementId.trim();
+}
+
 /**
  * @param {FullTextFeature} fulltextData
  */
 dlfViewerFullTextControl.prototype.loadFulltextData = function (fulltextData) {
+
+    if(dlfUtils.exists(fulltextData.type) && fulltextData.type == 'tei') {
+      document.getElementById(this.getFullTextScrollElementId()).innerHTML = fulltextData.fulltext;
+      return;
+    }
     // add features to fulltext layer
     this.textblockFeatures_ = fulltextData.getTextblocks();
     this.layers_.textblock.getSource().addFeatures(this.textblockFeatures_);
@@ -262,13 +278,13 @@ dlfViewerFullTextControl.prototype.loadFulltextData = function (fulltextData) {
 
     // add first feature of textBlockFeatures to map
     if (this.textblockFeatures_.length > 0) {
-        this.layers_.select.getSource().addFeature(this.textblockFeatures_[0]);
-        this.selectedFeature_ = this.textblockFeatures_[0];
+      this.layers_.select.getSource().addFeature(this.textblockFeatures_[0]);
+      this.selectedFeature_ = this.textblockFeatures_[0];
 
-        // If the control is *not* yet active, the fulltext is instead rendered on activation.
-        if (this.isActive) {
-            this.showFulltext(this.textblockFeatures_);
-        }
+      // If the control is *not* yet active, the fulltext is instead rendered on activation.
+      if (this.isActive) {
+        this.showFulltext(this.textblockFeatures_);
+      }
     }
 };
 
@@ -606,13 +622,7 @@ dlfViewerFullTextControl.prototype.showFulltext = function(features) {
         return;
     }
 
-    // in getElementById no '#' is necessary / allowed at the beginning
-    // of the string. Therefor remove '#' if present
-    let fullTextScrollElementId = this.fullTextScrollElement;
-    if (fullTextScrollElementId.substr(0,1) === '#') {
-        fullTextScrollElementId = fullTextScrollElementId.substr(1);
-    }
-    var target = document.getElementById(fullTextScrollElementId.trim());
+    var target = document.getElementById(this.getFullTextScrollElementId());
     if (target !== null) {
         target.innerHTML = "";
         for (var feature of features) {

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -82,9 +82,11 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type === 'tei') {
       fileContent = fulltextData.fulltext;
       // Use regex to replace any whitespace (spaces or tabs) before '<'
+      // eslint-disable-next-line
       fileContent = fileContent.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
+      // eslint-disable-next-line
       fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -68,16 +68,16 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type == 'tei') {
       fileContent = fulltextData.fulltext;
       // Use regex to replace any whitespace (spaces or tabs) before '<'
-      fileContent = fileContent.replace(/[ \t]+</g, '<');
+      fileContent = fileContent.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
-      fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/g, '');
+      fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines
       fileContent = fileContent.split('\n').filter(line => line.trim() !== '').join('\n');
 
       // Replace </p> with newlines
-      fileContent = fileContent.replace(/<\/p>/g, '\n')
+      fileContent = fileContent.replace(/<\/p>/gu, '\n');
       return fileContent;
     }
 

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -1,3 +1,17 @@
+'use strict';
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+/* global dlfUtils */
+
 var dlfViewerFullTextDownloadControl = function(map, fulltextData) {
 
     /**
@@ -65,7 +79,7 @@ dlfViewerFullTextDownloadControl.prototype.downloadFullTextFile = function() {
  */
 dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fulltextData) {
     let fileContent = '';
-    if(dlfUtils.exists(fulltextData.type) && fulltextData.type == 'tei') {
+    if(dlfUtils.exists(fulltextData.type) && fulltextData.type === 'tei') {
       fileContent = fulltextData.fulltext;
       // Use regex to replace any whitespace (spaces or tabs) before '<'
       fileContent = fileContent.replace(/[ \t]+</gu, '<');

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -64,14 +64,31 @@ dlfViewerFullTextDownloadControl.prototype.downloadFullTextFile = function() {
  * @param {FullTextFeature} fulltextData
  */
 dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fulltextData) {
+    let fileContent = '';
+    if(dlfUtils.exists(fulltextData.type) && fulltextData.type == 'tei') {
+      fileContent = fulltextData.fulltext;
+      // Use regex to replace any whitespace (spaces or tabs) before '<'
+      fileContent = fileContent.replace(/[ \t]+</g, '<');
+
+      // Replace every tag except </p> with an empty string
+      fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/g, '');
+
+      // Remove empty lines
+      fileContent = fileContent.split('\n').filter(line => line.trim() !== '').join('\n');
+
+      // Replace </p> with newlines
+      fileContent = fileContent.replace(/<\/p>/g, '\n')
+      return fileContent;
+    }
+
+
     var features = fulltextData.getTextblocks();
-    var fileContent = '';
     for (var feature of features) {
-        var textLines = feature.get('textlines');
-        for (var textLine of textLines) {
-            fileContent = fileContent.concat(this.appendTextLine(textLine));
-        }
-        fileContent = fileContent.concat('\n\n');
+      var textLines = feature.get('textlines');
+      for (var textLine of textLines) {
+        fileContent = fileContent.concat(this.appendTextLine(textLine));
+      }
+      fileContent = fileContent.concat('\n\n');
     }
 
     return fileContent;

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -81,9 +81,11 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
       fileContent = dlfUtils.escapeHtml(fulltextData.fulltext);
 
       // Use regex to replace any whitespace (spaces or tabs) before '<'
+      // eslint-disable-next-line
       fileContent = fileContent.replace(/[ \t]+&lt;/gu, '&lt;');
 
       // Replace every tag except <p> with an empty string
+      // eslint-disable-next-line
       fileContent = fileContent.replace(/&lt;(?!\/?p&gt;)[^&]*?&gt;/gu, '');
 
       // Remove empty lines
@@ -93,7 +95,7 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
       fileContent = fileContent.replace(/&lt;\/?p&gt;/gu, '\n');
 
       // Remove leading empty lines
-      return fileContent.replace(/^\s*\n+/g, '');
+      return fileContent.replace(/^\s*\n+/gu, '');
     }
 
 

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -67,18 +67,18 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type === 'tei') {
       safeHtml = fulltextData.fulltext;
       // Use regex to replace any whitespace (spaces or tabs) before '<'
-      // eslint-disable-next-line security/detect-script-injection
+      // eslint-disable-next-line
       safeHtml = safeHtml.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
-      // eslint-disable-next-line security/detect-script-injection
+      // eslint-disable-next-line
       safeHtml = safeHtml.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines
       safeHtml = safeHtml.split('\n').filter(line => line.trim() !== '').join('\n');
 
       // Replace </p> with newlines
-      return afeHtml.replace(/<\/p>/gu, '\n');
+      return safeHtml.replace(/<\/p>/gu, '\n');
     }
 
     let fileContent = '';

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -1,17 +1,3 @@
-'use strict';
-
-/**
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/* global dlfUtils */
-
 var dlfViewerFullTextDownloadControl = function(map, fulltextData) {
 
     /**
@@ -82,11 +68,11 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type === 'tei') {
       fileContent = fulltextData.fulltext;
       // Use regex to replace any whitespace (spaces or tabs) before '<'
-      // eslint-disable-next-line
+      // eslint-disable-next-line security/detect-script-injection
       fileContent = fileContent.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
-      // eslint-disable-next-line
+      // eslint-disable-next-line security/detect-script-injection
       fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -1,3 +1,15 @@
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+/* global dlfUtils */
+
 var dlfViewerFullTextDownloadControl = function(map, fulltextData) {
 
     /**
@@ -64,24 +76,27 @@ dlfViewerFullTextDownloadControl.prototype.downloadFullTextFile = function() {
  * @param {FullTextFeature} fulltextData
  */
 dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fulltextData) {
+    let fileContent = '';
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type === 'tei') {
-      safeHtml = fulltextData.fulltext;
-      // Use regex to replace any whitespace (spaces or tabs) before '<'
-      // eslint-disable-next-line
-      safeHtml = safeHtml.replace(/[ \t]+</gu, '<');
+      fileContent = dlfUtils.escapeHtml(fulltextData.fulltext);
 
-      // Replace every tag except </p> with an empty string
-      // eslint-disable-next-line
-      safeHtml = safeHtml.replace(/<(?!\/p>)[^>]*>/gu, '');
+      // Use regex to replace any whitespace (spaces or tabs) before '<'
+      fileContent = fileContent.replace(/[ \t]+&lt;/gu, '&lt;');
+
+      // Replace every tag except <p> with an empty string
+      fileContent = fileContent.replace(/&lt;(?!\/?p&gt;)[^&]*?&gt;/gu, '');
 
       // Remove empty lines
-      safeHtml = safeHtml.split('\n').filter(line => line.trim() !== '').join('\n');
+      fileContent = fileContent.split('\n').filter(line => line.trim() !== '').join('\n');
 
-      // Replace </p> with newlines
-      return safeHtml.replace(/<\/p>/gu, '\n');
+      // Replace <p> with newlines
+      fileContent = fileContent.replace(/&lt;\/?p&gt;/gu, '\n');
+
+      // Remove leading empty lines
+      return fileContent.replace(/^\s*\n+/g, '');
     }
 
-    let fileContent = '';
+
     var features = fulltextData.getTextblocks();
     for (var feature of features) {
       var textLines = feature.get('textlines');
@@ -115,3 +130,5 @@ dlfViewerFullTextDownloadControl.prototype.appendTextLine = function(textLine) {
     }
     return fileContent;
 };
+
+

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -86,7 +86,7 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
       fileContent = fileContent.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
-      // codacy-disable-next-line
+      // eslint-disable-next-line
       fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -64,26 +64,24 @@ dlfViewerFullTextDownloadControl.prototype.downloadFullTextFile = function() {
  * @param {FullTextFeature} fulltextData
  */
 dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fulltextData) {
-    let fileContent = '';
     if(dlfUtils.exists(fulltextData.type) && fulltextData.type === 'tei') {
-      fileContent = fulltextData.fulltext;
+      safeHtml = fulltextData.fulltext;
       // Use regex to replace any whitespace (spaces or tabs) before '<'
       // eslint-disable-next-line security/detect-script-injection
-      fileContent = fileContent.replace(/[ \t]+</gu, '<');
+      safeHtml = safeHtml.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
       // eslint-disable-next-line security/detect-script-injection
-      fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/gu, '');
+      safeHtml = safeHtml.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines
-      fileContent = fileContent.split('\n').filter(line => line.trim() !== '').join('\n');
+      safeHtml = safeHtml.split('\n').filter(line => line.trim() !== '').join('\n');
 
       // Replace </p> with newlines
-      fileContent = fileContent.replace(/<\/p>/gu, '\n');
-      return fileContent;
+      return afeHtml.replace(/<\/p>/gu, '\n');
     }
 
-
+    let fileContent = '';
     var features = fulltextData.getTextblocks();
     for (var feature of features) {
       var textLines = feature.get('textlines');

--- a/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextDownloadControl.js
@@ -86,7 +86,7 @@ dlfViewerFullTextDownloadControl.prototype.createFullTextFile = function (fullte
       fileContent = fileContent.replace(/[ \t]+</gu, '<');
 
       // Replace every tag except </p> with an empty string
-      // eslint-disable-next-line
+      // codacy-disable-next-line
       fileContent = fileContent.replace(/<(?!\/p>)[^>]*>/gu, '');
 
       // Remove empty lines

--- a/Resources/Public/JavaScript/PageView/PageView.js
+++ b/Resources/Public/JavaScript/PageView/PageView.js
@@ -986,7 +986,7 @@ dlfViewer.prototype.initLoadFulltexts = function () {
         var image = this.images[i];
 
         if (dlfUtils.isFulltextDescriptor(fulltext)) {
-            this.fulltextsLoaded_[i] = dlfFullTextUtils.fetchFullTextDataFromServer(fulltext.url, image, xOffset);
+            this.fulltextsLoaded_[i] = dlfFullTextUtils.fetchFullTextDataFromServer(fulltext, image, xOffset);
         }
 
         xOffset += image.width;

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -19,7 +19,7 @@ var dlfTeiParser = function(pageId) {
      * @type {string|undefined}
      * @private
      */
-    this.pageId = dlfUtils.exists(pageId) ? pageId : undefined;
+    this.pageId = pageId;
 };
 
 /**
@@ -31,6 +31,7 @@ dlfTeiParser.prototype.parse = function(document) {
     let contentHtml = $(parsedDoc).find('text')[0].innerHTML;
 
     // Remove tags but keep their content
+    // eslint-disable-next-line
     contentHtml = contentHtml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
     // Replace linebreaks
@@ -43,9 +44,12 @@ dlfTeiParser.prototype.parse = function(document) {
     const facsHtml = {};
     let match;
 
+   // eslint-disable-next-line
     while ((match = regex.exec(contentHtml)) !== null) {
+      // eslint-disable-next-line
       const facsMatch = match[1].trim();
       const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch;
+      // eslint-disable-next-line
       facsHtml[facs] = match[2].trim(); // Everything until next <pb /> or end of string
     }
 

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -1,0 +1,76 @@
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * @constructor
+ * @param {string=} pageId
+ */
+var dlfTeiParser = function(pageId) {
+    /**
+     * @type {string|undefined}
+     * @private
+     */
+    this.pageId_ = dlfUtils.exists(pageId) ? pageId : undefined;
+};
+
+/**
+ * @param {XMLDocument|string} document
+ * @return {Object}
+ */
+dlfTeiParser.prototype.parse = function(document) {
+    let parsedDoc = this.parseXML_(document),
+        xml = $(parsedDoc).find('text')[0].innerHTML;
+
+    // Remove tags but keep their content
+    xml = xml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/g, '');
+
+    // Replace linebreaks
+    xml = xml.replace(/<lb(?:\s[^>]*)?\/>/g, '<br/>');
+
+    // Extract content between each <pb /> and the next <pb /> or end of string
+    const regex = /<pb[^>]*facs="([^"]+)"[^>]*\/>([\s\S]*?)(?=<pb[^>]*\/>|$)/g;
+
+    const facsMap = {};
+    let match;
+
+    while ((match = regex.exec(xml)) !== null) {
+      const facsMatch = match[1].trim(); // e.g. "#f0002"
+      const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch; // e.g. "f0002"
+      const content = match[2].trim(); // everything until next <pb /> or end of string
+      facsMap[facs] = content;
+    }
+
+    let fulltext = facsMap[this.getFacsMapId()];
+    return { type: 'tei', fulltext: dlfUtils.exists(fulltext) ? fulltext + '<br/>' : '' };
+};
+
+/**
+ * @return {string}
+ * @private
+ */
+dlfTeiParser.prototype.getFacsMapId = function() {
+  if (!isNaN(this.pageId_) && this.pageId_ !== null && this.pageId_ !== '') {
+    return 'f' + String(this.pageId_).padStart(4, '0');
+  }
+  return this.pageId_;
+}
+
+/**
+ *
+ * @param {XMLDocument|string}
+ * @return {XMLDocument}
+ * @private
+ */
+dlfTeiParser.prototype.parseXML_ = function(document) {
+    if (typeof document === 'string' || document instanceof String) {
+        return $.parseXML(document);
+    }
+    return document;
+};

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -34,13 +34,15 @@ dlfTeiParser.prototype.parse = function(document) {
     // Remove all <script> elements
     parsedDoc.querySelectorAll('script').forEach(script => script.remove());
 
-    let content = dlfUtils.escapeHtml($(parsedDoc).find('text')[0].innerHTML);
+    let contentHtml = $(parsedDoc).find('text')[0].innerHTML;
 
     // Remove tags but keep their content
-    content = content.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
+    // eslint-disable-next-line
+    contentHtml = contentHtml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
     // Replace linebreaks
-    content = content.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
+    // eslint-disable-next-line
+    contentHtml = contentHtml.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
 
     // Extract content between each <pb /> and the next <pb /> or end of string
     const regex = /<pb[^>]*facs="([^"]+)"[^>]*\/>([\s\S]*?)(?=<pb[^>]*\/>|$)/gu;
@@ -49,7 +51,7 @@ dlfTeiParser.prototype.parse = function(document) {
     let match;
 
    // eslint-disable-next-line
-    while ((match = regex.exec(content)) !== null) {
+    while ((match = regex.exec(contentHtml)) !== null) {
       // eslint-disable-next-line
       const facsMatch = match[1].trim();
       const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch;

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -30,6 +30,10 @@ class dlfTeiParser {y
  */
 dlfTeiParser.prototype.parse = function(document) {
     const parsedDoc = this.parseXML(document);
+
+    // Remove all <script> elements
+    parsedDoc.querySelectorAll('script').forEach(script => script.remove());
+
     let contentHtml = $(parsedDoc).find('text')[0].innerHTML;
 
     // Remove tags but keep their content

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -34,15 +34,13 @@ dlfTeiParser.prototype.parse = function(document) {
     // Remove all <script> elements
     parsedDoc.querySelectorAll('script').forEach(script => script.remove());
 
-    let contentHtml = $(parsedDoc).find('text')[0].innerHTML;
+    let content = dlfUtils.escapeHtml($(parsedDoc).find('text')[0].innerHTML);
 
     // Remove tags but keep their content
-    // eslint-disable-next-line
-    contentHtml = contentHtml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
+    content = content.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
     // Replace linebreaks
-    // eslint-disable-next-line
-    contentHtml = contentHtml.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
+    content = content.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
 
     // Extract content between each <pb /> and the next <pb /> or end of string
     const regex = /<pb[^>]*facs="([^"]+)"[^>]*\/>([\s\S]*?)(?=<pb[^>]*\/>|$)/gu;
@@ -51,7 +49,7 @@ dlfTeiParser.prototype.parse = function(document) {
     let match;
 
    // eslint-disable-next-line
-    while ((match = regex.exec(contentHtml)) !== null) {
+    while ((match = regex.exec(content)) !== null) {
       // eslint-disable-next-line
       const facsMatch = match[1].trim();
       const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch;

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -27,13 +27,13 @@ var dlfTeiParser = function(pageId) {
  * @returns {object}
  */
 dlfTeiParser.prototype.parse = function(document) {
-    const parsedDoc = this.parseXML(document),
-        content = $(parsedDoc).find('text')[0].innerHTML;
+    const parsedDoc = this.parseXML(document);
+    let content = $(parsedDoc).find('text')[0].innerHTML;
 
-    // Remove tags but keep their content
+    // remove tags but keep their content
     content = content.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
-    // Replace linebreaks
+    // replace linebreaks
     content = content.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
 
     // Extract content between each <pb /> and the next <pb /> or end of string
@@ -48,8 +48,8 @@ dlfTeiParser.prototype.parse = function(document) {
       facsMap[facs] = match[2].trim(); // everything until next <pb /> or end of string
     }
 
-    let fulltext = facsMap[this.getFacsMapId()];
-    return { type: 'tei', fulltext: dlfUtils.exists(fulltext) ? fulltext + '<br/>' : '' };
+    const fulltextHtml = facsMap[this.getFacsMapId()];
+    return { type: 'tei', fulltext: dlfUtils.exists(fulltextHtml) ? fulltextHtml + '<br/>' : '' };
 };
 
 /**

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -17,15 +17,15 @@ var dlfTeiParser = function(pageId) {
      * @type {string|undefined}
      * @private
      */
-    this.pageId_ = dlfUtils.exists(pageId) ? pageId : undefined;
+    this.pageId = dlfUtils.exists(pageId) ? pageId : undefined;
 };
 
 /**
  * @param {XMLDocument|string} document
- * @return {Object}
+ * @returns {Object}
  */
 dlfTeiParser.prototype.parse = function(document) {
-    let parsedDoc = this.parseXML_(document),
+    let parsedDoc = this.parseXML(document),
         xml = $(parsedDoc).find('text')[0].innerHTML;
 
     // Remove tags but keep their content
@@ -56,19 +56,19 @@ dlfTeiParser.prototype.parse = function(document) {
  * @private
  */
 dlfTeiParser.prototype.getFacsMapId = function() {
-  if (!isNaN(this.pageId_) && this.pageId_ !== null && this.pageId_ !== '') {
-    return 'f' + String(this.pageId_).padStart(4, '0');
+  if (!isNaN(this.pageId) && this.pageId !== null && this.pageId !== '') {
+    return 'f' + String(this.pageId).padStart(4, '0');
   }
-  return this.pageId_;
+  return this.pageId;
 }
 
 /**
  *
- * @param {XMLDocument|string}
- * @return {XMLDocument}
+ * @param {XMLDocument|string} document
+ * @returns {XMLDocument}
  * @private
  */
-dlfTeiParser.prototype.parseXML_ = function(document) {
+dlfTeiParser.prototype.parseXML = function(document) {
     if (typeof document === 'string' || document instanceof String) {
         return $.parseXML(document);
     }

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -34,6 +34,7 @@ dlfTeiParser.prototype.parse = function(document) {
     contentHtml = contentHtml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
     // Replace linebreaks
+    // eslint-disable-next-line
     contentHtml = contentHtml.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
 
     // Extract content between each <pb /> and the next <pb /> or end of string
@@ -48,7 +49,8 @@ dlfTeiParser.prototype.parse = function(document) {
       facsHtml[facs] = match[2].trim(); // Everything until next <pb /> or end of string
     }
 
-    const fulltextHtml = facsMap[this.getFacsMapId()];
+    const fulltextHtml = facsHtml[this.getFacsMapId()];
+    // eslint-disable-next-line
     return { type: 'tei', fulltext: dlfUtils.exists(fulltextHtml) ? fulltextHtml + '<br/>' : '' };
 };
 

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -14,12 +14,14 @@
  * @class
  * @param {string=} pageId
  */
-var dlfTeiParser = function(pageId) {
-    /**
-     * @type {string|undefined}
-     * @private
-     */
-    this.pageId = pageId;
+class dlfTeiParser {y
+    constructor(pageId) {
+      /**
+       * @type {string|undefined}
+       * @private
+       */
+      this.pageId = dlfUtils.exists(pageId) ? pageId : undefined;
+    }
 };
 
 /**

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -8,8 +8,10 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
+/* global dlfUtils */
+
 /**
- * @constructor
+ * @class
  * @param {string=} pageId
  */
 var dlfTeiParser = function(pageId) {
@@ -22,29 +24,28 @@ var dlfTeiParser = function(pageId) {
 
 /**
  * @param {XMLDocument|string} document
- * @returns {Object}
+ * @returns {object}
  */
 dlfTeiParser.prototype.parse = function(document) {
-    let parsedDoc = this.parseXML(document),
-        xml = $(parsedDoc).find('text')[0].innerHTML;
+    const parsedDoc = this.parseXML(document),
+        content = $(parsedDoc).find('text')[0].innerHTML;
 
     // Remove tags but keep their content
-    xml = xml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/g, '');
+    content = content.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
     // Replace linebreaks
-    xml = xml.replace(/<lb(?:\s[^>]*)?\/>/g, '<br/>');
+    content = content.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
 
     // Extract content between each <pb /> and the next <pb /> or end of string
-    const regex = /<pb[^>]*facs="([^"]+)"[^>]*\/>([\s\S]*?)(?=<pb[^>]*\/>|$)/g;
+    const regex = /<pb[^>]*facs="([^"]+)"[^>]*\/>([\s\S]*?)(?=<pb[^>]*\/>|$)/gu;
 
     const facsMap = {};
     let match;
 
-    while ((match = regex.exec(xml)) !== null) {
+    while ((match = regex.exec(content)) !== null) {
       const facsMatch = match[1].trim(); // e.g. "#f0002"
       const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch; // e.g. "f0002"
-      const content = match[2].trim(); // everything until next <pb /> or end of string
-      facsMap[facs] = content;
+      facsMap[facs] = match[2].trim(); // everything until next <pb /> or end of string
     }
 
     let fulltext = facsMap[this.getFacsMapId()];

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -28,24 +28,24 @@ var dlfTeiParser = function(pageId) {
  */
 dlfTeiParser.prototype.parse = function(document) {
     const parsedDoc = this.parseXML(document);
-    let content = $(parsedDoc).find('text')[0].innerHTML;
+    let contentHtml = $(parsedDoc).find('text')[0].innerHTML;
 
-    // remove tags but keep their content
-    content = content.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
+    // Remove tags but keep their content
+    contentHtml = contentHtml.replace(/<\/?(body|front|div|head|titlePage)[^>]*>/gu, '');
 
-    // replace linebreaks
-    content = content.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
+    // Replace linebreaks
+    contentHtml = contentHtml.replace(/<lb(?:\s[^>]*)?\/>/gu, '<br/>');
 
     // Extract content between each <pb /> and the next <pb /> or end of string
     const regex = /<pb[^>]*facs="([^"]+)"[^>]*\/>([\s\S]*?)(?=<pb[^>]*\/>|$)/gu;
 
-    const facsMap = {};
+    const facsHtml = {};
     let match;
 
-    while ((match = regex.exec(content)) !== null) {
-      const facsMatch = match[1].trim(); // e.g. "#f0002"
-      const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch; // e.g. "f0002"
-      facsMap[facs] = match[2].trim(); // everything until next <pb /> or end of string
+    while ((match = regex.exec(contentHtml)) !== null) {
+      const facsMatch = match[1].trim();
+      const facs =  facsMatch.startsWith("#") ? facsMatch.slice(1) : facsMatch;
+      facsHtml[facs] = match[2].trim(); // Everything until next <pb /> or end of string
     }
 
     const fulltextHtml = facsMap[this.getFacsMapId()];
@@ -53,7 +53,7 @@ dlfTeiParser.prototype.parse = function(document) {
 };
 
 /**
- * @return {string}
+ * @returns {string}
  * @private
  */
 dlfTeiParser.prototype.getFacsMapId = function() {

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -220,7 +220,7 @@ dlfUtils.exists = function (val) {
 
 
 /**
- * Excape html
+ * Escape html
  *
  * @param {string} html
  * @returns {string} escaped html

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -232,7 +232,7 @@ dlfUtils.escapeHtml = function(html) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
-}
+};
 
 /**
  * Fetch image data for given image sources.

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -218,6 +218,22 @@ dlfUtils.exists = function (val) {
     return val !== undefined;
 };
 
+
+/**
+ * Excape html
+ *
+ * @param {string} html
+ * @returns {string} escaped html
+ */
+dlfUtils.escapeHtml = function(html) {
+  return html
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 /**
  * Fetch image data for given image sources.
  *


### PR DESCRIPTION
- Add parser for TEI (DTABf) fulltext
- Add fulltext to FulltextControl and FulltextDownloadControl

Implementation details:
- The tx_dlf[page] parameter is used and converted into a FACS identifier to reference the correct page break (referencing by the identifier of mets:div is not implemented at the moment, but I will add that once I have an example for it or generate one in my local environment)
- The FULLTEXT FileGroup must contain a file with the attribute MIMETYPE="application/tei+xml", for example:
```
      <ns2:fileGrp USE="FULLTEXT">
        <ns2:file ID="uuid-60447140-edd8-40b5-8860-ec323d8a4f22" MIMETYPE="application/tei+xml">
            <ns2:FLocat LOCTYPE="URL" ns4:href="https://dfg-viewer-typo3-11.ddev.site/fileadmin/examples/312453388/feinere_kochkunst.xml" />
        </ns2:file>
      </ns2:fileGrp>
```
-  A PhysicalDivision element with type "page" includes a FilePointer referencing the corresponding TEI file
```
        <ns2:div ID="PHYS_0528" TYPE="page" ORDER="528" ORDERLABEL="494">
...
            <ns2:fptr FILEID="uuid-60447140-edd8-40b5-8860-ec323d8a4f22" />
...
         </ns2:div>
```
-  A test using METS and TEI with 572 pages ran without any performance issues