### PR TITLE
[BUGFIX] Decode HTML entities in pagination labels

### DIFF
--- a/Resources/Private/Partials/Lists/Pagination.html
+++ b/Resources/Private/Partials/Lists/Pagination.html
@@ -18,7 +18,7 @@
                 <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': 1, 'tx_dlf[id]': docUid}" arguments="{page: 1, search: lastSearch}" title="1">1</f:link.action>
             </li>
             <li class="tx-dlf-pagination-previous">
-                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.previousPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.prevPage')}">{f:translate(key: 'listView.pagination.prevPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</f:link.action>
+                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.previousPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.prevPage')}">{f:translate(key: 'listView.pagination.prevPage')->f:format.htmlentitiesDecode(encoding: 'UTF-8')}</f:link.action>
             </li>
         </f:then>
         <f:else>
@@ -26,7 +26,7 @@
                 <span>1</span>
             </li>
             <li class="tx-dlf-pagination-previous disabled">
-                <span>{f:translate(key: 'listView.pagination.prevPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</span>
+                <span>{f:translate(key: 'listView.pagination.prevPage')->f:format.htmlentitiesDecode(encoding: 'UTF-8')}</span>
             </li>
         </f:else>
     </f:if>
@@ -65,7 +65,7 @@
     <f:if condition="{pagination.nextPageNumberG} && {pagination.nextPageNumberG} <= {pagination.lastPageNumber}">
         <f:then>
             <li class="tx-dlf-pagination-next">
-                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.nextPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.nextPage')}">{f:translate(key: 'listView.pagination.nextPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</f:link.action>
+                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.nextPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.nextPage')}">{f:translate(key: 'listView.pagination.nextPage')->f:format.htmlentitiesDecode(encoding: 'UTF-8')}</f:link.action>
             </li>
             <li class="tx-dlf-pagination-last">
                 <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.lastPageNumberG, 'tx_dlf[id]': docUid}" arguments="{page: pagination.lastPageNumberG, search: lastSearch}" title="{pagination.lastPageNumber}">{pagination.lastPageNumber}</f:link.action>
@@ -73,7 +73,7 @@
         </f:then>
         <f:else>
             <li class="tx-dlf-pagination-next disabled">
-                <span>{f:translate(key: 'listView.pagination.nextPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</span>
+                <span>{f:translate(key: 'listView.pagination.nextPage')->f:format.htmlentitiesDecode(encoding: 'UTF-8')}</span>
             </li>
             <li class="tx-dlf-pagination-last disabled">
                 <span>{pagination.lastPageNumber}</span>

--- a/Resources/Private/Partials/Lists/Pagination.html
+++ b/Resources/Private/Partials/Lists/Pagination.html
@@ -18,7 +18,7 @@
                 <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': 1, 'tx_dlf[id]': docUid}" arguments="{page: 1, search: lastSearch}" title="1">1</f:link.action>
             </li>
             <li class="tx-dlf-pagination-previous">
-                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.previousPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.prevPage')}">{f:translate(key: 'listView.pagination.prevPage')}</f:link.action>
+                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.previousPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.previousPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.prevPage')}">{f:translate(key: 'listView.pagination.prevPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</f:link.action>
             </li>
         </f:then>
         <f:else>
@@ -26,7 +26,7 @@
                 <span>1</span>
             </li>
             <li class="tx-dlf-pagination-previous disabled">
-                <span>{f:translate(key: 'listView.pagination.prevPage')}</span>
+                <span>{f:translate(key: 'listView.pagination.prevPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</span>
             </li>
         </f:else>
     </f:if>
@@ -65,7 +65,7 @@
     <f:if condition="{pagination.nextPageNumberG} && {pagination.nextPageNumberG} <= {pagination.lastPageNumber}">
         <f:then>
             <li class="tx-dlf-pagination-next">
-                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.nextPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.nextPage')}">{f:translate(key: 'listView.pagination.nextPage')}</f:link.action>
+                <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.nextPageNumber, 'tx_dlf[id]': docUid}" arguments="{page: pagination.nextPageNumber, search: lastSearch}" title="{f:translate(key: 'navigation.page.nextPage')}">{f:translate(key: 'listView.pagination.nextPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</f:link.action>
             </li>
             <li class="tx-dlf-pagination-last">
                 <f:link.action action="{action}" addQueryString="untrusted" argumentsToBeExcludedFromQueryString="{0: 'tx_dlf[page]'}" additionalParams="{'tx_dlf[page]': pagination.lastPageNumberG, 'tx_dlf[id]': docUid}" arguments="{page: pagination.lastPageNumberG, search: lastSearch}" title="{pagination.lastPageNumber}">{pagination.lastPageNumber}</f:link.action>
@@ -73,7 +73,7 @@
         </f:then>
         <f:else>
             <li class="tx-dlf-pagination-next disabled">
-                <span>{f:translate(key: 'listView.pagination.nextPage')}</span>
+                <span>{f:translate(key: 'listView.pagination.nextPage')->f:format.htmlentitiesDecode(encoding: 'ISO-8859-1')}</span>
             </li>
             <li class="tx-dlf-pagination-last disabled">
                 <span>{pagination.lastPageNumber}</span>


### PR DESCRIPTION
Ensure that localized labels for the previous and next page links in the pagination partial are correctly decoded. This prevents HTML entities within translation strings from being displayed as literal text.