### PR TITLE
[MAINTENANCE] Support PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "docs": "https://docs.typo3.org/p/kitodo/presentation/main/en-us/"
   },
   "require": {
-    "php": "7.4 - 8.3",
+    "php": "7.4 - 8.4",
     "ext-curl": "*",
     "ext-dom": "*",
     "ext-json": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'misc',
     'constraints' => [
         'depends' => [
-            'php' => '7.4.0-8.3.99',
+            'php' => '7.4.0-8.4.99',
             'typo3' => '10.4.0-11.5.99'
         ],
         'conflicts' => [],


### PR DESCRIPTION
The latest stable release of Debian GNU/Linux comes with PHP 8.4. In my [test installation](https://digital.ladenburg.world/kitodo/), it works fine with Kitodo.Presentation 5.1.x after I enabled PHP 8.4.