### PR TITLE
[BUGFIX] filter for physSequence type where no fulltext is present

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1177,7 +1177,8 @@ final class MetsDocument extends AbstractDocument
             $physicalStructureNode = $this->physicalStructureInfo[$id];
             $fileLocations = [];
 
-            if (!empty($physicalStructureNode)) {
+            if (!empty($physicalStructureNode)
+                && (!isset($physicalStructureNode['type']) || $physicalStructureNode['type'] !== 'physSequence')) {
                 while ($useGroup = array_shift($useGroups)) {
                     $fileLocations[$useGroup] = $this->getFileLocation($physicalStructureNode['files'][$useGroup]);
                 }


### PR DESCRIPTION
This Fix Issues in PR #1665 
@sebastian-meyer Please have a look into it, if this is the intended use.

In this fixed Line it gets the File Location of the Fulltexts in the Physical structMap.
In debugging and in the XML you can see the PHYS_0000 is just TYPE="physSequence" don't have any fulltext elements, so the Array Key is Missing. We can filter for the Type, but i don't know if they could have fulltext elements. We might have to look into the METS/MODS specification.

```XML
...
<mets:structMap TYPE="PHYSICAL">
<mets:div ID="PHYS_0000" TYPE="physSequence">
  <mets:div ID="PHYS_0001" ORDER="1" TYPE="page">
    <mets:fptr FILEID="FILE_0001_DEFAULT"/>
    <mets:fptr FILEID="FILE_0001_FULLTEXT"/>
    <mets:fptr FILEID="FILE_0001_THUMBS"/>
  </mets:div>
  <mets:div ID="PHYS_0002" ORDER="2" TYPE="page">
    <mets:fptr FILEID="FILE_0002_DEFAULT"/>
    <mets:fptr FILEID="FILE_0002_FULLTEXT"/>
    <mets:fptr FILEID="FILE_0002_THUMBS"/>
  </mets:div>
</mets:div>
....

```