### PR TITLE
[DOCUMENTATION] Update documentation about kitodo:dbdocs command

### DIFF
--- a/Classes/Command/DbDocs/Generator.php
+++ b/Classes/Command/DbDocs/Generator.php
@@ -255,7 +255,7 @@ class Generator
         $page->addText(<<<RST
 This is a reference of all database tables defined by Kitodo.Presentation.
 
-.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs`` from the composer-based Typo3 install directory (not the Kitodo.Presentation source directory).
+.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs`` from the composer-based TYPO3 install directory (not the Kitodo.Presentation source directory).
 RST);
 
         // Sort tables alphabetically

--- a/Classes/Command/DbDocs/Generator.php
+++ b/Classes/Command/DbDocs/Generator.php
@@ -255,7 +255,7 @@ class Generator
         $page->addText(<<<RST
 This is a reference of all database tables defined by Kitodo.Presentation.
 
-.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs``.
+.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs`` from the composer-based Typo3 install directory (not the Kitodo.Presentation source directory).
 RST);
 
         // Sort tables alphabetically

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -115,7 +115,7 @@ composer docs:stop
 
 ### Database Documentation
 
-Generate the database reference table by running the following command from the composer-based Typo3 install directory (not the Kitodo.Presentation source directory):
+Generate the database reference table by running the following command from the composer-based TYPO3 install directory (not the Kitodo.Presentation source directory):
 
 ```bash
 vendor/bin/typo3 kitodo:dbdocs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -115,11 +115,10 @@ composer docs:stop
 
 ### Database Documentation
 
-Generate the database reference table:
+Generate the database reference table by running the following command from the composer-based Typo3 install directory (not the Kitodo.Presentation source directory):
 
 ```bash
-composer install
-typo3 kitodo:dbdocs
+vendor/bin/typo3 kitodo:dbdocs
 ```
 
 ### Troubleshooting

--- a/Documentation/Developers/Database.rst
+++ b/Documentation/Developers/Database.rst
@@ -4,7 +4,7 @@ Database Tables
 
 This is a reference of all database tables defined by Kitodo.Presentation.
 
-.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``typo3 kitodo:dbdocs`` inside the Kitodo.Presentation base folder.
+.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs`` from the composer-based Typo3 install directory (not the Kitodo.Presentation source directory).
 
 tx_dlf_actionlog: Action protocol
 =================================

--- a/Documentation/Developers/Database.rst
+++ b/Documentation/Developers/Database.rst
@@ -4,7 +4,7 @@ Database Tables
 
 This is a reference of all database tables defined by Kitodo.Presentation.
 
-.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs`` from the composer-based Typo3 install directory (not the Kitodo.Presentation source directory).
+.. tip:: This page is auto-generated. If you would like to edit it, please use doc-comments in the model class, COMMENT fields in ``ext_tables.sql`` if the table does not have one, or TCA labels. Then, you may re-generate the page by running ``vendor/bin/typo3 kitodo:dbdocs`` from the composer-based TYPO3 install directory (not the Kitodo.Presentation source directory).
 
 tx_dlf_actionlog: Action protocol
 =================================


### PR DESCRIPTION
This pull requests improves the documentation by clarifying how the `kitodo:dbdocs` command should be run, see #1572 and #1559.