### PR TITLE
[BUGFIX] Prefix cache key with 'dlf_' and hash the recordId

### DIFF
--- a/Classes/Controller/PageGridController.php
+++ b/Classes/Controller/PageGridController.php
@@ -47,7 +47,7 @@ class PageGridController extends AbstractController
 
         // Access cachemanager for pagegrid
         $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('tx_dlf_pagegrid');
-        $cacheKey = $this->document->getCurrentDocument()->recordId;
+        $cacheKey = 'dlf_' . md5($this->document->getCurrentDocument()->recordId);
         $cachedData = $cache->get($cacheKey);
 
         $entryArray = [];


### PR DESCRIPTION
Prefix cache key with 'dlf_' and hash the recordId for PageGridController to avoid failed validation of the cacheKey.
close: #1743 