### PR TITLE
[MAINTENANCE] Add classes to `li` elements of toolbox

### DIFF
--- a/Resources/Private/Partials/Toolbox/AnnotationTool.html
+++ b/Resources/Private/Partials/Toolbox/AnnotationTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-annotation">
     <span class="tx-dlf-tools-annotation">
         <f:if condition="{annotationTool}">
             <f:then>

--- a/Resources/Private/Partials/Toolbox/FulltextDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/FulltextDownloadTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-fulltextdownload">
     <span class="tx-dlf-tools-fulltextdownload">
         <f:if condition="{fulltextDownload}">
             <f:then>

--- a/Resources/Private/Partials/Toolbox/FulltextTool.html
+++ b/Resources/Private/Partials/Toolbox/FulltextTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-fulltext">
     <span class="tx-dlf-tools-fulltext">
         <f:if condition="{fulltext}">
             <f:then>

--- a/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-imagedownload">
     <span class="tx-dlf-tools-imagedownload">
         <f:if condition="{double} === 0">
             <f:then>

--- a/Resources/Private/Partials/Toolbox/ModelDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/ModelDownloadTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-modeldownload">
     <span class="tx-dlf-tools-modeldownload">
         <f:link.external uri="{modelUrl}">
             <f:translate key="downloadModel"/>

--- a/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-pdfdownload">
     <span class="tx-dlf-tools-pdf-page">
         <f:if condition="{double} === 0">
             <f:then>

--- a/Resources/Private/Partials/Toolbox/SearchInDocumentTool.html
+++ b/Resources/Private/Partials/Toolbox/SearchInDocumentTool.html
@@ -12,7 +12,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<li>
+<li class="tx-dlf-tools-searchindocument">
     <f:if condition="{settings.searchUrl}">
         <f:then>
             <f:variable name="actionUrl" value="{settings.searchUrl}" />


### PR DESCRIPTION
Generally it would be beneficial to make those classes more exact. Example:

```
<li class="tx-dlf-tools-annotation-list-element">
    <span class="tx-dlf-tools-annotation-span">
```

We should discuss and agree on some unified version for naming those classes.