### PR TITLE
[BUGFIX] Change return to empty string

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -237,7 +237,7 @@ final class MetsDocument extends AbstractDocument
             // TODO CVT is an optional IIP server capability; in theory, capabilities should be determined in the object request with '&obj=IIP-server'
             return $baseURL . '&CVT=jpeg';
         }
-        return $file['location'] ?? null;
+        return $file['location'] ?? "";
     }
 
     /**

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -237,7 +237,7 @@ final class MetsDocument extends AbstractDocument
             // TODO CVT is an optional IIP server capability; in theory, capabilities should be determined in the object request with '&obj=IIP-server'
             return $baseURL . '&CVT=jpeg';
         }
-        return $file['location'] ?? "";
+        return $file['location'] ?? '';
     }
 
     /**

--- a/Tests/Functional/Common/MetsDocumentTest.php
+++ b/Tests/Functional/Common/MetsDocumentTest.php
@@ -227,12 +227,8 @@ class MetsDocumentTest extends FunctionalTestCase
         $correct = $doc->getDownloadLocation('FILE_0000_DOWNLOAD');
         self::assertEquals('https://example.com/download?&CVT=jpeg', $correct);
 
-        /*
-         * The method `getDownloadLocation` should return a string, but returns null in some cases.
-         * Therefore, a TypeError must be expected here.
-         */
-        $this->expectException('TypeError');
-        $doc->getDownloadLocation('ID_DOES_NOT_EXIST');
+        $empty = $doc->getDownloadLocation('ID_DOES_NOT_EXIST');
+        self::assertEmpty($empty);
     }
 
 


### PR DESCRIPTION
This function can't return null, return needs to be changed to string or function signature needs to be adjusted