### PR TITLE
[BUGFIX] Fix showing text in disabled fulltext view

### DIFF
--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -242,10 +242,8 @@ var dlfViewerFullTextControl = function(map) {
         this)
     };
 
-    if (this.isActive) {
-        this.activate();
-    } else {
-        this.deactivate();
+    if (!this.isActive) {
+      $(this.fullTextScrollElement).hide();
     }
 
     $(this.fullTextScrollElement).text(this.dic['fulltext-loading']);

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -242,7 +242,13 @@ var dlfViewerFullTextControl = function(map) {
         this)
     };
 
-    $('html').find(this.fullTextScrollElement).text(this.dic['fulltext-loading']);
+    if (this.isActive) {
+        this.activate();
+    } else {
+        this.deactivate();
+    }
+
+    $(this.fullTextScrollElement).text(this.dic['fulltext-loading']);
 
     this.changeActiveBehaviour();
 };


### PR DESCRIPTION
- Now checks whether the control variable is initially active. If it is active, perform the necessary procedures to enable full-text view. Otherwise, disable the view.

Fixes #1408

