### PR TITLE
[MAINTENANCE] Add functional tests for DocumentRepository

### DIFF
--- a/Tests/Functional/Repository/DocumentRepositoryTest.php
+++ b/Tests/Functional/Repository/DocumentRepositoryTest.php
@@ -14,7 +14,11 @@ namespace Kitodo\Dlf\Tests\Functional\Repository;
 
 use Kitodo\Dlf\Common\AbstractDocument;
 use Kitodo\Dlf\Common\MetsDocument;
+use Kitodo\Dlf\Domain\Model\Document;
 use Kitodo\Dlf\Domain\Repository\DocumentRepository;
+use Kitodo\Dlf\Domain\Model\Structure;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use Kitodo\Dlf\Tests\Functional\FunctionalTestCase;
 use TYPO3\CMS\Extbase\Persistence\Generic\LazyObjectStorage;
 
@@ -56,6 +60,103 @@ class DocumentRepositoryTest extends FunctionalTestCase
 
         $doc = AbstractDocument::getInstance($document->getLocation());
         self::assertInstanceOf(MetsDocument::class, $doc);
+    }
+
+    /**
+     * @test
+     */
+    public function canFindOneByParametersWithIdReturnsDocument(): void
+    {
+        $result = $this->documentRepository->findOneByParameters(['id' => '1001']);
+        self::assertInstanceOf(Document::class, $result);
+        self::assertEquals(1001, $result->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function canFindOneByParametersWithRecordIdReturnsDocument(): void
+    {
+        $result = $this->documentRepository->findOneByParameters(['recordId' => 'oai:de:slub-dresden:db:id-476251419']);
+        self::assertInstanceOf(Document::class, $result);
+        self::assertEquals('oai:de:slub-dresden:db:id-476251419', $result->getRecordId());
+    }
+
+    /**
+     * @test
+     */
+    public function canFindOneByParametersWithLocationReturnsDocumentWithLocation(): void
+    {
+        $location = 'https://digital.slub-dresden.de/data/kitodo/10Kepi_476251419/10Kepi_476251419_mets.xml';
+        $result = $this->documentRepository->findOneByParameters(['location' => $location]);
+        self::assertInstanceOf(Document::class, $result);
+        self::assertEquals($location, $result->getLocation());
+    }
+
+    /**
+     * @test
+     */
+    public function canGetChildrenOfYearAnchor(): void
+    {
+        // Create an empty Structure instance; repository should return a QueryResultInterface (possibly empty)
+        $structure = GeneralUtility::makeInstance(Structure::class);
+
+        $result = $this->documentRepository->getChildrenOfYearAnchor(null, $structure);
+
+        // The method may return either an array or a QueryResultInterface; accept both
+        self::assertTrue(is_array($result) || $result instanceof QueryResultInterface);
+    }
+
+    /**
+     * @test
+     */
+    public function canFindOneByIdAndSettings(): void
+    {
+        $document = $this->documentRepository->findOneByIdAndSettings(1001);
+        self::assertInstanceOf(Document::class, $document);
+        self::assertEquals(1001, $document->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function canFindDocumentsBySettings(): void
+    {
+        $settings = ['documentSets' => '1001,1002'];
+        $result = $this->documentRepository->findDocumentsBySettings($settings);
+
+        if (is_array($result)) {
+            self::assertNotEmpty($result);
+            $uids = array_map(static fn($first) => $first->getUid(), $result);
+            self::assertContains(1001, $uids);
+        } else {
+            // QueryResultInterface
+            $first = $result->getFirst();
+            self::assertInstanceOf(Document::class, $first);
+            self::assertEquals(1001, $first->getUid());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function canFindAllByCollectionsLimited(): void
+    {
+        $result = $this->documentRepository->findAllByCollectionsLimited([1101], 1, 2);
+
+        // should return a QueryResultInterface or an array
+        self::assertTrue(is_array($result) || $result instanceof QueryResultInterface);
+
+        if (is_array($result)) {
+            self::assertNotEmpty($result);
+            $uids = array_map(static fn($first) => $first->getUid(), $result);
+            self::assertContains(1002, $uids);
+        } else {
+            // QueryResultInterface
+            $first = $result->getFirst();
+            self::assertInstanceOf(Document::class, $first);
+            self::assertEquals(1002, $first->getUid());
+        }
     }
 
     /**


### PR DESCRIPTION
Increase test coverage for DocumentRepository by adding functional tests for methods including findOneByParameters, getChildrenOfYearAnchor, findOneByIdAndSettings, findDocumentsBySettings, and findAllByCollectionsLimited.