### PR TITLE
[MAINTENANCE] Translate Helper Refactoring

### DIFF
--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -616,6 +616,16 @@ class Helper
         $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
         return $languageAspect->getContentId();
     }
+
+    /**
+     * Queries the Backend Repo for the given parameter table with the matching 
+     * PID (now not used because only run on the table structures where all PID are the same)
+     * 
+     * @param string $table
+     * @param string $pid
+     * 
+     * @return array
+     */
     public static function translate_test(string $table, string $pid): array
     {
         static $translations = [];
@@ -639,6 +649,17 @@ class Helper
             return $translations;
         }
     }
+    
+    /**
+     * This method searches in the translation array which is an excerpt from the backend table for matching parents and than checks 
+     * for the language Id and translates the given parameter indexName
+     * 
+     * @param string $indexName
+     * @param array $translations
+     * @param mixed $languageContentId
+     * 
+     * @return string The translated index name or the index name if no translation found
+     */
     public static function translate_get(string $indexName, array $translations, $languageContentId)
     {
         $filtered_parent = array_filter($translations, function ($obj) use ($indexName) {

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -682,12 +682,7 @@ class Helper
                 self::error('Error querying backend pool: ' . $e->getMessage());
             }
             foreach ($rows as $row) {
-                    $indexNameFromTable = $row['index_name'];
-                    $languageIdFromTable = (int)$row['sys_language_uid'];
-            
-                    $translations[$table][$pid][$indexNameFromTable][$languageIdFromTable] = [
-                        'label' => $row['label']
-                    ];
+                    $translations[$table][$pid][$row['index_name']][(int)$row['sys_language_uid']] = ['label' => $row['label']];
                 }
         }
         //return translation based on parameters table, PID, indexName and languageId, else return indexName

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -682,9 +682,7 @@ class Helper
                 foreach ($rows as $row) {
                     $translations[$table][$pid][$row['index_name']][(int) $row['sys_language_uid']] = ['label' => $row['label']];
                 }
-            }
-            catch (Exception $e)
-            {
+            } catch (Exception $e) {
                 self::error('Error querying backend pool: ' . $e->getMessage());
             }
         }

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -661,7 +661,7 @@ class Helper
         //static Array to save all already queried Translations
         static $translations = [];
         //Query Backend for translations for one table and PID combination - only query if not yet done
-        if(empty($translations[$table][$pid])) {
+        if (empty($translations[$table][$pid])) {
             try {
                 $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                     ->getQueryBuilderForTable($table);
@@ -675,7 +675,7 @@ class Helper
                     ->where(
                         $queryBuilder->expr()->eq($table . '.pid', $pid),
                         $queryBuilder->expr()->eq($table . '.deleted', 0)
-                        )
+                    )
                     ->from($table)
                     ->executeQuery()
                     ->fetchAllAssociative();
@@ -691,7 +691,7 @@ class Helper
         //return translation based on parameters table, PID, indexName and languageId, else return indexName
         return isset($translations[$table][$pid][$indexName][$languageId]) ? $translations[$table][$pid][$indexName][$languageId]['label'] : $indexName;
     }
-    
+
     /**
      * This returns the additional WHERE expression of a table based on its TCA configuration
      *

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -661,8 +661,7 @@ class Helper
         //static Array to save all already queried Translations
         static $translations = [];
         //Query Backend for translations for one table and PID combination - only query if not yet done
-        if(empty($translations[$table][$pid]))
-        {
+        if(empty($translations[$table][$pid])) {
             try {
                 $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                     ->getQueryBuilderForTable($table);
@@ -680,14 +679,14 @@ class Helper
                     ->from($table)
                     ->executeQuery()
                     ->fetchAllAssociative();
+                foreach ($rows as $row) {
+                    $translations[$table][$pid][$row['index_name']][(int) $row['sys_language_uid']] = ['label' => $row['label']];
+                }
             }
             catch (Exception $e)
             {
                 self::error('Error querying backend pool: ' . $e->getMessage());
             }
-            foreach ($rows as $row) {
-                    $translations[$table][$pid][$row['index_name']][(int)$row['sys_language_uid']] = ['label' => $row['label']];
-                }
         }
         //return translation based on parameters table, PID, indexName and languageId, else return indexName
         return isset($translations[$table][$pid][$indexName][$languageId]) ? $translations[$table][$pid][$indexName][$languageId]['label'] : $indexName;

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -678,12 +678,7 @@ class Helper
                 self::error('Error querying backend pool: ' . $e->getMessage());
             }
             foreach ($rows as $row) {
-                    $indexNameFromTable = $row['index_name'];
-                    $languageIdFromTable = (int)$row['sys_language_uid'];
-            
-                    $translations[$table][$pid][$indexNameFromTable][$languageIdFromTable] = [
-                        'label' => $row['label']
-                    ];
+                    $translations[$table][$pid][$row['index_name']][(int)$row['sys_language_uid']] = ['label' => $row['label']];
                 }
         }
         //return translation based on parameters table, PID, indexName and languageId, else return indexName

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -631,7 +631,7 @@ class Helper
 
         return $totalSeconds;
     }
-
+    
     /**
      * This translates an internal "index_name"
      *
@@ -668,7 +668,8 @@ class Helper
                         $table . '.sys_language_uid As sys_language_uid'
                     )
                     ->where(
-                        $queryBuilder->expr()->eq($table . '.pid', $pid)
+                        $queryBuilder->expr()->eq($table . '.pid', $pid),
+                        $queryBuilder->expr()->eq($table . '.deleted', 0)
                         )
                     ->from($table)
                     ->executeQuery()
@@ -679,10 +680,10 @@ class Helper
                 self::error('Error querying backend pool: ' . $e->getMessage());
             }
             foreach ($rows as $row) {
-                    $indexName = $row['index_name'];
-                    $languageId = (int)$row['sys_language_uid'];
+                    $indexNameFromTable = $row['index_name'];
+                    $languageIdFromTable = (int)$row['sys_language_uid'];
             
-                    $translations[$table][$pid][$indexName][$languageId] = [
+                    $translations[$table][$pid][$indexNameFromTable][$languageIdFromTable] = [
                         'uid' => (int)$row['uid'],
                         'l18n_parent' => (int)$row['l18n_parent'],
                         'label' => $row['label'],
@@ -690,7 +691,7 @@ class Helper
                 }
         }
         //return translation based on parameters table, PID, indexName and languageId, else return indexName
-        return empty($translations[$table][$pid][$indexName][$languageId]) ? $indexName : $translations[$table][$pid][$indexName][$languageId]['label'];
+        return isset($translations[$table][$pid][$indexName][$languageId]) ? $translations[$table][$pid][$indexName][$languageId]['label'] : $indexName;
     }
     
     /**

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -631,8 +631,8 @@ class Helper
 
         $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
         $languageId = $languageAspect->getContentId();
-        static $translationsArray = [];
-        if(empty($translationsArray[$table][$pid]))
+        static $translations = [];
+        if(empty($translations[$table][$pid]))
         {
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
                 ->getQueryBuilderForTable($table);
@@ -655,14 +655,14 @@ class Helper
                     $indexName = $row['index_name'];
                     $languageId = (int)$row['sys_language_uid'];
             
-                    $translationsArray[$table][$pid][$indexName][$languageId] = [
+                    $translations[$table][$pid][$indexName][$languageId] = [
                         'uid' => (int)$row['uid'],
                         'l18n_parent' => (int)$row['l18n_parent'],
                         'label' => $row['label'],
                     ];
                 }
         }
-        return empty($translationsArray[$table][$pid][$indexName][$languageId]) ? $indexName : $translationsArray[$table][$pid][$indexName][$languageId]['label'];
+        return empty($translations[$table][$pid][$indexName][$languageId]) ? $indexName : $translations[$table][$pid][$indexName][$languageId]['label'];
     }
     
     /**

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -651,6 +651,10 @@ class Helper
      */
     public static function translate(string $indexName, string $table, string $pid): string
     {
+        //Check if this table is allowed for translation.
+        if (!in_array($table, ['tx_dlf_collections', 'tx_dlf_libraries', 'tx_dlf_metadata', 'tx_dlf_metadatasubentries', 'tx_dlf_structures'])) {
+            return $indexName;
+        }
         //Get LanguageId (sys_language_uid in Backend) from context
         $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
         $languageId = $languageAspect->getContentId();

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -631,7 +631,7 @@ class Helper
 
         return $totalSeconds;
     }
-    
+
     /**
      * This translates an internal "index_name"
      *
@@ -661,8 +661,6 @@ class Helper
 
                 $rows = $queryBuilder
                     ->select(
-                        $table . '.uid AS uid',
-                        $table . '.l18n_parent AS l18n_parent',
                         $table . '.label AS label',
                         $table . '.index_name AS index_name',
                         $table . '.sys_language_uid As sys_language_uid'
@@ -684,9 +682,7 @@ class Helper
                     $languageIdFromTable = (int)$row['sys_language_uid'];
             
                     $translations[$table][$pid][$indexNameFromTable][$languageIdFromTable] = [
-                        'uid' => (int)$row['uid'],
-                        'l18n_parent' => (int)$row['l18n_parent'],
-                        'label' => $row['label'],
+                        'label' => $row['label']
                     ];
                 }
         }

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -612,7 +612,10 @@ class Helper
 
         return $totalSeconds;
     }
-
+    public static function translate_contextId() {
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        return $languageAspect->getContentId();
+    }
     public static function translate_test(string $table, string $pid): array
     {
         static $translations = [];
@@ -636,19 +639,19 @@ class Helper
             return $translations;
         }
     }
-    public static function translate_get(string $indexName, array $translations)
+    public static function translate_get(string $indexName, array $translations, $languageContentId)
     {
         $filtered_parent = array_filter($translations, function ($obj) use ($indexName) {
             return $obj['index_name'] == $indexName && $obj['l18n_parent'] != 0;
         });
-        $xkey = key($filtered_parent);
-        
-        $filtered_uid = array_filter($translations, function ($obj) use ($filtered_parent, $xkey) {
-            return $obj['uid'] == $filtered_parent[$xkey]['l18n_parent'];
+        $xKey = key($filtered_parent);
+        if($xKey == '')
+        {
+            return $indexName;
+        }
+        $filtered_uid = array_filter($translations, function ($obj) use ($filtered_parent, $xKey) {
+            return $obj['uid'] == $filtered_parent[$xKey]['l18n_parent'];
         });
-
-        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
-        $languageContentId = $languageAspect->getContentId();
         $filtered_language = array_filter($filtered_uid, function($obj) use ($languageContentId) {
             return $obj['sys_language_uid'] == (int)$languageContentId;
         });

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -35,8 +35,8 @@ class TableOfContentsController extends AbstractController
      */
     protected array $activeEntries = [];
 
-    protected array $translations;
-    protected string $languageContentId;
+    //protected array $translations;
+    //protected string $languageContentId;
 
     /**
      * The main method of the plugin
@@ -47,8 +47,8 @@ class TableOfContentsController extends AbstractController
      */
     public function mainAction(): ResponseInterface
     {
-        $this->translations = Helper::translate_test('tx_dlf_structures', $this->settings['storagePid']);
-        $this->languageContentId = Helper::translate_contextId();
+        //$this->translations = Helper::translate_test('tx_dlf_structures', $this->settings['storagePid']);
+        //$this->languageContentId = Helper::translate_contextId();
         // Load current document.
         $this->loadDocument();
 
@@ -322,8 +322,8 @@ class TableOfContentsController extends AbstractController
      */
     private function getTranslatedType(string $type): string
     {
-        return Helper::translate_get($type, $this->translations, $this->languageContentId);
-        //return Helper::translate($type, 'tx_dlf_structures', $this->settings['storagePid']);
+        //return Helper::translate_get($type, $this->translations, $this->languageContentId);
+        return Helper::translate($type, 'tx_dlf_structures', $this->settings['storagePid']);
     }
 
     /**

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -46,7 +46,6 @@ class TableOfContentsController extends AbstractController
     {
         // Load current document.
         $this->loadDocument();
-
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return $this->htmlResponse();
@@ -57,7 +56,6 @@ class TableOfContentsController extends AbstractController
         }
 
         $this->view->assign('viewData', $this->viewData);
-    
         return $this->htmlResponse();
     }
 

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -35,6 +35,9 @@ class TableOfContentsController extends AbstractController
      */
     protected array $activeEntries = [];
 
+    protected array $translations;
+    protected string $languageContentId;
+
     /**
      * The main method of the plugin
      *
@@ -44,8 +47,11 @@ class TableOfContentsController extends AbstractController
      */
     public function mainAction(): ResponseInterface
     {
+        $this->translations = Helper::translate_test('tx_dlf_structures', $this->settings['storagePid']);
+        $this->languageContentId = Helper::translate_contextId();
         // Load current document.
         $this->loadDocument();
+
         if ($this->isDocMissing()) {
             // Quit without doing anything if required variables are not set.
             return $this->htmlResponse();
@@ -56,10 +62,7 @@ class TableOfContentsController extends AbstractController
         }
 
         $this->view->assign('viewData', $this->viewData);
-        $translations = Helper::translate_test('tx_dlf_structures', '2');
-        $this->view->assign('translations', $translations);
-        $result = Helper::translate_get('bookplate', $translations);
-        $this->view->assign('test_translation', $result);
+    
         return $this->htmlResponse();
     }
 
@@ -141,7 +144,7 @@ class TableOfContentsController extends AbstractController
         }
         $entryArray['year'] = $entry['year'];
         $entryArray['orderlabel'] = $entry['orderlabel'];
-        $entryArray['type'] = $entry['type'];
+        $entryArray['type'] = $this->getTranslatedType($entry['type']);
         $entryArray['pagination'] = htmlspecialchars($entry['pagination']);
         $entryArray['_OVERRIDE_HREF'] = '';
         $entryArray['doNotLinkIt'] = 1;
@@ -319,7 +322,8 @@ class TableOfContentsController extends AbstractController
      */
     private function getTranslatedType(string $type): string
     {
-        return Helper::translate($type, 'tx_dlf_structures', $this->settings['storagePid']);
+        return Helper::translate_get($type, $this->translations, $this->languageContentId);
+        //return Helper::translate($type, 'tx_dlf_structures', $this->settings['storagePid']);
     }
 
     /**

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -56,6 +56,10 @@ class TableOfContentsController extends AbstractController
         }
 
         $this->view->assign('viewData', $this->viewData);
+        $translations = Helper::translate_test('tx_dlf_structures', '2');
+        $this->view->assign('translations', $translations);
+        $result = Helper::translate_get('bookplate', $translations);
+        $this->view->assign('test_translation', $result);
         return $this->htmlResponse();
     }
 

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -35,9 +35,6 @@ class TableOfContentsController extends AbstractController
      */
     protected array $activeEntries = [];
 
-    //protected array $translations;
-    //protected string $languageContentId;
-
     /**
      * The main method of the plugin
      *
@@ -47,8 +44,6 @@ class TableOfContentsController extends AbstractController
      */
     public function mainAction(): ResponseInterface
     {
-        //$this->translations = Helper::translate_test('tx_dlf_structures', $this->settings['storagePid']);
-        //$this->languageContentId = Helper::translate_contextId();
         // Load current document.
         $this->loadDocument();
 
@@ -322,7 +317,6 @@ class TableOfContentsController extends AbstractController
      */
     private function getTranslatedType(string $type): string
     {
-        //return Helper::translate_get($type, $this->translations, $this->languageContentId);
         return Helper::translate($type, 'tx_dlf_structures', $this->settings['storagePid']);
     }
 

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
  *
@@ -137,7 +138,8 @@ class TableOfContentsController extends AbstractController
         }
         $entryArray['year'] = $entry['year'];
         $entryArray['orderlabel'] = $entry['orderlabel'];
-        $entryArray['type'] = $this->getTranslatedType($entry['type']);
+        $entryArray['type'] = $entry['type'];
+        $entryArray['translatedType'] = $this->getTranslatedType($entry['type']);
         $entryArray['pagination'] = htmlspecialchars($entry['pagination']);
         $entryArray['_OVERRIDE_HREF'] = '';
         $entryArray['doNotLinkIt'] = 1;

--- a/Resources/Private/Partials/TableOfContents/Title.html
+++ b/Resources/Private/Partials/TableOfContents/Title.html
@@ -18,7 +18,7 @@
             <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.title}</f:format.htmlspecialchars></f:format.crop>
         </f:then>
         <f:else>
-            <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false"><f:translate key="LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{child.type}" /></f:format.htmlspecialchars><f:if condition="{child.volume}"> &nbsp;<f:format.htmlspecialchars doubleEncode="false">{child.volume}</f:format.htmlspecialchars></f:if></f:format.crop>
+            <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.type}</f:format.htmlspecialchars><f:if condition="{child.volume}"> &nbsp;<f:format.htmlspecialchars doubleEncode="false">{child.volume}</f:format.htmlspecialchars></f:if></f:format.crop>
         </f:else>
     </f:if>
 </span>

--- a/Resources/Private/Partials/TableOfContents/Title.html
+++ b/Resources/Private/Partials/TableOfContents/Title.html
@@ -18,7 +18,7 @@
             <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.title}</f:format.htmlspecialchars></f:format.crop>
         </f:then>
         <f:else>
-            <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.type}</f:format.htmlspecialchars><f:if condition="{child.volume}"> &nbsp;<f:format.htmlspecialchars doubleEncode="false">{child.volume}</f:format.htmlspecialchars></f:if></f:format.crop>
+            <f:format.crop maxCharacters="55" append="&nbsp;..."><f:format.htmlspecialchars doubleEncode="false">{child.translatedType}</f:format.htmlspecialchars><f:if condition="{child.volume}"> &nbsp;<f:format.htmlspecialchars doubleEncode="false">{child.volume}</f:format.htmlspecialchars></f:if></f:format.crop>
         </f:else>
     </f:if>
 </span>

--- a/Resources/Private/Templates/TableOfContents/Main.html
+++ b/Resources/Private/Templates/TableOfContents/Main.html
@@ -1,4 +1,3 @@
-<f:debug maxDepth="12">{_all}</f:debug>
 <f:comment>
 <!--
  * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>

--- a/Resources/Private/Templates/TableOfContents/Main.html
+++ b/Resources/Private/Templates/TableOfContents/Main.html
@@ -1,3 +1,4 @@
+<f:debug maxDepth="12">{_all}</f:debug>
 <f:comment>
 <!--
  * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>


### PR DESCRIPTION
This PR reduces excessive SQL backend querying for single entry translations and lazy loading of single entries to the cache variable. Now we have just a single call to the backend per request and table and PID (retrieving as batch) and else O(1) lookup for translations. 