### PR TITLE
[BUGFIX] Allow null for 1st argument of DocumentRepository::getChildrenOfYearAnchor

### DIFF
--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -126,12 +126,12 @@ class DocumentRepository extends Repository
     /**
      * @access public
      *
-     * @param int $partOf
+     * @param int|null $partOf
      * @param Structure $structure
      *
      * @return array|QueryResultInterface
      */
-    public function getChildrenOfYearAnchor(int $partOf, Structure $structure): array|QueryResultInterface
+    public function getChildrenOfYearAnchor(?int $partOf, Structure $structure): array|QueryResultInterface
     {
         $query = $this->createQuery();
 


### PR DESCRIPTION
This fixes issue #1696 (regression in commit 200489788b418649).