### PR TITLE
[BUGFIX] Fix link rendering by using current ViewHelper tag instance

### DIFF
--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -98,12 +98,10 @@ final class LinkViewHelper extends AbstractTagBasedViewHelper
             $uri .= '#' . $this->arguments['section'];
         }
 
-        $tag = new static();
-        $tag->tag->setTagName('a');
-        $tag->tag->addAttribute('href', $uri);
-        $tag->tag->setContent($childContent);
+        $this->tag->addAttribute('href', $uri);
+        $this->tag->setContent($childContent);
 
-        return $tag->tag->render();
+        return $this->tag->render();
     }
 
     /**


### PR DESCRIPTION
closes: #1815

Avoid creating a new static ViewHelper instance during render(). Render $this->tag to keep Fluid-initialized attributes from parent. 
This change renders the already-initialized `$this->tag` instance provided by Fluid, ensuring all registered attributes and arguments like `title` are preserved.