### PR TITLE
[BUGFIX] Fixes navigation URL encoding and measure navigation

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -140,6 +140,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             'requestData' => $this->requestData
         ];
 
+        // Workaround cause ViewHelper f:link.action / UriBuilder does not properly encode specified entities in URL parameter
+        // For more details, please see the following TYPO3 issue https://forge.typo3.org/issues/107026
         if( isset($this->requestData['id']) ) {
            $this->viewData['partlyEncodedId'] = str_replace("%2F", "%252F", $this->requestData['id']);
         }

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -140,7 +140,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             'requestData' => $this->requestData
         ];
 
-        // Workaround cause ViewHelper f:link.action / UriBuilder does not properly encode specified entities in URL parameter
+        // TODO: ViewHelper f:link.action / UriBuilder does not properly encode specified entities in URL parameter
         // For more details, please see the following TYPO3 issue https://forge.typo3.org/issues/107026
         if ( isset($this->requestData['id']) ) {
             $this->viewData['partlyEncodedId'] = str_replace("%2F", "%252F", $this->requestData['id']);

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -140,6 +140,10 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             'requestData' => $this->requestData
         ];
 
+        if( isset($this->requestData['id']) ) {
+           $this->viewData['partlyEncodedId'] = str_replace("%2F", "%252F", $this->requestData['id']);
+        }
+
         try {
             $this->viewData['publicResourcePath'] = PathUtility::getPublicResourceWebPath('EXT:dlf/Resources/Public');
         } catch (InvalidFileException) {

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -142,8 +142,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
         // Workaround cause ViewHelper f:link.action / UriBuilder does not properly encode specified entities in URL parameter
         // For more details, please see the following TYPO3 issue https://forge.typo3.org/issues/107026
-        if( isset($this->requestData['id']) ) {
-           $this->viewData['partlyEncodedId'] = str_replace("%2F", "%252F", $this->requestData['id']);
+        if ( isset($this->requestData['id']) ) {
+            $this->viewData['partlyEncodedId'] = str_replace("%2F", "%252F", $this->requestData['id']);
         }
 
         try {

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -135,8 +135,8 @@ class NavigationController extends AbstractController
                 $musicalStructure = $this->document->getCurrentDocument()->musicalStructure;
                 $musicalStructureInfo = $this->document->getCurrentDocument()->musicalStructureInfo;
                 for ($i = 1; $i <= $this->document->getCurrentDocument()->numMeasures; $i++) {
-                    if (array_key_exists($i, $musicalStructure) && array_key_exists($i, $musicalStructureInfo)) {
-                        $measureOptions[$i] = '[' . $i . ']' . ($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel'] ? ' - ' . htmlspecialchars($musicalStructureInfo[$musicalStructureInfo[$i]]['orderlabel']) : '');
+                    if (isset($musicalStructure[$i]) && array_key_exists($i, $musicalStructure) && isset($musicalStructureInfo) && array_key_exists($musicalStructure[$i]['measureid'],$musicalStructureInfo)) {
+                        $measureOptions[$i] = '[' . $i . ']' . ($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel'] ? ' - ' . htmlspecialchars($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel']) : '');
                         $measurePages[$i] = $musicalStructure[$i]['page'];
                     }
                 }

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -138,7 +138,7 @@ class NavigationController extends AbstractController
                     if (isset($musicalStructure[$i])
                         && array_key_exists($i, $musicalStructure)
                         && isset($musicalStructureInfo)
-                        && array_key_exists($musicalStructure[$i]['measureid'],$musicalStructureInfo)) {
+                        && array_key_exists($musicalStructure[$i]['measureid'], $musicalStructureInfo)) {
                         $measureOptions[$i] = '[' . $i . ']' . ($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel'] ? ' - ' . htmlspecialchars($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel']) : '');
                         $measurePages[$i] = $musicalStructure[$i]['page'];
                     }

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -135,11 +135,9 @@ class NavigationController extends AbstractController
                 $musicalStructure = $this->document->getCurrentDocument()->musicalStructure;
                 $musicalStructureInfo = $this->document->getCurrentDocument()->musicalStructureInfo;
                 for ($i = 1; $i <= $this->document->getCurrentDocument()->numMeasures; $i++) {
-                    if (isset($musicalStructure[$i])
-                        && array_key_exists($i, $musicalStructure)
-                        && isset($musicalStructureInfo)
-                        && array_key_exists($musicalStructure[$i]['measureid'], $musicalStructureInfo)) {
-                        $measureOptions[$i] = '[' . $i . ']' . ($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel'] ? ' - ' . htmlspecialchars($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel']) : '');
+                    if (isset($musicalStructure[$i]['measureid'])
+                        && isset($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel'])) {
+                        $measureOptions[$i] = '[' . $i . ']' . (!empty($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel']) ? ' - ' . htmlspecialchars($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel']) : '');
                         $measurePages[$i] = $musicalStructure[$i]['page'];
                     }
                 }

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -135,7 +135,10 @@ class NavigationController extends AbstractController
                 $musicalStructure = $this->document->getCurrentDocument()->musicalStructure;
                 $musicalStructureInfo = $this->document->getCurrentDocument()->musicalStructureInfo;
                 for ($i = 1; $i <= $this->document->getCurrentDocument()->numMeasures; $i++) {
-                    if (isset($musicalStructure[$i]) && array_key_exists($i, $musicalStructure) && isset($musicalStructureInfo) && array_key_exists($musicalStructure[$i]['measureid'],$musicalStructureInfo)) {
+                    if (isset($musicalStructure[$i])
+                        && array_key_exists($i, $musicalStructure)
+                        && isset($musicalStructureInfo)
+                        && array_key_exists($musicalStructure[$i]['measureid'],$musicalStructureInfo)) {
                         $measureOptions[$i] = '[' . $i . ']' . ($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel'] ? ' - ' . htmlspecialchars($musicalStructureInfo[$musicalStructure[$i]['measureid']]['orderlabel']) : '');
                         $measurePages[$i] = $musicalStructure[$i]['page'];
                     }

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -530,10 +530,7 @@ class PageViewController extends AbstractController
             }
 
             $docMeasures = $this->getMeasures($docPage);
-            if (isset($docMeasures['measureCounterToMeasureId'])
-                && count($docMeasures['measureCounterToMeasureId']) > 0
-                && isset($this->requestData['measure'])
-                && array_key_exists($this->requestData['measure'], $docMeasures['measureCounterToMeasureId'])) {
+            if (isset($docMeasures['measureCounterToMeasureId'][$this->requestData['measure']])) {
                 $currentMeasureId = $docMeasures['measureCounterToMeasureId'][$this->requestData['measure']];
             }
 

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -523,7 +523,11 @@ class PageViewController extends AbstractController
                 });';
         } else {
             $currentMeasureId = '';
-            $docPage = $this->requestData['page'] ?? 0;
+            $docPage = 0;
+
+            if (isset($this->requestData['page'])) {
+                $docPage = $this->requestData['page'];
+            }
 
             $docMeasures = $this->getMeasures($docPage);
             if (isset($docMeasures['measureCounterToMeasureId']) && count($docMeasures['measureCounterToMeasureId']) > 0 && isset($this->requestData['measure']) && $this->requestData['measure'] ?? false) {

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -533,7 +533,7 @@ class PageViewController extends AbstractController
             if (isset($docMeasures['measureCounterToMeasureId'])
                 && count($docMeasures['measureCounterToMeasureId']) > 0
                 && isset($this->requestData['measure'])
-                && array_key_exists($this->requestData['measure'],$docMeasures['measureCounterToMeasureId'])) {
+                && array_key_exists($this->requestData['measure'], $docMeasures['measureCounterToMeasureId'])) {
                 $currentMeasureId = $docMeasures['measureCounterToMeasureId'][$this->requestData['measure']];
             }
 

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -530,7 +530,10 @@ class PageViewController extends AbstractController
             }
 
             $docMeasures = $this->getMeasures($docPage);
-            if (isset($docMeasures['measureCounterToMeasureId']) && count($docMeasures['measureCounterToMeasureId']) > 0 && isset($this->requestData['measure']) && $this->requestData['measure'] ?? false) {
+            if (isset($docMeasures['measureCounterToMeasureId'])
+                && count($docMeasures['measureCounterToMeasureId']) > 0
+                && isset($this->requestData['measure'])
+                && array_key_exists($this->requestData['measure'],$docMeasures['measureCounterToMeasureId'])) {
                 $currentMeasureId = $docMeasures['measureCounterToMeasureId'][$this->requestData['measure']];
             }
 

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -526,7 +526,7 @@ class PageViewController extends AbstractController
             $docPage = $this->requestData['page'] ?? 0;
 
             $docMeasures = $this->getMeasures($docPage);
-            if ($this->requestData['measure'] ?? false) {
+            if (isset($docMeasures['measureCounterToMeasureId']) && count($docMeasures['measureCounterToMeasureId']) > 0 && isset($this->requestData['measure']) && $this->requestData['measure'] ?? false) {
                 $currentMeasureId = $docMeasures['measureCounterToMeasureId'][$this->requestData['measure']];
             }
 

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -26,16 +26,16 @@
             <f:if condition="{viewData.requestData.double}">
                 <f:then>
                     <div class="tx-dlf-navigation-single">
-                        <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'0'}"
-                                       argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                        <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'0','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                       argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                             <f:translate key="doublePageOff"/>
                         </f:link.action>
                     </div>
                     <div class="tx-dlf-navigation-double+">
                         <f:if condition="{viewData.requestData.double} && ({viewData.requestData.page} < {numPages})">
                             <f:then>
-                                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}'}"
-                                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                                     <f:translate key="doublePage+1"/>
                                 </f:link.action>
                             </f:then>
@@ -49,8 +49,8 @@
                 </f:then>
                 <f:else>
                     <div class="tx-dlf-navigation-double">
-                        <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'1'}"
-                                       argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                        <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[double]':'1','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                       argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                             <f:translate key="doublePageOn"/>
                         </f:link.action>
                     </div>
@@ -72,8 +72,8 @@
     <div class="tx-dlf-navigation-first">
         <f:if condition="{viewData.requestData.page} > 1">
             <f:then>
-                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'1'}"
-                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'1', 'tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                     <f:translate key="firstPage"/>
                 </f:link.action>
             </f:then>
@@ -90,8 +90,8 @@
     <div class="tx-dlf-navigation-back">
         <f:if condition="{viewData.requestData.page} > {pageSteps}">
             <f:then>
-                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}'}"
-                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - pageSteps}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                     <f:translate key="backXPages" arguments="{0: '{pageSteps}'}"/>
                 </f:link.action>
             </f:then>
@@ -108,8 +108,8 @@
     <div class="tx-dlf-navigation-prev">
         <f:if condition="{viewData.requestData.page} > {viewData.requestData.double + 1}">
             <f:then>
-                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}'}"
-                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page - 1 - viewData.requestData.double}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                     <f:translate key="prevPage"/>
                 </f:link.action>
             </f:then>
@@ -150,8 +150,8 @@
     <div class="tx-dlf-navigation-next">
         <f:if condition="{viewData.requestData.page + viewData.requestData.double} < {numPages}">
             <f:then>
-                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1 + viewData.requestData.double}'}"
-                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + 1 + viewData.requestData.double}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                     <f:translate key="nextPage"/>
                 </f:link.action>
             </f:then>
@@ -168,8 +168,8 @@
         <div class="tx-dlf-navigation-fwd">
             <f:if condition="{viewData.requestData.page} <= {numPages - pageSteps}">
                 <f:then>
-                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}'}"
-                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                    <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{viewData.requestData.page + pageSteps}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                                   argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                         <f:translate key="forwardXPages" arguments="{0: '{pageSteps}'}"/>
                     </f:link.action>
                 </f:then>
@@ -186,8 +186,8 @@
     <div class="tx-dlf-navigation-last">
         <f:if condition="{viewData.requestData.page} < {numPages - viewData.requestData.double}">
             <f:then>
-                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}'}"
-                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]'}">
+                <f:link.action addQueryString="untrusted" additionalParams="{'tx_dlf[page]':'{numPages - viewData.requestData.double}','tx_dlf[id]':'{viewData.partlyEncodedId}'}"
+                               argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[measure]', 1: 'tx_dlf[id]'}">
                     <f:translate key="lastPage"/>
                 </f:link.action>
             </f:then>


### PR DESCRIPTION
- Implement workaround cause ViewHelper f:link.action / UriBuilder does not properly encode specified entities in URL parameter
  - For more details, please see the following TYPO3 issue https://forge.typo3.org/issues/107026
- Fix measure navigation - cause behavior of jumping to the next measure page did not work