### PR TITLE
[BUGFIX] Adjust TEI HDR metadata for retrieving title

### DIFF
--- a/Resources/Private/Data/MetadataDefaults.json
+++ b/Resources/Private/Data/MetadataDefaults.json
@@ -28,7 +28,7 @@
             },
             {
                 "format_root": "teiHeader",
-                "xpath": "./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:note[@type=\"caption\"]",
+                "xpath": "./teihdr:fileDesc/teihdr:titleStmt/teihdr:title",
                 "xpath_sorting": ""
             },
             {

--- a/Resources/Private/Data/MetadataDefaults.json
+++ b/Resources/Private/Data/MetadataDefaults.json
@@ -28,7 +28,7 @@
             },
             {
                 "format_root": "teiHeader",
-                "xpath": "./teihdr:fileDesc/teihdr:titleStmt/teihdr:title",
+                "xpath": "./teihdr:fileDesc/teihdr:titleStmt/teihdr:title | ./teihdr:fileDesc/teihdr:sourceDesc/teihdr:msDesc/teihdr:head/teihdr:title",
                 "xpath_sorting": ""
             },
             {


### PR DESCRIPTION
https://github.com/slub/dfg-viewer/issues/70
https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-titleStmt.html
https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-sourceDesc.html

Element `titleStmt` looks more correct here than `sourceDesc`.