### PR TITLE
[MAINTENANCE] Update version numbers

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -24,3 +24,6 @@ rules:
   - base: 5.1.x
     upstream: kitodo:5.1.x
     mergeMethod: hardreset
+  - base: 6.x
+    upstream: kitodo:6.x
+    mergeMethod: hardreset

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: [ "main", "1.x", "2.x", "3.2.x", "3.3.x", "4.x", "5.0.x", "5.1.x" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/Build/Test/runTests.sh
+++ b/Build/Test/runTests.sh
@@ -78,12 +78,12 @@ Options:
             - functional: PHP functional tests
             - unit (default): PHP unit tests
 
-    -t <11.5|12.4>
+    -t <12.4|13.4>
         Only with -s composerInstall
         Specifies which TYPO3 version to install. When unset, installs either the packages from
         composer.lock, or the latest version otherwise (default behavior of "composer install").
-            - 11.5
             - 12.4
+            - 13.4
 
     -a <mysqli|pdo_mysql>
         Only with -s functional
@@ -101,20 +101,18 @@ Options:
             - mariadb (default): use mariadb
             - mysql: use MySQL server
 
-    -i <10.2|10.3|10.4|10.5|10.6|10.11>
+    -i <10.3|10.4|10.5|10.6|10.11>
         Only with -d mariadb
         Specifies on which version of mariadb tests are performed
-            - 10.2
             - 10.3 (default)
             - 10.4
             - 10.5
             - 10.6
             - 10.11
 
-    -j <5.7|8.0>
+    -j <8.0>
         Only with -d mysql
         Specifies on which version of mysql tests are performed
-            - 5.7
             - 8.0 (default)
 
     -p <8.1|8.2|8.3|8.4>
@@ -217,7 +215,7 @@ while getopts ":a:s:t:d:i:j:p:e:xy:whuv" OPT; do
             ;;
         j)
             MYSQL_VERSION=${OPTARG}
-            if ! [[ ${MYSQL_VERSION} =~ ^(5.7|8.0)$ ]]; then
+            if ! [[ ${MYSQL_VERSION} =~ ^(8.0)$ ]]; then
                 INVALID_OPTIONS+=("${OPTARG}")
             fi
             ;;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-Please read the excellent [GitHub Open Source Guide](https://opensource.guide/how-to-contribute/) on *How to Contribute on Open Source*.
+Please read the excellent [GitHub Open Source Guide](https://opensource.guide/how-to-contribute/) on *How to Contribute on Open Source* as well as our [Kitodo Coding Guidelines](https://github.com/kitodo/coding-guidelines/releases/latest/).
 
 If you have any further questions just [open a new issue](https://github.com/kitodo/kitodo-presentation/issues/new) and we'll be happy to assist!

--- a/Classes/Common/Solr/Solr.php
+++ b/Classes/Common/Solr/Solr.php
@@ -580,22 +580,13 @@ class Solr implements LoggerAwareInterface
      */
     protected function __construct(?string $core)
     {
-        // Solarium requires different code for version 5 and 6.
-        $isSolarium5 = Client::checkExact('5');
         // Get Solr connection parameters from configuration.
         $this->loadSolrConnectionInfo();
         // Configure connection adapter.
         $adapter = GeneralUtility::makeInstance(Http::class);
         $adapter->setTimeout($this->config['timeout']);
         // Configure event dispatcher.
-        if ($isSolarium5) {
-            $eventDispatcher = null;
-        } else {
-            // When updating to TYPO3 >=10.x and Solarium >=6.x
-            // we have to provide a PSR-14 Event Dispatcher instead of
-            // "null".
-            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcher::class);
-        }
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcher::class);
         // Configure endpoint.
         $config = [
             'endpoint' => [
@@ -611,14 +602,7 @@ class Solr implements LoggerAwareInterface
             ]
         ];
         // Instantiate Solarium\Client class.
-        if ($isSolarium5) {
-            $this->service = GeneralUtility::makeInstance(Client::class, $config);
-        } else {
-            // When updating to TYPO3 >=10.x and Solarium >=6.x
-            // $adapter and $eventDispatcher are mandatory arguments
-            // of the \Solarium\Client constructor.
-            $this->service = GeneralUtility::makeInstance(Client::class, $adapter, $eventDispatcher, $config);
-        }
+        $this->service = GeneralUtility::makeInstance(Client::class, $adapter, $eventDispatcher, $config);
         $this->service->setAdapter($adapter);
         // Check if connection is established.
         $query = $this->service->createCoreAdmin();

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,12 +5,8 @@
 Before running any of the tests, please install the project dependencies. Choose which version of TYPO3 you would like to test against.
 
 ```bash
-# If you use PHP 8.1 (supported by Kitodo)
-composer update --with=typo3/cms-core:^11.5
-
-# If you use PHP 8
-composer install-via-docker -- -t 11.5
 composer install-via-docker -- -t 12.4
+composer install-via-docker -- -t 13.4
 ```
 
 ### Quick Start
@@ -80,7 +76,7 @@ docker compose down
 ### External Links
 
 - [TYPO3 Testing Framework](https://github.com/TYPO3/testing-framework)
-- [TYPO3 Explained: Extension testing](https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/Testing/ExtensionTesting.html)
+- [TYPO3 Explained: Extension testing](https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Testing/ExtensionTesting.html)
 - [typo3/cms-styleguide](https://github.com/TYPO3/styleguide)
 
 ## Documentation

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <guides xmlns="https://www.phpdoc.org/guides" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd" links-are-relative="true">
   <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension" project-home="https://kitodo.org" project-contact="mailto:contact@kitodo.org" project-repository="https://github.com/kitodo/kitodo-presentation" project-issues="https://github.com/kitodo/kitodo-presentation/issues" edit-on-github-branch="main" edit-on-github="kitodo/kitodo-presentation" typo3-core-preferred="stable"/>
-  <project title="Kitodo.Presentation" release="6.0" copyright="since 2017 by Kitodo Release Management Team"/>
+  <project title="Kitodo.Presentation" release="7.0" copyright="since 2017 by Kitodo Release Management Team"/>
   <inventory id="t3tsref" url="http://docs.typo3.org/typo3cms/TyposcriptReference/"/>
 </guides>

--- a/README.md
+++ b/README.md
@@ -34,4 +34,3 @@ To ensure it can best advise and assist users on technical and organisational is
 
 * [Extension Documentation](https://kitodo.github.io/kitodo-presentation)
 * [DDEV Development Environment](https://github.com/kitodo/ddev-kitodo-presentation)
-* [Demo Server](https://presentation-demo.kitodo.org/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,9 @@ The following versions of Kitodo.Presentation are currently being supported with
 
 | Version | With TYPO3      | Active Development | Security Fixes |
 | ------- | --------------- | :----------------: | :------------: |
-| 6.x     | 11 LTS + 12 LTS | ☒                 | ☒              |
-| 5.x     | 10 LTS + 11 LTS | ☐                 | ☒              |
+| 7.x     | 12 LTS + 13 LTS | ☒                 | ☒              |
+| 6.x     | 11 LTS + 12 LTS | ☐                 | ☒              |
+| 5.x     | 10 LTS + 11 LTS | ☐                 | ☐              |
 | 4.x     | 9 LTS + 10 LTS  | ☐                 | ☐              |
 | 3.3.x   | 9 LTS           | ☐                 | ☐              |
 | 3.2.x   | 8 LTS + 9 LTS   | ☐                 | ☐              |

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Kitodo.Presentation',
     'description' => 'Base plugins, modules, services and API of the Digital Library Framework. It is part of the community-based Kitodo Digitization Suite.',
-    'version' => '6.0.0',
+    'version' => '7.0.0',
     'category' => 'misc',
     'constraints' => [
         'depends' => [


### PR DESCRIPTION
This updates old version numbers throughout the code. It also removes dead code for Solarium 5.x, which is no longer supported.