### PR TITLE
[BUGFIX] Add required typo3/cms-reports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "typo3/cms-core": "^12.4|^13.4",
     "typo3/cms-extbase": "^12.4|^13.4",
     "typo3/cms-install": "^12.4|^13.4",
+    "typo3/cms-reports": "^12.4|^13.4",
     "typo3/cms-scheduler": "^12.4|^13.4",
     "typo3/cms-tstemplate": "^12.4|^13.4",
     "caseyamcl/phpoaipmh": "^3.3",


### PR DESCRIPTION
This fixes lots of CI errors:

    Error: Interface "TYPO3\CMS\Reports\StatusProviderInterface" not found