### PR TITLE
[BUGFIX] Fix ViewHelper namespace in IiifEntries partial

### DIFF
--- a/Resources/Private/Partials/Metadata/IiifEntries.html
+++ b/Resources/Private/Partials/Metadata/IiifEntries.html
@@ -1,4 +1,5 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:kitodo="http://typo3.org/ns/Kitodo/Dlf/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
 <f:comment>
@@ -12,7 +13,7 @@
 </f:comment>
 
 <f:for each="{iiifData}" as="data" key="key">
-    <f:if condition="{data.data} && {adm:isArray(value: '{data.data}')}">
+    <f:if condition="{data.data} && {kitodo:isArray(value: '{data.data}')}">
         <f:then>
             <f:for each="{data.data}" as="subData" iteration="subIterator">
                 <f:if condition="{subIterator.isFirst}">


### PR DESCRIPTION
The `isArray` ViewHelper was using the incorrect `adm` namespace prefix. This replaces it with the correct `kitodo` namespace.