### PR TITLE
[FEATURE] Introduce DocumentService for one-time loading of current document

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -16,6 +16,7 @@ use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Configuration\UseGroupsConfiguration;
 use Kitodo\Dlf\Domain\Model\Document;
 use Kitodo\Dlf\Domain\Repository\DocumentRepository;
+use Kitodo\Dlf\Service\DocumentService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -32,6 +33,7 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Extbase\Mvc\RequestInterface;
+
 
 /**
  * Abstract controller class for most of the plugin controller.
@@ -60,6 +62,17 @@ abstract class AbstractController extends ActionController implements LoggerAwar
      *
      * @return void
      */
+
+    /**
+     * @access protected
+     * @var DocumentService
+     */
+    protected DocumentService $documentService;
+ 
+    public function injectDocumentService(DocumentService $service): void
+    {
+        $this->documentService = $service;
+    }
     public function injectDocumentRepository(DocumentRepository $documentRepository): void
     {
         $this->documentRepository = $documentRepository;
@@ -136,6 +149,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         $this->useGroupsConfiguration = UseGroupsConfiguration::getInstance();
 
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
+
+        $this->documentService = GeneralUtility::makeInstance(DocumentService::class);
 
         $this->viewData = [
             'pageUid' => $this->pageUid ?? 0,

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -259,55 +259,15 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     }
 
     /**
-     * Loads the current document into $this->document
+     * Load the current Document to Globals Temp just once with Document Service - it will then be available for all controllers.
      *
      * @access protected
-     *
-     * @param string $documentId The document's UID or URL (id), fallback: record ID (recordId)
-     *
      * @return void
      */
-    protected function loadDocument(string $documentId = ''): void
+    protected function loadDocument(): void
     {
-        // Sanitize FlexForm settings to avoid later casting.
         $this->sanitizeSettings();
-
-        // Get document ID from request data if not passed as parameter.
-        if (!$documentId && !empty($this->requestData['id'])) {
-            $documentId = $this->requestData['id'];
-        }
-
-        // Try to get document format from database
-        if (!empty($documentId)) {
-
-
-            $doc = null;
-
-            if (MathUtility::canBeInterpretedAsInteger($documentId)) {
-                $doc = $this->getDocumentByUid((int) $documentId);
-            } elseif (GeneralUtility::isValidUrl($documentId)) {
-                $doc = $this->getDocumentByUrl($documentId);
-            }
-
-            if ($this->document !== null && $doc !== null) {
-                $this->document->setCurrentDocument($doc);
-            }
-
-        } elseif (!empty($this->requestData['recordId'])) {
-
-            $this->document = $this->documentRepository->findOneBy(['recordId' => $this->requestData['recordId']]);
-
-            if ($this->document !== null) {
-                $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
-                if ($doc !== null) {
-                    $this->document->setCurrentDocument($doc);
-                } else {
-                    $this->logger->error('Failed to load document with record ID "' . $this->requestData['recordId'] . '"');
-                }
-            }
-        } else {
-            $this->logger->error('Invalid ID "' . $documentId . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
-        }
+        $this->document = $this->documentService->getDocument($this->requestData['id'], $this->settings);
     }
 
     /**

--- a/Classes/Service/DocumentService.php
+++ b/Classes/Service/DocumentService.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Service;
+
+use Kitodo\Dlf\Domain\Repository\DocumentRepository;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Kitodo\Dlf\Common\AbstractDocument;
+use Kitodo\Dlf\Domain\Model\Document;
+use TYPO3\CMS\Core\Utility\MathUtility;
+/**
+ * (Service For Abstract Controller) Service that decouples the loading of documents from each controller to only once.
+ *
+ * @package TYPO3
+ * @subpackage dlf
+ *
+ * @access public
+ */
+class DocumentService
+{
+     /**
+     * @access protected
+     * @var Document|null This holds the current document
+     */
+    protected ?Document $document = null;
+    /**
+     * @access protected
+     * @var array
+     */
+    protected $settings;
+    /**
+     * @access protected
+     * @var array
+     */
+    protected $logger;
+    protected DocumentRepository $documentRepository;
+
+    public function __construct()
+    {
+        $this->documentRepository = GeneralUtility::makeInstance(DocumentRepository::class);
+        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
+    }
+
+    protected function init()
+    {
+        return true;
+    }
+    protected function reset()
+    {
+    }
+    /**
+     * @access public
+     * @param int $recordId
+     * @param array $settings
+     * @return ?Document
+     */
+    public function getDocument($recordId, $settings)
+    {
+        if (isset($GLOBALS['TX_DLF_TEMP_DOCUMENT'])) {
+            return $GLOBALS['TX_DLF_TEMP_DOCUMENT'];
+        } else {
+            $this->serviceLoadDocument($recordId, $settings);
+            $GLOBALS['TX_DLF_TEMP_DOCUMENT'] = $this->document;
+            return $this->document;
+        }
+    }
+    /**
+     * @access public
+     * @param int $recordId
+     * @param array $settings
+     */
+    private function serviceLoadDocument($recordId, $settings){
+       
+        $this->settings = $settings;
+
+        // Get document ID from request data if not passed as parameter.
+        if (!empty($recordId)) {
+            $documentId = $recordId;
+        }
+
+        // Try to get document format from database
+        if (!empty($documentId)) {
+
+            $doc = null;
+
+            if (MathUtility::canBeInterpretedAsInteger($documentId)) {
+                $doc = $this->getDocumentByUid($documentId);
+            } elseif (GeneralUtility::isValidUrl($documentId)) {
+                $doc = $this->getDocumentByUrl($documentId);
+            }
+
+            if ($this->document !== null && $doc !== null) {
+                $this->document->setCurrentDocument($doc);
+            }
+
+        } elseif (!empty($this->requestData['recordId'])) {
+
+            $this->document = $this->documentRepository->findOneByRecordId($this->requestData['recordId']);
+
+            if ($this->document !== null) {
+                $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings, false);
+                if ($doc !== null) {
+                    $this->document->setCurrentDocument($doc);
+                } else {
+                    $this->logger->error('Failed to load document with record ID "' . $this->requestData['recordId'] . '"');
+                }
+            }
+        } else {
+            $this->logger->error('Invalid ID "' . $documentId . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
+        }
+    }
+    /**
+     * Get document from repository by uid.
+     *
+     * @access private
+     *
+     * @param int $documentId The document's UID
+     *
+     * @return AbstractDocument
+     */
+    private function getDocumentByUid(int $documentId): AbstractDocument|null
+    {
+        $doc = null;
+        $this->document = $this->documentRepository->findOneByIdAndSettings($documentId);
+
+        if ($this->document) {
+            $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings, false);
+        } else {
+            $this->logger->error('Invalid UID "' . $documentId . '" or PID "' . $this->settings['storagePid'] . '" for document loading');
+        }
+
+        return $doc;
+    }
+
+    /**
+     * Get document by URL.
+     *
+     * @access private
+     *
+     * @param string $documentId The document's URL
+     *
+     * @return AbstractDocument
+     */
+    private function getDocumentByUrl(string $documentId)
+    {
+        $doc = AbstractDocument::getInstance($documentId, $this->settings, false);
+
+        if ($doc !== null) {
+            if ($doc->recordId) {
+                // find document from repository by recordId
+                $docFromRepository = $this->documentRepository->findOneByRecordId($doc->recordId);
+                if ($docFromRepository !== null) {
+                    $this->document = $docFromRepository;
+                } else {
+                    // create new dummy Document object
+                    $this->document = GeneralUtility::makeInstance(Document::class);
+                }
+            }
+
+            // Make sure configuration PID is set when applicable
+            if ($doc->cPid == 0) {
+                $doc->cPid = max($this->settings['storagePid'], 0);
+            }
+
+            $this->document->setLocation($documentId);
+        } else {
+            $this->logger->error('Invalid location given "' . $documentId . '" for document loading');
+        }
+
+        return $doc;
+    }
+}
+?>

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -53,3 +53,6 @@ services:
 
   Kitodo\Dlf\Validation\XmlSchemesValidator:
     autowire: false
+
+  Kitodo\Dlf\Service\DocumentService:
+    public: true


### PR DESCRIPTION
This pull-request introduces a Document Service for document loading, so that the initialized document object persists across controllers. It adresses the current state issue, that every plugin controller (that implements AbstractController) loads the current document, initializes it and once the controller finishes it is deconstructed.
Every consecutive controller needs to load and initialize the document again.
This solution reuses the loaded document for the whole request and significantly optimizes execution time:
- 5000 Page Adressbuch loads one-time for about 0.5 Seconds in the first controller and then loading is nearly instantly.
- without this change each controller takes 0.5 seconds (chaining for example 6 controllers -e.g. detail view with PageGrid, PageView, ToC, Navigation, Toolbox, Metadata - leads to a loading time of about 3 seconds).
- in this case the change improves execution time by a factor of 6.
