### PR TITLE
[MAINTENANCE] Move license comments inside html container

### DIFF
--- a/Resources/Private/Partials/Annotation/SingleAnnotation.html
+++ b/Resources/Private/Partials/Annotation/SingleAnnotation.html
@@ -1,18 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
-
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <details class="annotation-details"
          data-annotation-id="{annotation.id}"

--- a/Resources/Private/Partials/Backend/InfoBox.html
+++ b/Resources/Private/Partials/Backend/InfoBox.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="typo3-messages">
     <div class="alert alert-{alert}">

--- a/Resources/Private/Partials/Basket/AddToBasket.html
+++ b/Resources/Private/Partials/Basket/AddToBasket.html
@@ -1,17 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{settings.basketButton} && {settings.targetBasket}">
     <div>

--- a/Resources/Private/Partials/Calendar/Day.html
+++ b/Resources/Private/Partials/Calendar/Day.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{day}">
     <div class="tx-dlf-calendar-issues">

--- a/Resources/Private/Partials/ListView/Results.html
+++ b/Resources/Private/Partials/ListView/Results.html
@@ -1,25 +1,23 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />
-    <f:variable name="pageOffset" value="{settings.list.paginate.itemsPerPage * currentPage}" />
-    <ol class="tx-dlf-abstracts">
-        <f:for each="{paginator.paginatedItems}" as="document" iteration="docIterator">
-            <f:variable name="metadataTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
-            <f:variable name="docTitle" value="{f:if(condition:'{metadataTitle}', then:'{metadataTitle}', else:'{f:translate(key: \'noTitle\')}')}" />
-            <li value="{settings.list.paginate.itemsPerPage * pageOffset + docIterator.index}">
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />
+<f:variable name="pageOffset" value="{settings.list.paginate.itemsPerPage * currentPage}" />
+<ol class="tx-dlf-abstracts">
+    <f:for each="{paginator.paginatedItems}" as="document" iteration="docIterator">
+        <f:variable name="metadataTitle" value="{f:if(condition:'{document.title}', then:'{document.title}', else:'{document.metsOrderlabel}')}" />
+        <f:variable name="docTitle" value="{f:if(condition:'{metadataTitle}', then:'{metadataTitle}', else:'{f:translate(key: \'noTitle\')}')}" />
+        <li value="{settings.list.paginate.itemsPerPage * pageOffset + docIterator.index}">
             <f:link.page
             pageUid="{settings.targetPidPageView}"
             additionalParams="{tx_dlf:{page:'{document.page}', double:'0', id:'{document.uid}', pagegrid:'0'}}"
@@ -129,9 +127,9 @@
                     </f:for>
                 </ol>
             </f:if>
-            </li>
-        </f:for>
-    </ol>
-    <f:render partial="Lists/Pagination" arguments="{_all}" />
+        </li>
+    </f:for>
+</ol>
+<f:render partial="Lists/Pagination" arguments="{_all}" />
 
 </html>

--- a/Resources/Private/Partials/ListView/ResultsMetadata.html
+++ b/Resources/Private/Partials/ListView/ResultsMetadata.html
@@ -1,25 +1,23 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:for each="{listedMetadata}" as="metadata">
-        <f:if condition="{resultMetadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
-            <dt class="tx-dlf-metadata-{metadata.indexName}">{metadata.label}</dt>
-            <f:for each="{resultMetadata.{metadata.indexName}}" as="metadataEntry">
-                <dd class="tx-dlf-metadata-{metadata.indexName}">{metadataEntry}</dd>
-            </f:for>
-        </f:if>
-    </f:for>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<f:for each="{listedMetadata}" as="metadata">
+    <f:if condition="{resultMetadata.{metadata.indexName}.0} && {metadata.indexName} != 'type' && {metadata.indexName} != 'title'">
+        <dt class="tx-dlf-metadata-{metadata.indexName}">{metadata.label}</dt>
+        <f:for each="{resultMetadata.{metadata.indexName}}" as="metadataEntry">
+            <dd class="tx-dlf-metadata-{metadata.indexName}">{metadataEntry}</dd>
+        </f:for>
+    </f:if>
+</f:for>
 
 </html>

--- a/Resources/Private/Partials/ListView/ResultsStructurePathMetadata.html
+++ b/Resources/Private/Partials/ListView/ResultsStructurePathMetadata.html
@@ -1,19 +1,17 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <dt class="tx-dlf-structure_path"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.structure_path' /></dt>
-    <dd class="tx-dlf-structure_path">{structure_path}</dd>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<dt class="tx-dlf-structure_path"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.structure_path' /></dt>
+<dd class="tx-dlf-structure_path">{structure_path}</dd>
 
 </html>

--- a/Resources/Private/Partials/ListView/ResultsThumbnailMetadata.html
+++ b/Resources/Private/Partials/ListView/ResultsThumbnailMetadata.html
@@ -1,27 +1,25 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:comment>
-        slub_digitalcollections uses the :empty CSS selector to check for missing thumbnail.
-        The HTML comments make sure there is no whitespace in that case.
-    </f:comment>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
 
-    <div class="tx-dlf-listview-thumbnail"><!--
-        --><f:if condition="{thumbnail}">
-        <img src="{thumbnail}" loading="lazy" alt="{f:translate(key:'thumbnail.alt', arguments:{0: '{title}'})}" />
-        </f:if><!--
-    --></div>
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<f:comment>
+    slub_digitalcollections uses the :empty CSS selector to check for missing thumbnail.
+    The HTML comments make sure there is no whitespace in that case.
+</f:comment>
+
+<div class="tx-dlf-listview-thumbnail"><!--
+    --><f:if condition="{thumbnail}">
+    <img src="{thumbnail}" loading="lazy" alt="{f:translate(key:'thumbnail.alt', arguments:{0: '{title}'})}" />
+    </f:if><!--
+--></div>
 
 </html>

--- a/Resources/Private/Partials/ListView/ResultsTitleMetadata.html
+++ b/Resources/Private/Partials/ListView/ResultsTitleMetadata.html
@@ -1,19 +1,17 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
-    <dd class="tx-dlf-title">{title}</dd>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<dt class="tx-dlf-title"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.title' /></dt>
+<dd class="tx-dlf-title">{title}</dd>
 
 </html>

--- a/Resources/Private/Partials/ListView/ResultsTypeMetadata.html
+++ b/Resources/Private/Partials/ListView/ResultsTypeMetadata.html
@@ -1,19 +1,17 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
-    <dd class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{type}' /></dd>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<dt class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.type' /></dt>
+<dd class="tx-dlf-type"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_structure.xlf:structure.{type}' /></dd>
 
 </html>

--- a/Resources/Private/Partials/ListView/SearchHits.html
+++ b/Resources/Private/Partials/ListView/SearchHits.html
@@ -1,18 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <p class="tx-dlf-search-numHits">
-        <f:translate key="listview.hits" arguments="{0: '{numResults}', 1: '{documents->f:count()}'}" />
-    </p>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<p class="tx-dlf-search-numHits"><f:translate key="listview.hits" arguments="{0: '{numResults}', 1: '{documents->f:count()}'}" /></p>
 </html>

--- a/Resources/Private/Partials/ListView/SortingForm.html
+++ b/Resources/Private/Partials/ListView/SortingForm.html
@@ -1,69 +1,58 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <f:if condition="{sortableMetadata}">
-        <f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />
-        <f:variable name="pageOffset" value="{settings.list.paginate.itemsPerPage * currentPage}" />
-        <f:variable name="allDocuments" value="{documents->f:count()}" />
-        <f:variable name="numDocuments" value="{pageOffset + settings.list.paginate.itemsPerPage}" />
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
 
-        <f:if condition="{allDocuments} > 0">
-            <p class="tx-dlf-sortinfo">
-                <f:translate
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<f:if condition="{sortableMetadata}">
+    <f:variable name="currentPage" value="{pagination.currentPageNumber - 1}" />
+    <f:variable name="pageOffset" value="{settings.list.paginate.itemsPerPage * currentPage}" />
+    <f:variable name="allDocuments" value="{documents->f:count()}" />
+    <f:variable name="numDocuments" value="{pageOffset + settings.list.paginate.itemsPerPage}" />
+
+    <f:if condition="{allDocuments} > 0">
+        <p class="tx-dlf-sortinfo">
+            <f:translate
                     key="listview.count"
                     arguments="{0:'{pageOffset + 1}', 1:'{f:if(condition: \'{numDocuments} > {allDocuments}\', then: \'{allDocuments}\', else: \'{numDocuments}\')}', 2:'{allDocuments}'}" />
-            </p>
-        </f:if>
-
-        <f:form section="showResults" action="search" controller="Search" name="search" method="post" class="tx-dlf-search-form">
-            <div>
-                <label for="form-orderBy-{viewData.uniqueId}">
-                    <f:translate key="listview.form.orderBy"/>
-                </label>
-                <f:form.select id="form-orderBy-{viewData.uniqueId}" property="orderBy" value="{lastSearch.orderBy}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
-                    <f:form.select.option value="score">
-                        <f:translate key="listview.form.relevance" />
-                    </f:form.select.option>
-                    <f:for each="{sortableMetadata}" as="meta">
-                        <f:form.select.option value="{meta.indexName}_sorting">
-                            <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.{meta.indexName}' />
-                        </f:form.select.option>
-                    </f:for>
-                </f:form.select>
-                <label for="form-order-{viewData.uniqueId}">
-                    <f:translate key="listview.form.order"/>
-                </label>
-                <f:form.select id="form-order-{viewData.uniqueId}" property="order" value="{lastSearch.order}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
-                    <f:form.select.option value="asc">
-                    <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:listview.form.order.asc' />
-                    </f:form.select.option>
-                    <f:form.select.option value="desc">
-                    <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:listview.form.order.desc' />
-                    </f:form.select.option>
-
-                </f:form.select>
-                <f:form.hidden property="collection" value="{lastSearch.collection}" />
-                <f:form.hidden property="query" value="{lastSearch.query}" />
-                <f:form.hidden property="fulltext" value="{lastSearch.fulltext}" />
-                <f:if condition="{lastSearch.dateFrom} || {lastSearch.dateTo}">
-                    <f:form.hidden property="dateFrom" value="{lastSearch.dateFrom}" />
-                    <f:form.hidden property="dateTo" value="{lastSearch.dateTo}" />
-                </f:if>
-                <f:for each="{lastSearch.fq}" as="filter" iteration="iter">
-                    <f:form.hidden name="search[fq][{iter.index}]" value="{filter}"/>
-                </f:for>
-            </div>
-        </f:form>
+        </p>
     </f:if>
+
+    <f:form section="showResults" action="search" controller="Search" name="search" method="post" class="tx-dlf-search-form">
+        <div>
+            <label for="form-orderBy-{viewData.uniqueId}"><f:translate key="listview.form.orderBy"/></label>
+            <f:form.select id="form-orderBy-{viewData.uniqueId}" property="orderBy" value="{lastSearch.orderBy}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
+                <f:form.select.option value="score"><f:translate key="listview.form.relevance" /></f:form.select.option>
+                <f:for each="{sortableMetadata}" as="meta">
+                    <f:form.select.option value="{meta.indexName}_sorting">
+                        <f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang_metadata.xlf:metadata.{meta.indexName}' />
+                    </f:form.select.option>
+                </f:for>
+            </f:form.select>
+            <label for="form-order-{viewData.uniqueId}"><f:translate key="listview.form.order"/></label>
+            <f:form.select id="form-order-{viewData.uniqueId}" property="order" value="{lastSearch.order}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
+                <f:form.select.option value="asc"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:listview.form.order.asc' /></f:form.select.option>
+                <f:form.select.option value="desc"><f:translate key='LLL:EXT:dlf/Resources/Private/Language/locallang.xlf:listview.form.order.desc' />
+                </f:form.select.option>
+            </f:form.select>
+            <f:form.hidden property="collection" value="{lastSearch.collection}" />
+            <f:form.hidden property="query" value="{lastSearch.query}" />
+            <f:form.hidden property="fulltext" value="{lastSearch.fulltext}" />
+            <f:if condition="{lastSearch.dateFrom} || {lastSearch.dateTo}">
+                <f:form.hidden property="dateFrom" value="{lastSearch.dateFrom}" />
+                <f:form.hidden property="dateTo" value="{lastSearch.dateTo}" />
+            </f:if>
+            <f:for each="{lastSearch.fq}" as="filter" iteration="iter">
+                <f:form.hidden name="search[fq][{iter.index}]" value="{filter}"/>
+            </f:for>
+        </div>
+    </f:form>
+</f:if>
 </html>

--- a/Resources/Private/Partials/Lists/Pagination.html
+++ b/Resources/Private/Partials/Lists/Pagination.html
@@ -1,17 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
-
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <ul class="tx-dlf-pagination">
     <f:if condition="{pagination.previousPageNumberG} && {pagination.previousPageNumberG} >= {pagination.firstPageNumber}">

--- a/Resources/Private/Partials/Metadata/Entries.html
+++ b/Resources/Private/Partials/Metadata/Entries.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 {configObject.wrap -> kitodo:metadataWrapVariable(name: 'metadataWrap')}
 <f:variable name="metaSectionConfigObject" value="{metaConfigObjectData.{sectionIterator.index}}" />
@@ -71,3 +70,5 @@
         {wrappedValues -> f:format.raw()}
     </kitodo:stdWrap>
 </f:if>
+
+</html>

--- a/Resources/Private/Partials/Metadata/ExternalLinkEntry.html
+++ b/Resources/Private/Partials/Metadata/ExternalLinkEntry.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{configObject.indexName} == 'author' || {configObject.indexName} == 'holder'">
     <f:then>
@@ -21,3 +20,5 @@
         <kitodo:stdWrap wrap="{metadataWrap.value}" data="{metaSectionConfigObject}"><f:link.external uri="{value}">{value}</f:link.external></kitodo:stdWrap>
     </f:else>
 </f:if>
+
+</html>

--- a/Resources/Private/Partials/Metadata/IiifEntries.html
+++ b/Resources/Private/Partials/Metadata/IiifEntries.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:for each="{iiifData}" as="data" key="key">
     <f:if condition="{data.data} && {adm:isArray(value: '{data.data}')}">
@@ -31,3 +30,5 @@
         </f:else>
     </f:if>
 </f:for>
+
+</html>

--- a/Resources/Private/Partials/Metadata/IiifEntry.html
+++ b/Resources/Private/Partials/Metadata/IiifEntry.html
@@ -1,27 +1,25 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{buildUrl}">
     <f:then>
         <dt>{entryData.label}</dt>
-        <dd>
-            <f:link.external uri="{entryData.value}">{entryData.value}</f:link.external>
-        </dd>
+        <dd><f:link.external uri="{entryData.value}">{entryData.value}</f:link.external></dd>
     </f:then>
     <f:else>
         <dt>{entryData.label}</dt>
         <dd>{entryData.value}</dd>
     </f:else>
 </f:if>
+
+</html>

--- a/Resources/Private/Partials/Metadata/LinkEntry.html
+++ b/Resources/Private/Partials/Metadata/LinkEntry.html
@@ -1,19 +1,19 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:variable name="urlParameterId" value="{buildUrlVariable.{configObject.indexName}.buildUrl.id}" />
 <f:link.page pageUid="{buildUrlVariable.{configObject.indexName}.buildUrl.targetPid}" additionalParams="{tx_dlf: '{id: \'{urlParameterId}\'}'}">
     {value}
 </f:link.page>
+
+</html>

--- a/Resources/Private/Partials/Navigation/DocumentBack.html
+++ b/Resources/Private/Partials/Navigation/DocumentBack.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-navigation-documentBack">
     <f:if condition="{documentBack}">

--- a/Resources/Private/Partials/Navigation/DocumentForward.html
+++ b/Resources/Private/Partials/Navigation/DocumentForward.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-navigation-documentForward">
     <f:if condition="{documentForward}">

--- a/Resources/Private/Partials/Navigation/DoublePage.html
+++ b/Resources/Private/Partials/Navigation/DoublePage.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{numPages} > 0">
     <f:then>

--- a/Resources/Private/Partials/Navigation/ListView.html
+++ b/Resources/Private/Partials/Navigation/ListView.html
@@ -1,16 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
+
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-navigation-listview">
     <f:link.page pageUid="{settings.targetPid}" additionalParams="{lastSearch}"><f:translate key="linkToList"/></f:link.page>

--- a/Resources/Private/Partials/Navigation/MeasureBack.html
+++ b/Resources/Private/Partials/Navigation/MeasureBack.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{numMeasures} > 0 && {double} != 1">
     <div class="measureBacks">

--- a/Resources/Private/Partials/Navigation/MeasureForward.html
+++ b/Resources/Private/Partials/Navigation/MeasureForward.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{numMeasures} > 0 && {double} != 1">
     <div class="measureFwds">

--- a/Resources/Private/Partials/Navigation/Page.html
+++ b/Resources/Private/Partials/Navigation/Page.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="{class}">
     <f:if condition="{condition}">

--- a/Resources/Private/Partials/Navigation/PageBack.html
+++ b/Resources/Private/Partials/Navigation/PageBack.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:variable name="navigationPage" value="{viewData.requestData.page - 1 - viewData.requestData.double}" />
 

--- a/Resources/Private/Partials/Navigation/PageFirst.html
+++ b/Resources/Private/Partials/Navigation/PageFirst.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-first', condition: pageFirstActive, navigationPage: '1', value: 'navigation.page.firstPage', viewData: viewData}" />
 

--- a/Resources/Private/Partials/Navigation/PageForward.html
+++ b/Resources/Private/Partials/Navigation/PageForward.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:variable name="navigationPage" value="{viewData.requestData.page + 1 + viewData.requestData.double}" />
 

--- a/Resources/Private/Partials/Navigation/PageLast.html
+++ b/Resources/Private/Partials/Navigation/PageLast.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:variable name="navigationPage" value="{numPages - viewData.requestData.double}" />
 

--- a/Resources/Private/Partials/Navigation/PageSelect.html
+++ b/Resources/Private/Partials/Navigation/PageSelect.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-navigation-pages">
     <f:form method="post" action="pageSelect" controller="Navigation" name="pageSelectForm" object="{pageSelectForm}" addQueryString="untrusted">

--- a/Resources/Private/Partials/Navigation/PageStep.html
+++ b/Resources/Private/Partials/Navigation/PageStep.html
@@ -1,17 +1,16 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="{class}">
     <f:if condition="{condition}">

--- a/Resources/Private/Partials/Navigation/PageStepBack.html
+++ b/Resources/Private/Partials/Navigation/PageStepBack.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:variable name="navigationPage" value="{viewData.requestData.page - pageSteps}" />
 <f:if condition="{navigationPage} < 1">

--- a/Resources/Private/Partials/Navigation/PageStepForward.html
+++ b/Resources/Private/Partials/Navigation/PageStepForward.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:variable name="navigationPage" value="{viewData.requestData.page + pageSteps}" />
 

--- a/Resources/Private/Partials/PageView/FulltextContainer.html
+++ b/Resources/Private/Partials/PageView/FulltextContainer.html
@@ -1,17 +1,14 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
 <f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
 <div class="tx-dlf-toolbox-fulltext-container">

--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:form action="search" controller="Search" name="search" method="get" class="tx-dlf-search-form">
     <label for="tx-dlf-search-query">

--- a/Resources/Private/Partials/TableOfContents/Children.html
+++ b/Resources/Private/Partials/TableOfContents/Children.html
@@ -1,17 +1,16 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:for each="{children}" as="child">
     <f:switch expression="{child.ITEM_STATE}">
@@ -75,3 +74,5 @@
 
     </li>
 </f:for>
+
+</html>

--- a/Resources/Private/Partials/TableOfContents/Title.html
+++ b/Resources/Private/Partials/TableOfContents/Title.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <span class="tx-dlf-tableofcontents-title">
     <f:if condition="{child.title}">
@@ -24,3 +23,5 @@
 </span>
 
 <span class="tx-dlf-tableofcontents-pagination"><f:format.htmlspecialchars doubleEncode="false">{child.pagination}</f:format.htmlspecialchars></span>
+
+</html>

--- a/Resources/Private/Partials/Toolbox/AnnotationTool.html
+++ b/Resources/Private/Partials/Toolbox/AnnotationTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-annotation">
     <span class="tx-dlf-tools-annotation">

--- a/Resources/Private/Partials/Toolbox/AudioVideoTool.html
+++ b/Resources/Private/Partials/Toolbox/AudioVideoTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{settings.isVideo} == 1">
     <li class="tx-dlf-tools-audiovideo tx-dlf-tools-videomediaplayer" id="tx-dlf-tools-videomediaplayer" data-tools-audiovideo="videomediaplayer">

--- a/Resources/Private/Partials/Toolbox/FulltextDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/FulltextDownloadTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-fulltextdownload">
     <span class="tx-dlf-tools-fulltextdownload">

--- a/Resources/Private/Partials/Toolbox/FulltextTool.html
+++ b/Resources/Private/Partials/Toolbox/FulltextTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-fulltext">
     <span class="tx-dlf-tools-fulltext">

--- a/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-imagedownload">
     <span class="tx-dlf-tools-imagedownload">

--- a/Resources/Private/Partials/Toolbox/ImageManipulationTool.html
+++ b/Resources/Private/Partials/Toolbox/ImageManipulationTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-imagemanipulation">
     <span id="tx-dlf-tools-imagemanipulation" data-dic="imagemanipulation-on:{f:translate(key: 'tools.imagemanipulation.on')};imagemanipulation-off:{f:translate(key: 'tools.imagemanipulation.off')};reset:{f:translate(key: 'tools.imagemanipulation.reset')};saturation:{f:translate(key: 'tools.imagemanipulation.saturation')};hue:{f:translate(key: 'tools.imagemanipulation.hue')};contrast:{f:translate(key: 'tools.imagemanipulation.contrast')};brightness:{f:translate(key: 'tools.imagemanipulation.brightness')};invert:{f:translate(key: 'tools.imagemanipulation.invert')};parentContainer:{parentContainer}" title="{f:translate(key: 'tools.imagemanipulation.no-support')}">

--- a/Resources/Private/Partials/Toolbox/ModelDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/ModelDownloadTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-modeldownload">
     <span class="tx-dlf-tools-modeldownload">

--- a/Resources/Private/Partials/Toolbox/MultiViewAddSourceTool.html
+++ b/Resources/Private/Partials/Toolbox/MultiViewAddSourceTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <a href="#" title="{f:translate(key:'tools.multiviewaddsource.label', extensionName:'dlf')}">{f:translate(key:'tools.multiviewaddsource.label', extensionName:'dlf')}</a>
 <form class="tx-dlf-tools-multiviewaddsource" >

--- a/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-pdfdownload">
     <span class="tx-dlf-tools-pdf-page">

--- a/Resources/Private/Partials/Toolbox/RotationTool.html
+++ b/Resources/Private/Partials/Toolbox/RotationTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-rotate-left">
     <a href="#" title="{f:translate(key: 'rotateLeft')}" onclick="tx_dlf_viewer.map.rotateLeft();"><f:translate key="rotateLeft"/></a>

--- a/Resources/Private/Partials/Toolbox/ScoreTool.html
+++ b/Resources/Private/Partials/Toolbox/ScoreTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-score">
     <a class="select switchoff" id="tx-dlf-tools-score-0" title="">

--- a/Resources/Private/Partials/Toolbox/SearchInDocumentTool.html
+++ b/Resources/Private/Partials/Toolbox/SearchInDocumentTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-searchindocument">
     <f:if condition="{settings.searchUrl}">

--- a/Resources/Private/Partials/Toolbox/ViewerSelectionTool.html
+++ b/Resources/Private/Partials/Toolbox/ViewerSelectionTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-viewerselection">
     <form method="get" action="{f:uri.page(pageUid='{viewData.pageUid}')}">

--- a/Resources/Private/Partials/Toolbox/ZoomTool.html
+++ b/Resources/Private/Partials/Toolbox/ZoomTool.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <li class="tx-dlf-tools-zoom-in">
     <a href="#" title="{f:translate(key: 'zoomIn')}" onclick="tx_dlf_viewer.map.zoomIn();"><f:translate key="zoomIn"/></a>

--- a/Resources/Private/Templates/Annotation/Main.html
+++ b/Resources/Private/Templates/Annotation/Main.html
@@ -1,17 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
-
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <ul class="tx-dlf-annotation-list">
     <f:for each="{annotations}" as="annotation">

--- a/Resources/Private/Templates/Backend/NewTenant/Error.html
+++ b/Resources/Private/Templates/Backend/NewTenant/Error.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="module-body t3js-module-body">
     <h1><f:translate key="newTenant.module" /></h1>

--- a/Resources/Private/Templates/Backend/NewTenant/Index.html
+++ b/Resources/Private/Templates/Backend/NewTenant/Index.html
@@ -1,16 +1,15 @@
-<f:comment>
-    <!--
-     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
-     *
-     * This file is part of the Kitodo and TYPO3 projects.
-     *
-     * @license GNU General Public License version 3 or later.
-     * For the full copyright and license information, please read the
-     * LICENSE.txt file that was distributed with this source code.
-    -->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:be.pageRenderer includeJavaScriptModules="{
     0:'@typo3/backend/modal.js'

--- a/Resources/Private/Templates/Basket/Main.html
+++ b/Resources/Private/Templates/Basket/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <p class="tx-dlf-basket-counts">
     <f:if condition="{countDocs} > 0">

--- a/Resources/Private/Templates/Calendar/Calendar.html
+++ b/Resources/Private/Templates/Calendar/Calendar.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-calendar">
     <div class="tx-dlf-calendar-meta-header">

--- a/Resources/Private/Templates/Calendar/Main.html
+++ b/Resources/Private/Templates/Calendar/Main.html
@@ -1,15 +1,14 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 </html>

--- a/Resources/Private/Templates/Calendar/Years.html
+++ b/Resources/Private/Templates/Calendar/Years.html
@@ -1,47 +1,41 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <div class="tx-dlf-calendar-years">
-        <div class="tx-dlf-calendar-meta-header">
-            <div class="tx-dlf-calendar-year-anchor">
-                <f:link.page additionalParams="{'tx_dlf[id]': documentId}">
-                    <f:translate key="calendar.allYears" /> {allYearDocTitle}
-                </f:link.page>
-            </div>
-            <div class="tx-dlf-calendar-meta-hint-year">
-                <f:translate key="calendar.please_choose_year" />
-            </div>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<div class="tx-dlf-calendar-years">
+    <div class="tx-dlf-calendar-meta-header">
+        <div class="tx-dlf-calendar-year-anchor">
+            <f:link.page additionalParams="{'tx_dlf[id]': documentId}"><f:translate key="calendar.allYears" /> {allYearDocTitle}</f:link.page>
         </div>
-        <div class="tx-dlf-calendar-year-view">
-            <ul>
-                <f:for each="{yearName}" as="yearEntry">
-                    <f:if condition="{yearEntry.documentId}">
-                        <f:then>
-                            <li class="tx-dlf-calendar-year">
-                                <f:link.page additionalParams="{'tx_dlf[id]': yearEntry.documentId}">
-                                    {yearEntry.title}
-                                </f:link.page>
-                            </li>
-                        </f:then>
-                        <f:else>
-                            <li class="tx-dlf-calendar-year-empty">
-                                <p>{yearEntry.title}</p>
-                            </li>
-                        </f:else>
-                    </f:if>
-                </f:for>
-            </ul>
-        </div>
+        <div class="tx-dlf-calendar-meta-hint-year"><f:translate key="calendar.please_choose_year" /></div>
     </div>
+    <div class="tx-dlf-calendar-year-view">
+        <ul>
+            <f:for each="{yearName}" as="yearEntry">
+                <f:if condition="{yearEntry.documentId}">
+                    <f:then>
+                        <li class="tx-dlf-calendar-year">
+                            <f:link.page additionalParams="{'tx_dlf[id]': yearEntry.documentId}">yearEntry.title} </f:link.page>
+                        </li>
+                    </f:then>
+                    <f:else>
+                        <li class="tx-dlf-calendar-year-empty">
+                            <p>{yearEntry.title}</p>
+                        </li>
+                    </f:else>
+                </f:if>
+            </f:for>
+        </ul>
+    </div>
+</div>
+
 </html>

--- a/Resources/Private/Templates/Collection/List.html
+++ b/Resources/Private/Templates/Collection/List.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-collection">
     <ul class="tx-dlf-collection-list">

--- a/Resources/Private/Templates/Collection/Show.html
+++ b/Resources/Private/Templates/Collection/Show.html
@@ -1,40 +1,37 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-      <div class="tx-dlf-listview">
-        <h2 class="tx-dlf-listview-label">{collection.label}</h2>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
 
-        <f:if condition="{collection.thumbnail}">
-            <div class="tx-dlf-collection-thumbnail">
-                <f:if condition="{collection.thumbnail}">
-                    <f:image image="{collection.thumbnail}" alt="{f:translate(key: 'thumbnail')} {collection.label}" title="{collection.label}" maxWidth="250" />
-                 </f:if>
-            </div>
-        </f:if>
+    This file is part of the Kitodo and TYPO3 projects.
 
-        <f:if condition="{collection.description}">
-            <div class="tx-dlf-collection-description">
-                <f:format.html>{collection.description}</f:format.html>
-            </div>
-        </f:if>
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
-        <f:variable name="action" value="showSorted" />
-        <f:variable name="controller" value="Collection" />
-        <f:render partial="ListView/SortingForm" arguments="{_all}" />
+<div class="tx-dlf-listview">
+    <h2 class="tx-dlf-listview-label">{collection.label}</h2>
 
-        <f:render partial="ListView/Results" arguments="{_all}" />
+    <f:if condition="{collection.thumbnail}">
+        <div class="tx-dlf-collection-thumbnail">
+            <f:if condition="{collection.thumbnail}">
+                <f:image image="{collection.thumbnail}" alt="{f:translate(key: 'thumbnail')} {collection.label}" title="{collection.label}" maxWidth="250" />
+            </f:if>
+        </div>
+    </f:if>
 
-    </div>
+    <f:if condition="{collection.description}">
+        <div class="tx-dlf-collection-description">
+            <f:format.html>{collection.description}</f:format.html>
+        </div>
+    </f:if>
+
+    <f:variable name="action" value="showSorted" />
+    <f:variable name="controller" value="Collection" />
+    <f:render partial="ListView/SortingForm" arguments="{_all}" />
+    <f:render partial="ListView/Results" arguments="{_all}" />
+</div>
 
 </html>

--- a/Resources/Private/Templates/Embedded3dViewer/Main.html
+++ b/Resources/Private/Templates/Embedded3dViewer/Main.html
@@ -1,19 +1,18 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <div class="tx-dlf-embedded3dviewer">
-        <iframe src="{embedded3dViewerUrl}" ></iframe>
-    </div>
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<div class="tx-dlf-embedded3dviewer">
+    <iframe src="{embedded3dViewerUrl}" ></iframe>
+</div>
 
 </html>

--- a/Resources/Private/Templates/ListView/Main.html
+++ b/Resources/Private/Templates/ListView/Main.html
@@ -1,37 +1,34 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-    <div class="tx-dlf-listview">
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
 
-        <h2 class="tx-dlf-listview-label">
-            <f:translate key="search.search"  />
-            <f:translate key="search.for" arguments="{0: '{lastSearch.query}'}" />
-            <f:comment>
-                We need a ViewHelper to get the Extbase document object here. Usable e.g. on search in a newspaper title.
-                <f:translate key="search.in" arguments="{0: '{lastSearch.documentId}'}" />
-            </f:comment>
-        </h2>
-        <f:render partial="ListView/SearchHits" arguments="{_all}" />
+    This file is part of the Kitodo and TYPO3 projects.
 
-        <f:variable name="action" value="main" />
-        <f:variable name="controller" value="ListView" />
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
-        <f:if condition="{numResults} > 0">
-            <f:render partial="ListView/SortingForm" arguments="{_all}" />
-            <f:render partial="ListView/Results" arguments="{_all}" />
-        </f:if>
+<div class="tx-dlf-listview">
+    <h2 class="tx-dlf-listview-label">
+        <f:translate key="search.search"  />
+        <f:translate key="search.for" arguments="{0: '{lastSearch.query}'}" />
+        <f:comment>
+            We need a ViewHelper to get the Extbase document object here. Usable e.g. on search in a newspaper title.
+            <f:translate key="search.in" arguments="{0: '{lastSearch.documentId}'}" />
+        </f:comment>
+    </h2>
+    <f:render partial="ListView/SearchHits" arguments="{_all}" />
 
-    </div>
+    <f:variable name="action" value="main" />
+    <f:variable name="controller" value="ListView" />
+
+    <f:if condition="{numResults} > 0">
+        <f:render partial="ListView/SortingForm" arguments="{_all}" />
+        <f:render partial="ListView/Results" arguments="{_all}" />
+    </f:if>
+</div>
 
 </html>

--- a/Resources/Private/Templates/Metadata/Main.html
+++ b/Resources/Private/Templates/Metadata/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:comment>
     <dl>

--- a/Resources/Private/Templates/MultiView/Main.html
+++ b/Resources/Private/Templates/MultiView/Main.html
@@ -1,17 +1,16 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="page-control">
     <div class="backs">

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:comment>Render all navigation features in the given order.</f:comment>
 <f:for each="{features}" key="feature" as="enabled">

--- a/Resources/Private/Templates/PageGrid/Main.html
+++ b/Resources/Private/Templates/PageGrid/Main.html
@@ -1,43 +1,43 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
-    <div class="tx-dlf-pagegrid">
-        <ol class="tx-dlf-pagegrid-list">
-            <f:for each="{paginator.paginatedItems}" as="entry" iteration="iterator">
-                <li class="tx-dlf-pagegrid-{entry.state}" value="{entry.page}">
-                    <div class="tx-dlf-pagegrid-thumbnail">
-                        <f:link.page pageUid="{settings.targetPid}" additionalParams="{'tx_dlf[id]': docUid, 'tx_dlf[page]': entry.page}">
-                            <f:if condition="{entry.thumbnail}">
-                                <f:then>
-                                    <img src="{entry.thumbnail}" alt="{f:translate(key: 'thumbnail')} {f:translate(key: 'page')} {entry.pagination}" title="{f:translate(key: 'page')} {entry.pagination}" />
-                                </f:then>
-                                <f:else>
-                                    <f:if condition="{settings.placeholder}">
-                                        <f:then>
-                                            <f:image src="{settings.placeholder}" alt="{f:translate(key: 'thumbnail')} {f:translate(key: 'page')} {entry.pagination}" title="{f:translate(key: 'page')} {entry.pagination}" maxWidth="250" />
-                                        </f:then>
-                                        <f:else>
-                                            <f:image src="EXT:dlf/Resources/Public/Images/PageGridPlaceholder.jpg" alt="{f:translate(key: 'thumbnail')} {f:translate(key: 'page')} {entry.pagination}" title="{f:translate(key: 'page')} {entry.pagination}" maxWidth="250" />
-                                        </f:else>
-                                    </f:if>
-                                </f:else>
-                            </f:if>
-                            <div class="tx-dlf-pagegrid-pagination">{entry.pagination}</div>
-                        </f:link.page>
-                    </div>
-                </li>
-            </f:for>
-        </ol>
-        <f:render partial="Lists/Pagination" arguments="{_all}" />
-    </div>
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<div class="tx-dlf-pagegrid">
+    <ol class="tx-dlf-pagegrid-list">
+        <f:for each="{paginator.paginatedItems}" as="entry" iteration="iterator">
+            <li class="tx-dlf-pagegrid-{entry.state}" value="{entry.page}">
+                <div class="tx-dlf-pagegrid-thumbnail">
+                    <f:link.page pageUid="{settings.targetPid}" additionalParams="{'tx_dlf[id]': docUid, 'tx_dlf[page]': entry.page}">
+                        <f:if condition="{entry.thumbnail}">
+                            <f:then>
+                                <img src="{entry.thumbnail}" alt="{f:translate(key: 'thumbnail')} {f:translate(key: 'page')} {entry.pagination}" title="{f:translate(key: 'page')} {entry.pagination}" />
+                            </f:then>
+                            <f:else>
+                                <f:if condition="{settings.placeholder}">
+                                    <f:then>
+                                        <f:image src="{settings.placeholder}" alt="{f:translate(key: 'thumbnail')} {f:translate(key: 'page')} {entry.pagination}" title="{f:translate(key: 'page')} {entry.pagination}" maxWidth="250" />
+                                    </f:then>
+                                    <f:else>
+                                        <f:image src="EXT:dlf/Resources/Public/Images/PageGridPlaceholder.jpg" alt="{f:translate(key: 'thumbnail')} {f:translate(key: 'page')} {entry.pagination}" title="{f:translate(key: 'page')} {entry.pagination}" maxWidth="250" />
+                                    </f:else>
+                                </f:if>
+                            </f:else>
+                        </f:if>
+                        <div class="tx-dlf-pagegrid-pagination">{entry.pagination}</div>
+                    </f:link.page>
+                </div>
+            </li>
+        </f:for>
+    </ol>
+    <f:render partial="Lists/Pagination" arguments="{_all}" />
+</div>
 </html>

--- a/Resources/Private/Templates/PageView/Main.html
+++ b/Resources/Private/Templates/PageView/Main.html
@@ -1,17 +1,16 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div id="tx-dlf-map" class="tx-dlf-map" data-dic="overview-map:{f:translate(key: 'pageview.overview-map')}">
     <div id="tx-dlf-annotationselection"></div>

--- a/Resources/Private/Templates/Search/Main.html
+++ b/Resources/Private/Templates/Search/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:render partial="Search/Form" arguments="{_all}" />
 

--- a/Resources/Private/Templates/Statistics/Main.html
+++ b/Resources/Private/Templates/Statistics/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-statistics">
     <f:comment>We need to use the lib.parseFunc here, as the default lib.parseFunc_RTE keeps empty lines.</f:comment>

--- a/Resources/Private/Templates/TableOfContents/Main.html
+++ b/Resources/Private/Templates/TableOfContents/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <div class="tx-dlf-tableofcontents">
     <ul class="tx-dlf-tableofcontents-list">

--- a/Resources/Private/Templates/Toolbox/Main.html
+++ b/Resources/Private/Templates/Toolbox/Main.html
@@ -1,16 +1,15 @@
-<f:comment>
-<!--
- * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
- *
- * This file is part of the Kitodo and TYPO3 projects.
- *
- * @license GNU General Public License version 3 or later.
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
--->
-</f:comment>
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
 
 <f:if condition="{settings.showAsList}">
     <ul>


### PR DESCRIPTION
Minor changes included like proper intendation, removing not used kitodo namespace or addining missing `html` closing tag