### PR TITLE
[MAINTENANCE] Drop support for PHP 8.1

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variants: [ {typo3: 12.4, php: 8.1}, {typo3: 13.4, php: 8.4}  ]
+        variants: [ {typo3: 12.4, php: 8.2}, {typo3: 13.4, php: 8.4}  ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variants: [ {typo3: 12.4, php: 8.1}, {typo3: 12.4, php: 8.4}, {typo3: 13.4, php: 8.2}, {typo3: 13.4, php: 8.4}  ]
+        variants: [ {typo3: 12.4, php: 8.2}, {typo3: 12.4, php: 8.4}, {typo3: 13.4, php: 8.2}, {typo3: 13.4, php: 8.4}  ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Build/Test/runTests.sh
+++ b/Build/Test/runTests.sh
@@ -69,7 +69,7 @@ a recent docker compose (tested >=2.27.1) is needed.
 
 Usage: $0 [options] [file]
 
-No arguments: Run all unit tests with PHP 8.1
+No arguments: Run all unit tests with PHP 8.2
 
 Options:
     -s <...>
@@ -115,10 +115,9 @@ Options:
         Specifies on which version of mysql tests are performed
             - 8.0 (default)
 
-    -p <8.1|8.2|8.3|8.4>
+    -p <8.2|8.3|8.4>
         Specifies the PHP minor version to be used
-            - 8.1: use PHP 8.1 (default)
-            - 8.2: use PHP 8.2
+            - 8.2: use PHP 8.2 (default)
             - 8.3: use PHP 8.3
             - 8.4: use PHP 8.4
 
@@ -176,7 +175,7 @@ fi
 TEST_SUITE="unit"
 TYPO3_VERSION=""
 DBMS="mariadb"
-PHP_VERSION="8.1"
+PHP_VERSION="8.2"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 SERVER_PORT=8000
@@ -221,7 +220,7 @@ while getopts ":a:s:t:d:i:j:p:e:xy:whuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(8.1|8.2|8.3|8.4)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.2|8.3|8.4)$ ]]; then
                 INVALID_OPTIONS+=("${OPTARG}")
             fi
             ;;

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "docs": "https://docs.typo3.org/p/kitodo/presentation/main/en-us/"
   },
   "require": {
-    "php": "8.1 - 8.4",
+    "php": "8.2 - 8.4",
     "ext-curl": "*",
     "ext-dom": "*",
     "ext-json": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'misc',
     'constraints' => [
         'depends' => [
-            'php' => '8.1.0-8.4.99',
+            'php' => '8.2.0-8.4.99',
             'typo3' => '12.4.0-13.4.99'
         ],
         'conflicts' => [],


### PR DESCRIPTION
PHP 8.1 had active support until 2023-11-25.
Security support will end 2025-12-31.

Therefore new installations should not be based on PHP 8.1.