### PR TITLE
[OPTIMIZATION] Speed up Table of Contents

### DIFF
--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -136,7 +136,7 @@ class TableOfContentsController extends AbstractController
         }
         $entryArray['year'] = $entry['year'];
         $entryArray['orderlabel'] = $entry['orderlabel'];
-        $entryArray['type'] = $this->getTranslatedType($entry['type']);
+        $entryArray['type'] = $entry['type'];
         $entryArray['pagination'] = htmlspecialchars($entry['pagination']);
         $entryArray['_OVERRIDE_HREF'] = '';
         $entryArray['doNotLinkIt'] = 1;

--- a/Resources/Private/Partials/TableOfContents/Title.html
+++ b/Resources/Private/Partials/TableOfContents/Title.html
@@ -18,7 +18,7 @@
             <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.title}</f:format.htmlspecialchars></f:format.crop>
         </f:then>
         <f:else>
-            <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.type}</f:format.htmlspecialchars><f:if condition="{child.volume}"> &nbsp;<f:format.htmlspecialchars doubleEncode="false">{child.volume}</f:format.htmlspecialchars></f:if></f:format.crop>
+            <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false"><f:translate key="LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{child.type}" /></f:format.htmlspecialchars><f:if condition="{child.volume}"> &nbsp;<f:format.htmlspecialchars doubleEncode="false">{child.volume}</f:format.htmlspecialchars></f:if></f:format.crop>
         </f:else>
     </f:if>
 </span>


### PR DESCRIPTION
This PR significantly speeds up the code execution of the `TableOfContentsController`. The underlying issue was, that the `type` was translated for each individual entry, even though it already had a `title` and did not require a translated `type` for the view anymore.
The behavior is now, that the `type` stays unchanged and gets translated in the view via the `languageFiles` when no `title` is present.

I have made some performance measurements on a large and in depth structured "Hamburger Adressbuch" from 1960 - around 4600 pages, 4000 structure elements, 7 file groups:
https://mets.sub.uni-hamburg.de/kitodo/PPN773134158_1960

old ToC (complete recursion):
creating the menuArray took about **7500ms** in average

new ToC (complete recursion):
creating the menuArray took about **500ms** in average

The execution time was improved roughly by a factor of 15.
