### PR TITLE
[FEATURE] Provide structure paths/breadcrumbs to search results

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -83,9 +83,9 @@ class Indexer
     /**
      * @access protected
      * @static
-     * @var array List of already processed structure paths
+     * @var array List of already extracted structure nodes for structure path
      */
-    protected static array $processedStructurePaths = [];
+    protected static array $extractedStructurePathNodes = [];
 
     /**
      * @access protected
@@ -378,10 +378,10 @@ class Indexer
                 $solrDoc->setField('toplevel', $logicalUnit['id'] == $doc->getToplevelId());
                 $solrDoc->setField('title', $metadata['title'][0]);
                 $solrDoc->setField('volume', $metadata['volume'][0] ?? '');
-                // process structure path and flag paths that end in leaf node
-                self::$processedStructurePaths[$logicalUnit['id']]['is_leaf'] = self::isLeafNode($doc->tableOfContents, $logicalUnit['id']);
-                self::$processedStructurePaths[$logicalUnit['id']]['segments'] = self::buildStructurePathData($doc->tableOfContents, $logicalUnit['id'], $document->getCurrentDocument()->getToplevelId());
-                $solrDoc->setField('structure_path', json_encode(self::$processedStructurePaths[$logicalUnit['id']]['segments'], JSON_UNESCAPED_UNICODE));
+                // extract structure path
+                self::$extractedStructurePathNodes[$logicalUnit['id']] = self::extractStructurePathNodes($doc->tableOfContents, $logicalUnit['id']);
+                $processedStructurePath = self::buildStructurePathData(self::$extractedStructurePathNodes[$logicalUnit['id']], $document->getCurrentDocument()->getToplevelId());
+                $solrDoc->setField('structure_path', json_encode($processedStructurePath, JSON_UNESCAPED_UNICODE));
                 // verify date formatting
                 if(strtotime($metadata['date'][0])) {
                     $solrDoc->setField('date', self::getFormattedDate($metadata['date'][0]));
@@ -476,19 +476,21 @@ class Indexer
             $solrDoc->setField('type', $physicalUnit['type']);
             $solrDoc->setField('collection', $doc->metadataArray[$doc->getToplevelId()]['collection']);
             $solrDoc->setField('location', $document->getLocation());
-            // pick only structure paths that end in leaf nodes
-            $leafStructurePaths = [];
+            // pick only the deepest structure paths
+            $associatedPaths = [];
             foreach ($doc->smLinks['p2l'][$physicalUnit['id']] as $logicalId) {
-                if (
-                    empty(self::$processedStructurePaths[$logicalId])
-                    || !self::$processedStructurePaths[$logicalId]['is_leaf']
-                ) {
-                    continue;
+                $path = self::$extractedStructurePathNodes[$logicalId] ?? [];
+                if (!empty($path)) {
+                    $associatedPaths[$logicalId] = $path;
                 }
-                $leafStructurePaths[] = json_encode(self::$processedStructurePaths[$logicalId]['segments'], JSON_UNESCAPED_UNICODE);
             }
-            $solrDoc->setField('structure_path', $leafStructurePaths);
-
+            $deepestPaths = self::filterDeepestStructurePaths($associatedPaths);
+            $processedStructurePath = [];
+            foreach ($deepestPaths as $path) {
+                $segments = self::buildStructurePathData($path, $document->getCurrentDocument()->getToplevelId());
+                $processedStructurePath[] = json_encode($segments, JSON_UNESCAPED_UNICODE);
+            }
+            $solrDoc->setField('structure_path', $processedStructurePath);
             $solrDoc->setField('fulltext', $fullText);
             if (is_array($doc->metadataArray[$doc->getToplevelId()])) {
                 self::addFaceting($doc, $solrDoc, $physicalUnit);
@@ -751,7 +753,20 @@ class Indexer
         return $authors;
     }
 
-    public static function findPath(array $nodes, $targetId, $path = []): array|bool
+    /**
+     * Extract nodes alongside the structure map in direct line to the target id and return them as flattened array.
+     *
+     * @access private
+     *
+     * @static
+     *
+     * @param array $nodes Tree or Sub-Tree, where the target id should be extracted from if present
+     * @param string $targetId The ID of the logical structure element to be found
+     * @param array $path An intermediate array that keeps track of the current branch that is being looked up
+     *
+     * @return array
+     */
+    private static function extractStructurePathNodes(array $nodes, string $targetId, array $path = []): array
     {
         foreach ($nodes as $node) {
             // remember where we came from
@@ -760,45 +775,97 @@ class Indexer
                 return $currentPath;
             }
             if (!empty($node['children'])) {
-                $result = self::findPath($node['children'], $targetId, $currentPath);
+                $result = self::extractStructurePathNodes($node['children'], $targetId, $currentPath);
                 if ($result) {
                     return $result;
                 }
             }
         }
-        return false;
+        return [];
     }
 
-    public static function isLeafNode(array $tree, $targetId): bool
+    /**
+     * Filters those structure path nodes that are the descending into the structure tree the most and removes any that resemble a "prefix" of another.
+     *
+     * @access private
+     *
+     * @static
+     *
+     * @param array $paths The array containing all structure path nodes associated with a physical page
+     *
+     * @return array
+     */
+    private static function filterDeepestStructurePaths(array $paths): array
     {
-        $path = self::findPath($tree, $targetId);
-        if (!$path) {
-            return false;
+        if (count($paths) <= 1) {
+            return $paths;
         }
-        $node = end($path);
-        return empty($node['children']);
+
+        $deepestPath = [];
+        foreach ($paths as $currentLogicalId => $currentPath) {
+            $currentIds = array_column($currentPath, 'id');
+            $isPrefix = false;
+
+            foreach ($paths as $comparisonLogicalId => $comparisonPath) {
+                if ($currentLogicalId === $comparisonLogicalId) {
+                    continue;
+                }
+                $comparisonIds = array_column($comparisonPath, 'id');
+                // check if structure path is part/prefix of another structure path
+                if (
+                    count($currentIds) < count($comparisonIds)
+                    && array_slice($comparisonIds, 0, count($currentIds)) === $currentIds
+                ) {
+                    $isPrefix = true;
+                    break;
+                }
+            }
+
+            if (!$isPrefix) {
+                $deepestPath[$currentLogicalId] = $currentPath;
+            }
+        }
+        return $deepestPath;
     }
 
-    public static function buildStructurePathData(array $tree, $targetId, $cutoffId): array
+    /**
+     * Create the actual array with the required data for the structure path that will be JSON encoded and indexed.
+     *
+     * @access private
+     *
+     * @static
+     *
+     * @param array $path The structure path nodes that shall be processed
+     * @param string $cutoffId The logical id at which ancestors and itself will not be part of the structure path data
+     *
+     * @return array
+     */
+    private static function buildStructurePathData(array $path, string $cutoffId): array
     {
-        $path = self::findPath($tree, $targetId);
-        if (!$path) {
-            return [];
-        }
-        // find cutoff index, so we dont list parents of the document itself
         $cutoffIndex = array_search($cutoffId, array_column($path, 'id'));
         if ($cutoffIndex !== false) {
-            // remove everything above and including cutoff index
             $path = array_slice($path, $cutoffIndex + 1);
         }
+
         $segments = [];
         foreach ($path as $node) {
-            $segments[] = self::buildStructurePathSegment($node);
+            $segments[] = self::buildStructurePathSegments($node);
         }
         return $segments;
     }
 
-    public static function buildStructurePathSegment(array $node): array
+    /**
+     * Gets the label or type of a structure path node with corresponding tag
+     *
+     * @access private
+     *
+     * @static
+     *
+     * @param array $node The current node that should be processed
+     *
+     * @return array
+     */
+    private static function buildStructurePathSegments(array $node): array
     {
         if (!empty($node['label'])) {
             return [

--- a/Classes/Common/Solr/SearchResult/ResultDocument.php
+++ b/Classes/Common/Solr/SearchResult/ResultDocument.php
@@ -75,6 +75,12 @@ class ResultDocument
 
     /**
      * @access private
+     * @var array The JSON encoded structure path(s)
+     */
+    private array $structurePath = [];
+
+    /**
+     * @access private
      * @var Page[] All pages in which search phrase was found
      */
     private array $pages = [];
@@ -117,6 +123,7 @@ class ResultDocument
         $this->title = $record[$fields['title']];
         $this->toplevel = $record[$fields['toplevel']] ?? false;
         $this->type = $record[$fields['type']];
+        $this->structurePath = $record[$fields['structure_path']] ?? [];
 
         if (!empty($highlighting[$this->id])) {
             $highlightingForRecord = $highlighting[$this->id][$fields['fulltext']];
@@ -223,6 +230,18 @@ class ResultDocument
     public function getType(): ?string
     {
         return $this->type;
+    }
+
+    /**
+     * Get the structure path(s)
+     *
+     * @access public
+     *
+     * @return string|null
+     */
+    public function getStructurePath(): array
+    {
+        return $this->structurePath;
     }
 
     /**

--- a/Classes/Common/Solr/SearchResult/ResultDocument.php
+++ b/Classes/Common/Solr/SearchResult/ResultDocument.php
@@ -237,7 +237,7 @@ class ResultDocument
      *
      * @access public
      *
-     * @return string|null
+     * @return array
      */
     public function getStructurePath(): array
     {

--- a/Classes/Common/Solr/Solr.php
+++ b/Classes/Common/Solr/Solr.php
@@ -256,6 +256,7 @@ class Solr implements LoggerAwareInterface
             self::$fields['type'] = $solrFields['type'];
             self::$fields['title'] = $solrFields['title'];
             self::$fields['volume'] = $solrFields['volume'];
+            self::$fields['structure_path'] = $solrFields['structure_path'];
             self::$fields['date'] = $solrFields['date'] ?? null;
             self::$fields['thumbnail'] = $solrFields['thumbnail'];
             self::$fields['default'] = $solrFields['default'];

--- a/Classes/Common/Solr/Solr.php
+++ b/Classes/Common/Solr/Solr.php
@@ -256,7 +256,7 @@ class Solr implements LoggerAwareInterface
             self::$fields['type'] = $solrFields['type'];
             self::$fields['title'] = $solrFields['title'];
             self::$fields['volume'] = $solrFields['volume'];
-            self::$fields['structure_path'] = $solrFields['structure_path'];
+            self::$fields['structure_path'] = $solrFields['structurePath'];
             self::$fields['date'] = $solrFields['date'] ?? null;
             self::$fields['thumbnail'] = $solrFields['thumbnail'];
             self::$fields['default'] = $solrFields['default'];

--- a/Configuration/ApacheSolr/configsets/dlf/conf/schema.xml
+++ b/Configuration/ApacheSolr/configsets/dlf/conf/schema.xml
@@ -144,6 +144,8 @@ limitations under the License.
         <!-- Next two fields are mandatory for identifying documents. -->
         <field name="title" type="standard" indexed="true" stored="true" multiValued="false" default="" />
         <field name="volume" type="standard" indexed="true" stored="true" multiValued="false" default="" />
+        <!-- Convenience field to provide context about the path within the logical structure map -->
+        <field name="structure_path" type="string" indexed="false" stored="true" multiValued="true" default="" />
         <!-- The keydate of a resource e.g a newspaper was issued or a letter was written -->
 	    <field name="date" type="daterange" indexed="true" stored="true" multiValued="false" />
         <!-- URL of thumbnail image for the document. -->

--- a/Configuration/FlexForms/ListView.xml
+++ b/Configuration/FlexForms/ListView.xml
@@ -65,6 +65,14 @@
                             <default>0</default>
                         </config>
                     </settings.getTitle>
+                    <settings.getStructurePath>
+                        <exclude>1</exclude>
+                        <label>LLL:EXT:dlf/Resources/Private/Language/locallang_be.xlf:flexform.getStructurePath</label>
+                        <config>
+                            <type>check</type>
+                            <default>0</default>
+                        </config>
+                    </settings.getStructurePath>
                     <settings.basketButton>
                         <onChange>reload</onChange>
                         <exclude>1</exclude>

--- a/Documentation/Administrator/Index.rst
+++ b/Documentation/Administrator/Index.rst
@@ -226,6 +226,26 @@ d. Reindex all documents. This can be done by the kitodo:reindex CLI command wit
 Furthermore version 5.1 supports the use of Solr Managed Schemas to update the schemas automatically during the update of the extension.
 To use this feature you have to change the schemaFactory within solrconfig.xml from "ClassicIndexSchemaFactory" to "ManagedIndexSchemaFactory".
 
+Version 5.1 & Version 6.0 -> 7.0
+==================
+
+Version 7.0 introduces a new Solr field :code:`structure_path`, that provides context in the ListView about where search results appear in the structure tree. Indexing requires 
+the field to be present in your running Solr instance, thus making the update of the schema.xml mandatory.
+
+Steps to Update your Solr schema.xml
+---------------
+a. Copy the updated schema.xml to your Solr configsets in $SOLR_HOME/configsets/dlf/
+b. Restart Solr.
+c. Reindex all documents in order to profit from the new field. This can be done by the kitodo:reindex CLI command with the '-a' (all) flag. See: :ref:`reindex_collections`.
+
+Plugin ListView
+---------------
+
+The ListView plugin has now a new setting 'Show breadcrumb/path to result location within the structure map', which is deactivated by default. When activated the 
+search results will display a string similar to a breadcrumb, that shows the label or type of the parents structures up to but excluding the toplevel structure. The 
+structure path will always be generated during indexing, the plugin settings toggles wether it will be displayed or not. Documents that not have been reindexed yet 
+will not display a structure path.
+
 *******
 Logging
 *******

--- a/Documentation/Plugins/Index.rst
+++ b/Documentation/Plugins/Index.rst
@@ -444,6 +444,13 @@ List View
        0
 
  - :Property:
+        getStructurePath
+   :Data Type:
+        :ref:`t3tsref:data-type-boolean`
+   :Default:
+       0
+
+ - :Property:
        basketButton
    :Data Type:
        :ref:`t3tsref:data-type-boolean`

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -17,6 +17,10 @@
                 <source><![CDATA[Show only documents from the selected collection(s)]]></source>
                 <target><![CDATA[Nur Dokumente der ausgewählten Kollektion(en) berücksichtigen]]></target>
             </trans-unit>
+            <trans-unit id="flexform.getStructurePath" approved="yes">
+                <source><![CDATA[Show breadcrumb/path to result location within the structure map]]></source>
+                <target><![CDATA[Breadcrumb/Pfad des Treffers innerhalb des Strukturbaums anzeigen]]></target>
+            </trans-unit>
             <trans-unit id="flexform.getTitle" approved="yes">
                 <source><![CDATA[Show title of parent document if document has no title itself]]></source>
                 <target><![CDATA[Bei Bedarf Titel des übergeordneten Dokuments anzeigen]]></target>

--- a/Resources/Private/Language/de.locallang_labels.xlf
+++ b/Resources/Private/Language/de.locallang_labels.xlf
@@ -821,7 +821,7 @@
                 <target>Solr-Schema-Feld "volume" : Volume field is mandatory for identifying documents (Standard ist "volume")</target>
                 <source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
             </trans-unit>
-            <trans-unit id="config.solr.fields.structure_path">
+            <trans-unit id="config.solr.fields.structurePath">
                 <target>Solr-Schema-Feld "structure_path" : Field providing context about the location of a resource in the structure map (Standard ist "structure_path")</target>
                 <source>Solr Schema Field "structure_path" : Field providing context about the location of a resource in the structure map (default is "structure_path")</source>
             </trans-unit>

--- a/Resources/Private/Language/de.locallang_labels.xlf
+++ b/Resources/Private/Language/de.locallang_labels.xlf
@@ -821,6 +821,10 @@
                 <target>Solr-Schema-Feld "volume" : Volume field is mandatory for identifying documents (Standard ist "volume")</target>
                 <source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
             </trans-unit>
+            <trans-unit id="config.solr.fields.structure_path">
+                <target>Solr-Schema-Feld "structure_path" : Field providing context about the location of a resource in the structure map (Standard ist "structure_path")</target>
+                <source>Solr Schema Field "structure_path" : Field providing context about the location of a resource in the structure map (default is "structure_path")</source>
+            </trans-unit>
             <trans-unit id="config.solr.fields.date">
                 <target>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (Standard ist "date")</target>
                 <source>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (default is "date")</source>

--- a/Resources/Private/Language/de.locallang_metadata.xlf
+++ b/Resources/Private/Language/de.locallang_metadata.xlf
@@ -93,6 +93,10 @@
                 <source><![CDATA[Shelfmark]]></source>
                 <target><![CDATA[Signatur]]></target>
             </trans-unit>
+            <trans-unit id="metadata.structure_path" approved="yes">
+                <source><![CDATA[Structure Path]]></source>
+                <target><![CDATA[Strukturpfad]]></target>
+            </trans-unit>
             <trans-unit id="metadata.terms" approved="yes">
                 <source><![CDATA[Terms of Use]]></source>
                 <target><![CDATA[Nutzungsbedingungen]]></target>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -14,6 +14,12 @@
             <trans-unit id="flexform.excludeOtherCollections">
                 <source><![CDATA[Show only documents from the selected collection(s)]]></source>
             </trans-unit>
+            <trans-unit id="flexform.getStructurePath">
+                <source><![CDATA[Show breadcrumb/path to result location within the structure map]]></source>
+            </trans-unit>
+            <trans-unit id="flexform.getTitle">
+                <source><![CDATA[Show title of parent document if document has no title itself]]></source>
+            </trans-unit>
             <trans-unit id="flexform.library">
                 <source><![CDATA[Providing library]]></source>
             </trans-unit>
@@ -355,9 +361,6 @@
             </trans-unit>
             <trans-unit id="plugins.listview.flexform.limit">
                 <source><![CDATA[Documents per page]]></source>
-            </trans-unit>
-            <trans-unit id="flexform.getTitle">
-                <source><![CDATA[Show title of parent document if document has no title itself]]></source>
             </trans-unit>
             <trans-unit id="plugins.collection.title">
                 <source><![CDATA[Kitodo: Collection]]></source>

--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -617,7 +617,7 @@
             <trans-unit id="config.solr.fields.volume">
                 <source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
             </trans-unit>
-            <trans-unit id="config.solr.fields.structure_path">
+            <trans-unit id="config.solr.fields.structurePath">
                 <source>Solr Schema Field "structure_path" : Field providing context about the location of a resource in the structure map (default is "structure_path")</source>
             </trans-unit>
             <trans-unit id="config.solr.fields.date">

--- a/Resources/Private/Language/locallang_labels.xlf
+++ b/Resources/Private/Language/locallang_labels.xlf
@@ -617,6 +617,9 @@
             <trans-unit id="config.solr.fields.volume">
                 <source>Solr Schema Field "volume" : Volume field is mandatory for identifying documents (default is "volume")</source>
             </trans-unit>
+            <trans-unit id="config.solr.fields.structure_path">
+                <source>Solr Schema Field "structure_path" : Field providing context about the location of a resource in the structure map (default is "structure_path")</source>
+            </trans-unit>
             <trans-unit id="config.solr.fields.date">
                 <source>Solr Schema Field "date" : The date a resource was issued or created. Used for datesearch (default is "date")</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_metadata.xlf
+++ b/Resources/Private/Language/locallang_metadata.xlf
@@ -68,6 +68,12 @@
             <trans-unit id="metadata.rights_info">
                 <source><![CDATA[Rights Information]]></source>
             </trans-unit>
+            <trans-unit id="metadata.shelfmark">
+                <source><![CDATA[Shelfmark]]></source>
+            </trans-unit>
+            <trans-unit id="metadata.structure_path">
+                <source><![CDATA[Structure Path]]></source>
+            </trans-unit>
             <trans-unit id="metadata.terms">
                 <source><![CDATA[Terms of Use]]></source>
             </trans-unit>
@@ -94,9 +100,6 @@
             </trans-unit>
             <trans-unit id="metadata.year">
                 <source><![CDATA[Year of Publication]]></source>
-            </trans-unit>
-            <trans-unit id="metadata.shelfmark">
-                <source><![CDATA[Shelfmark]]></source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Partials/ListView/Results.html
+++ b/Resources/Private/Partials/ListView/Results.html
@@ -104,6 +104,11 @@
                                     <f:if condition="{result.title}">
                                         <f:render partial="ListView/ResultsTitleMetadata" arguments="{title: result.title}" />
                                     </f:if>
+                                    <f:if condition="{settings.getStructurePath}">
+                                        <f:for each="{result.structure_path}" as="structure_path">
+                                            <f:render partial="ListView/ResultsStructurePathMetadata" arguments="{structure_path: structure_path}" />
+                                        </f:for>
+                                    </f:if>
                                     <f:if condition="{result.structure} != 'page'">
                                         <f:render partial="ListView/ResultsTypeMetadata" arguments="{type: result.structure}" />
                                     </f:if>

--- a/Resources/Private/Partials/ListView/ResultsStructurePathMetadata.html
+++ b/Resources/Private/Partials/ListView/ResultsStructurePathMetadata.html
@@ -1,0 +1,19 @@
+<f:comment>
+<!--
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+-->
+</f:comment>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+    <dt class="tx-dlf-structure_path"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.structure_path' /></dt>
+    <dd class="tx-dlf-structure_path">{structure_path}</dd>
+
+</html>

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -179,6 +179,7 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
                     'restrictions' => 'restrictions',
                     'root' => 'root',
                     'sid' => 'sid',
+                    'structurePath' => 'structure_path',
                     'terms' => 'terms',
                     'thumbnail' => 'thumbnail',
                     'timestamp' => 'timestamp',

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -82,6 +82,8 @@ solr.fields.type = type
 solr.fields.title = title
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.volume
 solr.fields.volume = volume
+# cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.structure_path
+solr.fields.structure_path = structure_path
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.date
 solr.fields.date = date
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.thumbnail

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -82,8 +82,8 @@ solr.fields.type = type
 solr.fields.title = title
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.volume
 solr.fields.volume = volume
-# cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.structure_path
-solr.fields.structure_path = structure_path
+# cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.structurePath
+solr.fields.structurePath = structure_path
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.date
 solr.fields.date = date
 # cat=Solr; type=string; label=LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:config.solr.fields.thumbnail


### PR DESCRIPTION
This PR adds a new feature, that (if activated in settings) displays the structure path to a search result (comparable to a breadcrumb) in the list view.

Current situation:
In the search result sets the documents have either...
* their distinct title, that is extracted from the `dmdsec`-Sections or the `@LABEL` from the ToC, and a page number => in the case for metadata search
* or only the page number => in the case for fulltext search

In both cases users cannot know, where within the logical structure of the document, the search result actually appears. Meaning, that a title like "Krankheiten" could both be in "Kapitel 1: Tiere" or "Kapitel 2: Pflanzen" and we would not know before hand. The same logic applies to fulltext results, where we know nothing of this at all and are completly lost.

Solution:
This PR adds a setting to the `ListView Plugin` that allows for displaying this information. For this to work:
* a new solr field `structure_path` was added, that holds a JSON encoded representation of the structure path/breadcrumb, which is required, so that the `type` (= structure without a custom `label`) can still be translated after retrieval to the correct language. The field is multivalued, because physical pages can be associated with multiple logical structures (= end of "Kapitel 1" and beginning of "Kapitel 2".
* it is required to update the solr `schema.xml`, so that the field is actually defined and used in your instance. Otherwise indexing will fail.

This PR provides the necessary changes to the schema.xml, translation files, listview flexform, the indexer and solrsearch/result as well as to the listview controller and corresponding templates.

Examples:
## Volltextsuche nach "Fischer"
<img width="1342" height="700" alt="grafik" src="https://github.com/user-attachments/assets/7648971e-2d48-4801-80c9-9a722de2e82f" />

## Metadatensuche nach "Optik"
<img width="1244" height="641" alt="grafik" src="https://github.com/user-attachments/assets/44ee2346-60ee-4453-8cdd-ba5ee6d509e3" />

## Volltextsuche nach "Schmied"
<img width="1175" height="713" alt="grafik" src="https://github.com/user-attachments/assets/791fd8b7-d789-4b43-bc88-d27c01a09095" />
