### PR TITLE
[FEATURE] Document loading helper

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -102,7 +102,14 @@ class Helper
         'chemical/x-xyz' => 'xyz',
         'text/html' => 'html'
     ];
-
+    public static function getDocumentInstance($documentLocation, $settings)
+    {
+        static $doc;
+        if($doc === null){
+            $doc = AbstractDocument::getInstance($documentLocation, $settings);
+        }
+        return $doc;
+    }
     /**
      * Generates a flash message and adds it to a message queue.
      *

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -202,13 +202,11 @@ class Helper
         libxml_use_internal_errors($libxmlErrors);
         return $xml;
     }
-    
     /**
      * @param string $documentLocation The URL of XML file or the IRI of the IIIF resource
      * @param array $settings
      * 
      * @return AbstractDocument
-     *  
      */
     public static function getDocumentInstance($documentLocation, $settings): AbstractDocument|null
     {

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -205,7 +205,7 @@ class Helper
     /**
      * @param string $documentLocation The URL of XML file or the IRI of the IIIF resource
      * @param array $settings
-     * 
+     *
      * @return AbstractDocument
      */
     public static function getDocumentInstance($documentLocation, $settings): AbstractDocument|null

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -102,7 +102,6 @@ class Helper
         'chemical/x-xyz' => 'xyz',
         'text/html' => 'html'
     ];
-    
     /**
      * Generates a flash message and adds it to a message queue.
      *
@@ -209,11 +208,12 @@ class Helper
      * @param array $settings
      * 
      * @return AbstractDocument
+     *  
      */
     public static function getDocumentInstance($documentLocation, $settings): AbstractDocument|null
     {
         static $doc;
-        if($doc === null){
+        if ($doc === null) {
             $doc = AbstractDocument::getInstance($documentLocation, $settings);
         }
         return $doc;

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -102,6 +102,14 @@ class Helper
         'chemical/x-xyz' => 'xyz',
         'text/html' => 'html'
     ];
+
+    /**
+     * @access protected
+     * @static
+     * @var array A list of loaded documents which can be accessed uniquely through a hash
+     */
+    protected static array $docs = [];
+
     /**
      * Generates a flash message and adds it to a message queue.
      *
@@ -202,7 +210,10 @@ class Helper
         libxml_use_internal_errors($libxmlErrors);
         return $xml;
     }
+
     /**
+     * This method checks if a unique document (through hash) is already loaded and returns it. If not loaded yet it will load it into the list 
+     * 
      * @param string $documentLocation The URL of XML file or the IRI of the IIIF resource
      * @param array $settings
      *
@@ -210,11 +221,11 @@ class Helper
      */
     public static function getDocumentInstance($documentLocation, $settings): AbstractDocument|null
     {
-        static $doc;
-        if ($doc === null) {
-            $doc = AbstractDocument::getInstance($documentLocation, $settings);
+        $hash = md5($documentLocation);
+        if (!isset(static::$docs[$hash])) {
+            static::$docs[$hash] = AbstractDocument::getInstance($documentLocation, $settings);
         }
-        return $doc;
+        return static::$docs[$hash];
     }
 
     /**

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -212,8 +212,8 @@ class Helper
     }
 
     /**
-     * This method checks if a unique document (through hash) is already loaded and returns it. If not loaded yet it will load it into the list 
-     * 
+     * This method checks if a unique document (through hash) is already loaded and returns it. If not loaded yet it will load it into the list
+     *
      * @param string $documentLocation The URL of XML file or the IRI of the IIIF resource
      * @param array $settings
      *
@@ -221,7 +221,7 @@ class Helper
      */
     public static function getDocumentInstance($documentLocation, $settings): AbstractDocument|null
     {
-        $hash = md5($documentLocation);
+        $hash = hash('sha256', $documentLocation);
         if (!isset(static::$docs[$hash])) {
             static::$docs[$hash] = AbstractDocument::getInstance($documentLocation, $settings);
         }

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -102,14 +102,7 @@ class Helper
         'chemical/x-xyz' => 'xyz',
         'text/html' => 'html'
     ];
-    public static function getDocumentInstance($documentLocation, $settings)
-    {
-        static $doc;
-        if($doc === null){
-            $doc = AbstractDocument::getInstance($documentLocation, $settings);
-        }
-        return $doc;
-    }
+    
     /**
      * Generates a flash message and adds it to a message queue.
      *
@@ -209,6 +202,21 @@ class Helper
         // Reset libxml's error logging.
         libxml_use_internal_errors($libxmlErrors);
         return $xml;
+    }
+    
+    /**
+     * @param string $documentLocation The URL of XML file or the IRI of the IIIF resource
+     * @param array $settings
+     * 
+     * @return AbstractDocument
+     */
+    public static function getDocumentInstance($documentLocation, $settings): AbstractDocument|null
+    {
+        static $doc;
+        if($doc === null){
+            $doc = AbstractDocument::getInstance($documentLocation, $settings);
+        }
+        return $doc;
     }
 
     /**

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -231,7 +231,6 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         if (isset($this->requestData['multiViewSource']) && is_array($this->requestData['multiViewSource'])) {
             foreach ($this->requestData['multiViewSource'] as $sourceKey => $documentUrl) {
                 $sourceDocument = Helper::getDocumentInstance($documentUrl, $this->settings);
-                //$sourceDocument = AbstractDocument::getInstance($documentUrl, $this->settings);
                 if ($sourceDocument !== null) {
                     if ($this->isMultiDocumentType($sourceDocument->tableOfContents[0]['type'])) {
                         $childDocuments = $sourceDocument->tableOfContents[0]['children'];
@@ -287,7 +286,6 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
             if ($this->document !== null) {
                 $doc = Helper::getDocumentInstance($this->document->getLocation(), $this->settings);
-                //$doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
                 if ($doc !== null) {
                     $this->document->setCurrentDocument($doc);
                 } else {
@@ -741,7 +739,6 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
         if ($this->document) {
             $doc = Helper::getDocumentInstance($this->document->getLocation(), $this->settings);
-            //$doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
             if ($doc !== null) {
                 $doc->configPid = $this->document->getPid();
                 $this->buildMultiViewDocuments($this->document->getLocation(), $doc);
@@ -767,7 +764,6 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     protected function getDocumentByUrl(string $documentUrl)
     {
         $doc = Helper::getDocumentInstance($documentUrl, $this->settings);
-        //$doc = AbstractDocument::getInstance($documentUrl, $this->settings);
         if ($doc !== null) {
             $this->buildMultiViewDocuments($documentUrl, $doc);
 

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -230,7 +230,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         }
         if (isset($this->requestData['multiViewSource']) && is_array($this->requestData['multiViewSource'])) {
             foreach ($this->requestData['multiViewSource'] as $sourceKey => $documentUrl) {
-                $sourceDocument = AbstractDocument::getInstance($documentUrl, $this->settings);
+                $sourceDocument = Helper::getDocumentInstance($documentUrl, $this->settings);
+                //$sourceDocument = AbstractDocument::getInstance($documentUrl, $this->settings);
                 if ($sourceDocument !== null) {
                     if ($this->isMultiDocumentType($sourceDocument->tableOfContents[0]['type'])) {
                         $childDocuments = $sourceDocument->tableOfContents[0]['children'];
@@ -285,7 +286,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             $this->document = $this->documentRepository->findOneBy(['recordId' => $this->requestData['recordId']]);
 
             if ($this->document !== null) {
-                $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
+                $doc = Helper::getDocumentInstance($this->document->getLocation(), $this->settings);
+                //$doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
                 if ($doc !== null) {
                     $this->document->setCurrentDocument($doc);
                 } else {
@@ -738,7 +740,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         $this->document = $this->documentRepository->findOneByIdAndSettings($documentId);
 
         if ($this->document) {
-            $doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
+            $doc = Helper::getDocumentInstance($this->document->getLocation(), $this->settings);
+            //$doc = AbstractDocument::getInstance($this->document->getLocation(), $this->settings);
             if ($doc !== null) {
                 $doc->configPid = $this->document->getPid();
                 $this->buildMultiViewDocuments($this->document->getLocation(), $doc);
@@ -763,8 +766,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
      */
     protected function getDocumentByUrl(string $documentUrl)
     {
-        $doc = AbstractDocument::getInstance($documentUrl, $this->settings);
-
+        $doc = Helper::getDocumentInstance($documentUrl, $this->settings);
+        //$doc = AbstractDocument::getInstance($documentUrl, $this->settings);
         if ($doc !== null) {
             $this->buildMultiViewDocuments($documentUrl, $doc);
 


### PR DESCRIPTION
In this pull request we replace the "obsolete" approach by loading documents one time with a service and fall back to the more easier to implement and straight forward approach of using a static helper method with a static field (i think this is what you meant with "singleton" like pattern) for one time loading of a document within abstract controller. The speed gain is slightly lesse but not significant. This PR is compatible with multiview and all other plugins.
The speed gain is based on the fact, that only the first loaded controller (plugin) makes an initial load of the document and all following controllers (plugins) use this loaded document.