### PR TITLE
[MAINTENANCE] Refactor OAI-PMH queries to use QueryBuilder

### DIFF
--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -795,9 +795,9 @@ class OaiPmhController extends AbstractController
         $documents = $this->documentRepository->getOaiDocumentList($documentsToProcess);
 
         $records = [];
-        while ($resArray = $documents->fetchAssociative()) {
+        foreach ($documents as $document) {
             // we need the collections as array later
-            $resArray['collections'] = explode(' ', $resArray['collections']);
+            $document['collections'] = explode(' ', $document['collections']);
 
             if ($verb === 'ListRecords') {
                 // Add metadata node.
@@ -806,15 +806,15 @@ class OaiPmhController extends AbstractController
                     // If we resume an action the metadataPrefix is stored with the documentSet
                     $metadataPrefix = $documentListSet['metadata']['metadataPrefix'];
                 }
-                $resArray['metadata'] = match ($metadataPrefix) {
-                    'oai_dc' => $this->getDublinCoreData($resArray),
-                    'epicur' => $resArray,
-                    'mets' => $this->getMetsData($resArray),
+                $document['metadata'] = match ($metadataPrefix) {
+                    'oai_dc' => $this->getDublinCoreData($document),
+                    'epicur' => $document,
+                    'mets' => $this->getMetsData($document),
                     default => null,
                 };
             }
 
-            $records[] = $resArray;
+            $records[] = $document;
         }
 
         $this->generateResumptionTokenForDocumentListSet($documentListSet, count($documentsToProcess));

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -441,35 +441,28 @@ class DocumentRepository extends Repository
      */
     public function getOaiRecord(array $settings, array $parameters): array|false
     {
-        $where = '';
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_dlf_documents');
 
-        if (!$settings['show_userdefined']) {
-            $where .= 'AND tx_dlf_collections.fe_cruser_id=0 ';
+        $select = 'tx_dlf_documents.crdate AS crdate, tx_dlf_documents.tstamp AS tstamp, tx_dlf_documents.deleted AS deleted, tx_dlf_documents.hidden AS hidden, tx_dlf_documents.record_id AS record_id, tx_dlf_documents.document_format AS document_format, tx_dlf_documents.purl AS purl, tx_dlf_documents.urn AS urn, tx_dlf_documents.location AS location, GROUP_CONCAT(DISTINCT tx_dlf_collections_join.oai_name ORDER BY tx_dlf_collections_join.oai_name SEPARATOR " ") AS collections';
+
+        $qb = $queryBuilder
+            ->selectLiteral($select)
+            ->from('tx_dlf_documents')
+            ->innerJoin('tx_dlf_documents', 'tx_dlf_relations', 'tx_dlf_relations_join', 'tx_dlf_relations_join.uid_local = tx_dlf_documents.uid')
+            ->innerJoin('tx_dlf_relations_join', 'tx_dlf_collections', 'tx_dlf_collections_join', 'tx_dlf_collections_join.uid = tx_dlf_relations_join.uid_foreign')
+            ->where($queryBuilder->expr()->eq('tx_dlf_documents.record_id', $queryBuilder->createNamedParameter($parameters['identifier'])))
+            ->andWhere($queryBuilder->expr()->eq('tx_dlf_relations_join.ident', $queryBuilder->createNamedParameter('docs_colls')))
+            ->groupBy('tx_dlf_documents.uid');
+
+        if (empty($settings['show_userdefined'])) {
+            $qb->andWhere($queryBuilder->expr()->eq('tx_dlf_collections_join.fe_cruser_id', 0));
         }
 
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_dlf_documents');
+        $qb->getConcreteQueryBuilder()->setMaxResults(1);
 
-        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.`oai_name` ORDER BY `tx_dlf_collections`.`oai_name` SEPARATOR " ") AS `collections` ' .
-            'FROM `tx_dlf_documents` ' .
-            'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
-            'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE `tx_dlf_documents`.`record_id` = ? ' .
-            'AND `tx_dlf_relations`.`ident`="docs_colls" ' .
-            $where;
-
-        $values = [
-            $parameters['identifier']
-        ];
-
-        $types = [
-            Connection::PARAM_STR
-        ];
-
-        // Create a prepared statement for the passed SQL query, bind the given params with their binding types and execute the query
-        $statement = $connection->executeQuery($sql, $values, $types);
-
-        return $statement->fetchAssociative();
+        $result = $qb->executeQuery();
+        return $result->fetchAssociative();
     }
 
     /**
@@ -479,32 +472,27 @@ class DocumentRepository extends Repository
      *
      * @param mixed[] $documentsToProcess
      *
-     * @return Result The found document objects
+     * @return list<array<string,mixed>> The found document objects as associative arrays
      */
-    public function getOaiDocumentList(array $documentsToProcess): Result
+    public function getOaiDocumentList(array $documentsToProcess): array
     {
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_dlf_documents');
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_dlf_documents');
 
-        $sql = 'SELECT `tx_dlf_documents`.*, GROUP_CONCAT(DISTINCT `tx_dlf_collections`.`oai_name` ORDER BY `tx_dlf_collections`.`oai_name` SEPARATOR " ") AS `collections` ' .
-            'FROM `tx_dlf_documents` ' .
-            'INNER JOIN `tx_dlf_relations` ON `tx_dlf_relations`.`uid_local` = `tx_dlf_documents`.`uid` ' .
-            'INNER JOIN `tx_dlf_collections` ON `tx_dlf_collections`.`uid` = `tx_dlf_relations`.`uid_foreign` ' .
-            'WHERE `tx_dlf_documents`.`uid` IN ( ? ) ' .
-            'AND `tx_dlf_relations`.`ident`="docs_colls" ' .
-            'AND ' . Helper::whereExpression('tx_dlf_collections') . ' ' .
-            'GROUP BY `tx_dlf_documents`.`uid` ';
+        $select = 'tx_dlf_documents.crdate AS crdate, tx_dlf_documents.tstamp AS tstamp, tx_dlf_documents.deleted AS deleted, tx_dlf_documents.hidden AS hidden, tx_dlf_documents.record_id AS record_id, tx_dlf_documents.document_format AS document_format, tx_dlf_documents.purl AS purl, tx_dlf_documents.urn AS urn, tx_dlf_documents.location AS location, GROUP_CONCAT(DISTINCT tx_dlf_collections_join.oai_name ORDER BY tx_dlf_collections_join.oai_name SEPARATOR " ") AS collections';
 
-        $values = [
-            $documentsToProcess,
-        ];
+        $qb = $queryBuilder
+            ->selectLiteral($select)
+            ->from('tx_dlf_documents')
+            ->innerJoin('tx_dlf_documents', 'tx_dlf_relations', 'tx_dlf_relations_join', 'tx_dlf_relations_join.uid_local = tx_dlf_documents.uid')
+            ->innerJoin('tx_dlf_relations_join', 'tx_dlf_collections', 'tx_dlf_collections_join', 'tx_dlf_collections_join.uid = tx_dlf_relations_join.uid_foreign')
+            ->where($queryBuilder->expr()->in('tx_dlf_documents.uid', $queryBuilder->createNamedParameter($documentsToProcess, Connection::PARAM_INT_ARRAY)))
+            ->andWhere($queryBuilder->expr()->eq('tx_dlf_relations_join.ident', $queryBuilder->createNamedParameter('docs_colls')))
+            ->andWhere($queryBuilder->expr()->eq('tx_dlf_collections_join.deleted', 0))
+            ->groupBy('tx_dlf_documents.uid');
 
-        $types = [
-            Connection::PARAM_INT_ARRAY,
-        ];
-
-        // Create a prepared statement for the passed SQL query, bind the given params with their binding types and execute the query
-        return $connection->executeQuery($sql, $values, $types);
+        $result = $qb->executeQuery();
+        return $result->fetchAllAssociative();
     }
 
     /**

--- a/Tests/Functional/Repository/DocumentRepositoryTest.php
+++ b/Tests/Functional/Repository/DocumentRepositoryTest.php
@@ -94,11 +94,7 @@ class DocumentRepositoryTest extends FunctionalTestCase
      */
     public function canGetOaiDocumentList(): void
     {
-        $result = $this->documentRepository->getOaiDocumentList([1001, 1002]);
-
-        self::assertInstanceOf(Result::class, $result);
-
-        $documents = $result->fetchAllAssociative();
+        $documents = $this->documentRepository->getOaiDocumentList([1001, 1002]);
 
         self::assertIsArray($documents);
         self::assertCount(2, $documents);

--- a/Tests/Functional/Repository/DocumentRepositoryTest.php
+++ b/Tests/Functional/Repository/DocumentRepositoryTest.php
@@ -12,6 +12,7 @@
 
 namespace Kitodo\Dlf\Tests\Functional\Repository;
 
+use Doctrine\DBAL\Result;
 use Kitodo\Dlf\Common\AbstractDocument;
 use Kitodo\Dlf\Common\MetsDocument;
 use Kitodo\Dlf\Domain\Repository\DocumentRepository;
@@ -66,6 +67,50 @@ class DocumentRepositoryTest extends FunctionalTestCase
         $document = $this->documentRepository->findOldestDocument();
         self::assertNotNull($document);
         self::assertEquals(1002, $document->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function canGetOaiRecord(): void
+    {
+        $settings = ['show_userdefined' => false, 'storagePid' => 20000];
+        $parameters = ['identifier' => 'oai:de:slub-dresden:db:id-476251419'];
+
+        $record = $this->documentRepository->getOaiRecord($settings, $parameters);
+
+        self::assertIsArray($record);
+        self::assertEquals('oai:de:slub-dresden:db:id-476251419', $record['record_id']);
+        self::assertNotEmpty($record['location']);
+        self::assertArrayHasKey('collections', $record);
+
+        $collections = explode(' ', $record['collections']);
+        self::assertContains('music', $collections);
+        self::assertContains('collection-with-single-document', $collections);
+    }
+
+    /**
+     * @test
+     */
+    public function canGetOaiDocumentList(): void
+    {
+        $result = $this->documentRepository->getOaiDocumentList([1001, 1002]);
+
+        self::assertInstanceOf(Result::class, $result);
+
+        $documents = $result->fetchAllAssociative();
+
+        self::assertIsArray($documents);
+        self::assertCount(2, $documents);
+
+        $found = array_column($documents, null, 'record_id');
+        self::assertArrayHasKey('oai:de:slub-dresden:db:id-476251419', $found);
+        self::assertArrayHasKey('oai:de:slub-dresden:db:id-476248086', $found);
+
+        $first = $found['oai:de:slub-dresden:db:id-476251419'];
+        self::assertNotEmpty($first['location']);
+        $collections = explode(' ', $first['collections']);
+        self::assertContains('music', $collections);
     }
 
     /**

--- a/Tests/Functional/Repository/DocumentRepositoryTest.php
+++ b/Tests/Functional/Repository/DocumentRepositoryTest.php
@@ -94,12 +94,7 @@ class DocumentRepositoryTest extends FunctionalTestCase
      */
     public function canGetOaiDocumentList(): void
     {
-        $result = $this->documentRepository->getOaiDocumentList([1001, 1002]);
-
-        self::assertInstanceOf(Result::class, $result);
-
-        $documents = $result->fetchAllAssociative();
-
+        $documents = $this->documentRepository->getOaiDocumentList([1001, 1002]);
         self::assertIsArray($documents);
         self::assertCount(2, $documents);
 


### PR DESCRIPTION
Replace raw SQL queries in DocumentRepository with the TYPO3 QueryBuilder API. This update also changes getOaiDocumentList to return an array, requiring a transition from while-loops to foreach-loops in the OaiPmhController.

Depends on #1928 and should be merged as second.