### PR TITLE
[BUGFIX] Prevent index_name duplication on proper localization of metadata

### DIFF
--- a/Configuration/TCA/tx_dlf_metadata.php
+++ b/Configuration/TCA/tx_dlf_metadata.php
@@ -82,7 +82,7 @@ return [
         ],
         'index_name' => [
             'exclude' => 1,
-            'l10n_mode' => '',
+            'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/Resources/Private/Language/locallang_labels.xlf:tx_dlf_metadata.index_name',
             'config' => [
                 'type' => 'input',


### PR DESCRIPTION
This PR fixes an error, where the `index_name`  of a new (proper) localization gets duplicated to `index_name0` in the metadata repository.

This fix will not prevent duplication, when translations are created through new records and by manual linking them afterwards (wrong usage!). But it will not duplicate anymore when page translations in the backend are used on the storage folder and new translations are created via "Localize To" - which is the proper way to do so.

<img width="1142" height="485" alt="grafik" src="https://github.com/user-attachments/assets/2f0fe0df-af88-4c6a-ac57-401dee9f4b77" />
