### PR TITLE
[BUGFIX] Change default for index_boost in table tx_dlf_metadata from 1.00 to 1

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -101,7 +101,7 @@ CREATE TABLE tx_dlf_metadata (
     index_tokenized smallint(6) DEFAULT '0' NOT NULL,
     index_stored smallint(6) DEFAULT '0' NOT NULL,
     index_indexed smallint(6) DEFAULT '0' NOT NULL,
-    index_boost float(4,2) DEFAULT '1.00' NOT NULL,
+    index_boost float(4,2) DEFAULT '1' NOT NULL,
     is_sortable smallint(6) DEFAULT '0' NOT NULL,
     is_facet smallint(6) DEFAULT '0' NOT NULL,
     is_listed smallint(6) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Otherwise TYPO3 v13 suggests to apply the following SQL command for Maintenance / Analyze Database Structure:

    ALTER TABLE `tx_dlf_metadata` CHANGE `index_boost` `index_boost` DOUBLE PRECISION DEFAULT '1.0000' NOT NULL;

This SQL command has no effect, so the suggestion won't change, no matter how often it is applied.

After this patch, the maintenance job says "Database schema is up to date. Good job!".