### PR TITLE
[MAINTENANCE] Use dot notation for object property access

### DIFF
--- a/Resources/Private/JavaScript/SlubMediaPlayer/SlubMediaPlayer.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/SlubMediaPlayer.js
@@ -473,7 +473,7 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   onCloseModal(modal) {
     if ('$startAtVariants' in modal) {
       // Removes the hidden class of the 'begin' element if it was called from the MarkerTable
-      setElementClass(modal.$startAtVariants['begin'].$container, 'bookmark-markertable-hidden', false);
+      setElementClass(modal.$startAtVariants.begin.$container, 'bookmark-markertable-hidden', false);
     }
 
     this.resumeOn(modal);
@@ -517,7 +517,7 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
 
     // If fromMarkerTable is true, hide the ['begin'] element
     if (fromMarkerTable === true) {
-      setElementClass(modal.$startAtVariants['begin'].$container, 'bookmark-markertable-hidden', true);
+      setElementClass(modal.$startAtVariants.begin.$container, 'bookmark-markertable-hidden', true);
     }
 
     this.openModal(modal, /* pause= */ true);

--- a/Resources/Private/JavaScript/SlubMediaPlayer/modals/BookmarkModal.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/modals/BookmarkModal.js
@@ -286,7 +286,7 @@ export default class BookmarkModal extends SimpleModal {
     const timerange = this.getActiveTimeRange(state);
     const extendedMetadata = makeExtendedMetadata(this.gen, metadata, timerange, fps);
 
-    const url = extendedMetadata['url']?.[0] ?? '';
+    const url = extendedMetadata.url?.[0] ?? '';
     const urlChanged = url !== this.lastRenderedUrl;
 
     if (urlChanged) {

--- a/Resources/Public/JavaScript/PageView/AnnotationControl.js
+++ b/Resources/Public/JavaScript/PageView/AnnotationControl.js
@@ -69,7 +69,7 @@ function DlfAnnotationControl(map, image, annotationContainers) {
 
     this.handlers = {
         mapClick: $.proxy(function(event){
-            var feature = this.map.forEachFeatureAtPixel(event['pixel'], function(feature, layer) {
+            var feature = this.map.forEachFeatureAtPixel(event.pixel, function(feature, layer) {
                 if (feature.get('type') === 'annotationList') {
                     return feature;
                 }
@@ -102,7 +102,7 @@ function DlfAnnotationControl(map, image, annotationContainers) {
         }, this),
         mapHover: $.proxy(function(event){
             // hover in case of dragging
-            if (event['dragging']) {
+            if (event.dragging) {
                 return;
             }
 
@@ -113,7 +113,7 @@ function DlfAnnotationControl(map, image, annotationContainers) {
                 annotationListFeature,
                 annotationFeature;
 
-            map_.forEachFeatureAtPixel(event['pixel'], function(feature, layer) {
+            map_.forEachFeatureAtPixel(event.pixel, function(feature, layer) {
                 if (feature.get('type') === 'annotationList') {
                     annotationListFeature = feature;
                 }

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -225,7 +225,7 @@ var dlfViewerFullTextControl = function(map) {
         this),
         mapHover: $.proxy(function(event) {
                 // hover in case of dragging
-                if (event['dragging']) {
+                if (event.dragging) {
                     return;
                 }
 

--- a/Resources/Public/JavaScript/PageView/SearchInDocument.js
+++ b/Resources/Public/JavaScript/PageView/SearchInDocument.js
@@ -185,11 +185,11 @@ function addImageHighlight(data, word) {
         var highlights = [];
 
         data['documents'].forEach(function (element, i) {
-            if(page <= element['page'] && element['page'] < page + tx_dlf_viewer.countPages()) { // eslint-disable-line camelcase
-                if (element['highlight'].length > 0) {
-                    highlights.push(getHighlights(element['highlight']));
+            if(page <= element.page && element.page < page + tx_dlf_viewer.countPages()) { // eslint-disable-line camelcase
+                if (element.highlight.length > 0) {
+                    highlights.push(getHighlights(element.highlight));
                 }
-                addHighlightEffect(element['highlight']);
+                addHighlightEffect(element.highlight);
             }
         });
 
@@ -244,17 +244,17 @@ $(document).ready(function() {
                 var resultItems = [];
                 var resultList = '<div class="results-active-indicator"></div><ul>';
                 var start = $( "input[id='" + input + "-start']" ).val();
-                if (data['numFound'] > 0) {
-                    data['documents'].forEach(function (element, i) {
+                if (data.numFound > 0) {
+                    data.documents.forEach(function (element, i) {
                         if (start < 0) {
                             start = i;
                         }
-                        if (element['snippet'].length > 0) {
-                            resultItems[element['page']] = '<span class="structure">'
-                                + $(id + '-label-page').text() + ' ' + element['page']
+                        if (element.snippet.length > 0) {
+                            resultItems[element.page] = '<span class="structure">'
+                                + $(id + '-label-page').text() + ' ' + element.page
                                 + '</span><br />'
                                 + '<span class="textsnippet">'
-                                + '<a href=\"' + element['url'] + '\">' + element['snippet'] + '</a>'
+                                + '<a href=\"' + element.url + '\">' + element.snippet + '</a>'
                                 + '</span>';
                         }
                     });


### PR DESCRIPTION
Refactor JavaScript code to use dot notation instead of bracket notation for property access where the keys are constant strings. This improves readability and aligns with standard JavaScript coding conventions.