### PR TITLE
[BUGFIX] Add search query filtering for highlighting in search in document middleware

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -571,7 +571,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
                                 $searchResult['highlight'] = $doc['highlight'];
                                 $searchResult['highlight_word'] = preg_replace('/^;|;$/', '',       // remove ; at beginning or end
                                                                   preg_replace('/;+/', ';',         // replace any multiple of ; with a single ;
-                                                                  preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $this->searchParams['query']))); // replace search operators and special characters with ;
+                                                                  preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}{\sAND\s}{\sOR\s}{\sNOT\s}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $this->searchParams['query']))); // replace search operators and special characters with ;
                             }
                             $documents[$doc['uid']]['searchResults'][] = $searchResult;
                         }

--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -104,7 +104,9 @@ class SearchInDocument implements MiddlewareInterface
                     [
                         'tx_dlf[id]' => !empty($resultDocument->getUid()) ? $resultDocument->getUid() : $parameters['uid'],
                         'tx_dlf[page]' => $resultDocument->getPage(),
-                        'tx_dlf[highlight_word]' => $parameters['q']
+                        'tx_dlf[highlight_word]' => preg_replace('/^;|;$/', '',       // remove ; at beginning or end
+                                                    preg_replace('/;+/', ';',         // replace any multiple of ; with a single ;
+                                                    preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}{\sAND\s}{\sOR\s}{\sNOT\s}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $parameters['q']))); // replace search operators and special characters with ;
                     ]
                 );
 

--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -106,7 +106,7 @@ class SearchInDocument implements MiddlewareInterface
                         'tx_dlf[page]' => $resultDocument->getPage(),
                         'tx_dlf[highlight_word]' => preg_replace('/^;|;$/', '',       // remove ; at beginning or end
                                                     preg_replace('/;+/', ';',         // replace any multiple of ; with a single ;
-                                                    preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}{\sAND\s}{\sOR\s}{\sNOT\s}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $parameters['q']))); // replace search operators and special characters with ;
+                                                    preg_replace('/[{~\d*}{\s+}{^=*\d+.*\d*}{\sAND\s}{\sOR\s}{\sNOT\s}`~!@#$%\^&*()_|+-=?;:\'",.<>\{\}\[\]\\\]/', ';', $parameters['q']))) // replace search operators and special characters with ;
                     ]
                 );
 


### PR DESCRIPTION
This PR adds filtering of the search query in the search in document middleware, in order to remove search operators, special characters and whitespaces from being used for word highlighting and/or breaking highlighting when multiple tokens are being searched. It also adds filtering of the boolean search operators (AND, OR, NOT) in solrSearch, which can cause highlighting issues on words starting with these strings.