### PR TITLE
[DOCUMENTATION] Improve and standardize JSDoc comments

### DIFF
--- a/Resources/Private/JavaScript/DlfMediaPlayer/3rd-party/VideoFrame.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/3rd-party/VideoFrame.js
@@ -55,15 +55,15 @@ var VideoFrame = function(options) {
  * FrameRates - Industry standard frame rates
  *
  * @namespace
- * @type {Object}
- * @property {Number} film - 24
- * @property {Number} NTSC - 29.97
- * @property {Number} NTSC_Film - 23.98
- * @property {Number} NTSC_HD - 59.94
- * @property {Number} PAL - 25
- * @property {Number} PAL_HD - 50
- * @property {Number} web - 30
- * @property {Number} high - 60
+ * @type {object}
+ * @property {number} film - 24
+ * @property {number} NTSC - 29.97
+ * @property {number} NTSC_Film - 23.98
+ * @property {number} NTSC_HD - 59.94
+ * @property {number} PAL - 25
+ * @property {number} PAL_HD - 50
+ * @property {number} web - 30
+ * @property {number} high - 60
  */
 var FrameRates = {
 	film: 24,
@@ -80,7 +80,7 @@ VideoFrame.prototype = {
 	/**
 	 * Returns the current frame number
 	 *
-	 * @returns {Number} - Frame number in video
+	 * @returns {number} - Frame number in video
 	 */
 	get : function() {
 		return Math.floor(this.video.currentTime.toFixed(5) * this.frameRate);
@@ -88,9 +88,9 @@ VideoFrame.prototype = {
 	/**
 	 * Event listener for handling callback execution at double the current frame rate interval
 	 *
-	 * @param {String} format - Accepted formats are: SMPTE, time, frame
-	 * @param {Number} tick - Number to set the interval by.
-	 * @returns {Number} Returns a value at a set interval
+	 * @param {string} format - Accepted formats are: SMPTE, time, frame
+	 * @param {number} tick - Number to set the interval by.
+	 * @returns {number} Returns a value at a set interval
 	 */
 	listen : function(format, tick) {
 		var _video = this;
@@ -114,8 +114,8 @@ VideoFrame.prototype = {
  * Returns the current time code in the video in HH:MM:SS format
  * - used internally for conversion to SMPTE format.
  *
- * @param  {Number} frames - The current time in the video
- * @returns {String} Returns the time code in the video
+ * @param {number} frames - The current time in the video
+ * @returns {string} Returns the time code in the video
  */
 VideoFrame.prototype.toTime = function(frames) {
 	var time = (typeof frames !== 'number' ? this.video.currentTime : frames), frameRate = this.frameRate;
@@ -136,8 +136,8 @@ VideoFrame.prototype.toTime = function(frames) {
  * Returns the current SMPTE Time code in the video.
  * - Can be used as a conversion utility.
  *
- * @param  {Number} frame - OPTIONAL: Frame number for conversion to it's equivalent SMPTE Time code.
- * @returns {String} Returns a SMPTE Time code in HH:MM:SS:FF format
+ * @param {number} frame - OPTIONAL: Frame number for conversion to it's equivalent SMPTE Time code.
+ * @returns {string} Returns a SMPTE Time code in HH:MM:SS:FF format
  */
 VideoFrame.prototype.toSMPTE = function(frame) {
 	if (!frame) { return this.toTime(this.video.currentTime); }
@@ -155,8 +155,8 @@ VideoFrame.prototype.toSMPTE = function(frame) {
 /**
  * Converts a SMPTE Time code to Seconds
  *
- * @param  {String} SMPTE - a SMPTE time code in HH:MM:SS:FF format
- * @returns {Number} Returns the Second count of a SMPTE Time code
+ * @param {string} SMPTE - a SMPTE time code in HH:MM:SS:FF format
+ * @returns {number} Returns the Second count of a SMPTE Time code
  */
 VideoFrame.prototype.toSeconds = function(SMPTE) {
 	if (!SMPTE) { return Math.floor(this.video.currentTime); }
@@ -167,9 +167,9 @@ VideoFrame.prototype.toSeconds = function(SMPTE) {
 /**
  * Converts a SMPTE Time code, or standard time code to Milliseconds
  *
- * @param  {String} SMPTE OPTIONAL: a SMPTE time code in HH:MM:SS:FF format,
+ * @param {string} SMPTE OPTIONAL: a SMPTE time code in HH:MM:SS:FF format,
  * or standard time code in HH:MM:SS format.
- * @returns {Number} Returns the Millisecond count of a SMPTE Time code
+ * @returns {number} Returns the Millisecond count of a SMPTE Time code
  */
 VideoFrame.prototype.toMilliseconds = function(SMPTE) {
 	var frames = (!SMPTE) ? Number(this.toSMPTE().split(':')[3]) : Number(SMPTE.split(':')[3]);
@@ -180,8 +180,8 @@ VideoFrame.prototype.toMilliseconds = function(SMPTE) {
 /**
  * Converts a SMPTE Time code to it's equivalent frame number
  *
- * @param  {String} SMPTE - OPTIONAL: a SMPTE time code in HH:MM:SS:FF format
- * @returns {Number} Returns the long running video frame number
+ * @param {string} SMPTE - OPTIONAL: a SMPTE time code in HH:MM:SS:FF format
+ * @returns {number} Returns the long running video frame number
  */
 VideoFrame.prototype.toFrames = function(SMPTE) {
 	var time = (!SMPTE) ? this.toSMPTE().split(':') : SMPTE.split(':');
@@ -196,8 +196,8 @@ VideoFrame.prototype.toFrames = function(SMPTE) {
 /**
  * Private - seek method used internally for the seeking functionality.
  *
- * @param  {String} direction - Accepted Values are: forward, backward
- * @param  {Number} frames - Number of frames to seek by.
+ * @param {string} direction - Accepted Values are: forward, backward
+ * @param {number} frames - Number of frames to seek by.
  */
 VideoFrame.prototype.__seek = function(direction, frames) {
 	if (!this.video.paused) { this.video.pause(); }
@@ -209,8 +209,8 @@ VideoFrame.prototype.__seek = function(direction, frames) {
 /**
  * Seeks forward [X] amount of frames in the video.
  *
- * @param  {Number} [frames] - Number of frames to seek by.
- * @param  {Function} [callback] - Callback function to execute once seeking is complete.
+ * @param {number} [frames] - Number of frames to seek by.
+ * @param {Function} [callback] - Callback function to execute once seeking is complete.
  */
 VideoFrame.prototype.seekForward = function(frames, callback) {
 	if (!frames) { frames = 1; }
@@ -221,8 +221,8 @@ VideoFrame.prototype.seekForward = function(frames, callback) {
 /**
  * Seeks backward [X] amount of frames in the video.
  *
- * @param  {Number} [frames] - Number of frames to seek by.
- * @param  {Function} [callback] - Callback function to execute once seeking is complete.
+ * @param {number} [frames] - Number of frames to seek by.
+ * @param {Function} [callback] - Callback function to execute once seeking is complete.
  */
 VideoFrame.prototype.seekBackward = function(frames, callback) {
 	if (!frames) { frames = 1; }
@@ -234,8 +234,9 @@ VideoFrame.prototype.seekBackward = function(frames, callback) {
  * For seeking to a certain SMPTE time code, standard time code, frame, second, or millisecond in the video.
  * - Was previously deemed not feasible. Veni, vidi, vici.
  *
- * @param  {Object} option - Configuration Object for seeking allowed keys are SMPTE, time, frame, seconds, and milliseconds
- * example: { SMPTE: '00:01:12:22' }, { time: '00:01:12' },  { frame: 1750 }, { seconds: 72 }, { milliseconds: 72916 }
+ * @param {object} config - Configuration Object for seeking allowed keys are SMPTE, time, frame, seconds, and milliseconds
+ *
+ * @example: { SMPTE: '00:01:12:22' }, { time: '00:01:12' },  { frame: 1750 }, { seconds: 72 }, { milliseconds: 72916 }
  */
 VideoFrame.prototype.seekTo = function(config) {
 	var obj = config || {}, seekTime, SMPTE;

--- a/Resources/Private/JavaScript/DlfMediaPlayer/Chapters.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/Chapters.js
@@ -5,7 +5,7 @@ import TimecodeIndex from 'lib/TimecodeIndex';
 /**
  * Represents a set of chapter markers that is ordered by timecode.
  *
- * @extends TimecodeIndex<dlf.media.Chapter>
+ * @auguments TimecodeIndex<dlf.media.Chapter>
  */
 export default class Chapters extends TimecodeIndex {
   /**

--- a/Resources/Private/JavaScript/DlfMediaPlayer/DlfMediaPlayer.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/DlfMediaPlayer.js
@@ -40,7 +40,10 @@ export default class DlfMediaPlayer extends HTMLElement {
       DlfMediaPlayer.hasInstalledPolyfills = true;
     }
 
-    /** @protected @type {dlf.media.PlayerConfig | null} */
+    /**
+     * @protected
+     * @type {dlf.media.PlayerConfig | null}
+     */
     this.config = null;
 
     /** @protected */
@@ -50,8 +53,9 @@ export default class DlfMediaPlayer extends HTMLElement {
     this.eventMgr_ = new EventManager();
 
     /**
-     * @protected
      * @type {ReturnType<this['constantDefaults']>}
+     *
+     * @protected
      */
     // @ts-expect-error
     this.constants = this.constantDefaults();
@@ -67,7 +71,14 @@ export default class DlfMediaPlayer extends HTMLElement {
       },
     };
 
-    /** @protected @readonly @type {HTMLVideoElement} */
+    /**
+     *
+     * @type {HTMLVideoElement}
+     *
+     * @readonly
+     *
+     * @protected
+     */
     this.video = e('video', {
       id: this.env.mkid(),
       className: "dlf-media",
@@ -79,46 +90,86 @@ export default class DlfMediaPlayer extends HTMLElement {
      *
      * See {@link pauseOn} and {@link resumeOn}.
      *
-     * @private
      * @type {any}
+     *
+     * @private
      */
     this.videoPausedOn = null;
 
-    /** @private @type {dlf.media.Source | null} */
+    /**
+     * @type {dlf.media.Source | null}
+     *
+     * @private
+     */
     this.currentSource = null;
 
-    /** @protected @type {dlf.media.TimeRange | null} */
+    /**
+     * @type {dlf.media.TimeRange | null}
+     * @protected
+     */
     this.timeRange = null;
 
-    /** @private @type {shaka.Player} */
+    /**
+     * @type {shaka.Player}
+     *
+     * @private
+     */
     this.player = new shaka.Player();
     this.player.attach(this.video);
 
-    /** @private @type {dlf.media.Fps | null} */
+    /**
+     * @type {dlf.media.Fps | null}
+     *
+     * @private
+     */
     this.fps = null;
 
-    /** @private @type {VariantGroups | null} */
+    /**
+     * @type {VariantGroups | null}
+     *
+     * @private
+     */
     this.variantGroups = null;
 
-    /** @private @type {Chapters} */
+    /**
+     * @type {Chapters}
+     *
+     * @private
+     */
     this.chapters_ = new Chapters([]);
 
-    /** @private @type {dlf.media.Chapter | null} */
+    /**
+     * @type {dlf.media.Chapter | null}
+     *
+     * @private
+     */
     this.currentChapter = null;
 
     /** @private */
     this.markers_ = new Markers();
 
-    /** @private @type {dlf.media.PlayerFrontend} */
+    /**
+     * @type {dlf.media.PlayerFrontend}
+     *
+     * @private
+     */
     this.frontend = new ShakaFrontend(this.env, this.eventMgr_, this.player, this.video);
 
-    /** @protected @type {HTMLElement | null} */
+    /**
+     * @type {HTMLElement | null}
+     *
+     * @protected
+     */
     this.playerView = null;
 
     /** @protected */
     this.autoplay_ = false;
 
-    /** @private @type {dlf.media.PlayerMode | 'auto'} */
+    /**
+     * @type {dlf.media.PlayerMode | 'auto'}
+     *
+     * @private
+     */
     this.mode = 'auto';
 
     /** @protected */
@@ -130,8 +181,9 @@ export default class DlfMediaPlayer extends HTMLElement {
      * The actions of the player. This is typed in a way that includes additions
      * made by overriding {@link getActions}.
      *
-     * @protected
      * @type {Readonly<ReturnType<this['getActions']>>}
+     *
+     * @protected
      */
     // @ts-expect-error
     this.actions = this.getActions();
@@ -1138,7 +1190,7 @@ export default class DlfMediaPlayer extends HTMLElement {
   }
 
   /**
-   * Whether or not enough data is available for the current playback position
+   * Whether enough data is available for the current playback position
    * (checks `readyState`).
    *
    * @returns {boolean}
@@ -1328,9 +1380,11 @@ export default class DlfMediaPlayer extends HTMLElement {
   /**
    * Returns the active segment if it exists and has a valid endTime.
    *
-   * @private
    * @typedef {import('./Markers.js').Segment & { endTime: number }} SegmentWithEnd
+   *
    * @returns {SegmentWithEnd | null}
+   *
+   * @private
    */
   getValidActiveSegment() {
     const activeSegment = this.markers_.activeSegment;
@@ -1343,8 +1397,9 @@ export default class DlfMediaPlayer extends HTMLElement {
   /**
    * Checks whether the active segment has reached or passed its end time and deactivates it.
    *
-   * @private
    * @returns {boolean}
+   *
+   * @private
    */
   deactivateActiveSegment() {
     const activeSegment = this.getValidActiveSegment();
@@ -1366,8 +1421,9 @@ export default class DlfMediaPlayer extends HTMLElement {
   /**
    * Checks whether playback has reached the active segment’s end time and pauses the video.
    *
-   * @private
    * @returns {boolean}
+   *
+   * @private
    */
   stopActiveSegment() {
     const activeSegment = this.getValidActiveSegment();

--- a/Resources/Private/JavaScript/DlfMediaPlayer/DlfMediaPlugin.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/DlfMediaPlugin.js
@@ -11,10 +11,18 @@ export default class DlfMediaPlugin extends HTMLElement {
   constructor() {
     super();
 
-    /** @protected @type {Translator & Identifier & Browser} */
+    /**
+     * @type {Translator & Identifier & Browser}
+     *
+     * @protected
+     */
     this.env = new Environment();
 
-    /** @protected @type {DlfMediaPlayer | null} */
+    /**
+     * @type {DlfMediaPlayer | null}
+     *
+     * @protected
+     */
     this.player = null;
 
     /** @protected */

--- a/Resources/Private/JavaScript/DlfMediaPlayer/ImageFetcher.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/ImageFetcher.js
@@ -64,8 +64,9 @@ export default class ImageFetcher {
     /**
      * Map from URL to task.
      *
-     * @private
      * @type {Record<string, Task>}
+     *
+     * @private
      */
     this.tasks = {};
   }
@@ -109,9 +110,10 @@ export default class ImageFetcher {
   }
 
   /**
-   * @protected
    * @param {string} url
    * @returns {Task}
+   *
+   * @protected
    */
   createTask(url) {
     return {
@@ -125,17 +127,19 @@ export default class ImageFetcher {
   }
 
   /**
-   * @protected
    * @param {Task} task
+   *
+   * @protected
    */
   stopTask(task) {
     task.stopNext = true;
   }
 
   /**
-   * @protected
    * @param {Task} task
    * @returns {Promise<HTMLImageElement>}
+   *
+   * @protected
    */
   resumeTask(task) {
     // If we're still in the `for(;;)` loop, this just tells them to
@@ -172,8 +176,9 @@ export default class ImageFetcher {
   /**
    * This should be the only method that re-sets `task.state`.
    *
-   * @protected
    * @param {Task} task
+   *
+   * @protected
    */
   async progressTask(task) {
     switch (task.state.type) {

--- a/Resources/Private/JavaScript/DlfMediaPlayer/Markers.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/Markers.js
@@ -47,7 +47,7 @@ import { EventTarget } from 'DlfMediaPlayer/3rd-party/EventTarget';
  *   'activate' parameter in {@link update}.
  * - The `activate_segment` event is fired whenever activation changes.
  *
- * @extends {EventTarget<Events>}
+ * @augments {EventTarget<Events>}
  */
 export default class Markers extends EventTarget {
   constructor() {
@@ -56,10 +56,18 @@ export default class Markers extends EventTarget {
     /** @private */
     this.cnt_ = 0;
 
-    /** @private @type {Segment | null} */
+    /**
+     * @type {Segment | null}
+     *
+     * @private
+     */
     this.activeSegment_ = null;
 
-    /** @private @type {Record<string, Segment>} */
+    /**
+     * @type {Record<string, Segment>}
+     *
+     * @private
+     */
     this.segments_ = {};
   }
 
@@ -168,8 +176,9 @@ export default class Markers extends EventTarget {
 
   /**
    *
-   * @protected
    * @param {Segment | null} segment
+   *
+   * @protected
    */
   activateSegment(segment) {
     if (segment !== this.activeSegment_) {
@@ -192,6 +201,7 @@ export default class Markers extends EventTarget {
   /**
    *
    * @param {string} id
+   *
    * @returns {Readonly<Segment> | undefined}
    */
   getSegment(id) {
@@ -208,8 +218,9 @@ export default class Markers extends EventTarget {
 
   /**
    *
-   * @private
    * @returns {string}
+   *
+   * @private
    */
   makeId() {
     return `dlf.segments.${this.cnt_++}`;

--- a/Resources/Private/JavaScript/DlfMediaPlayer/ThumbnailPreview.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/ThumbnailPreview.js
@@ -87,38 +87,79 @@ export default class ThumbnailPreview {
     this.network = params.network;
     this.interaction = params.interaction;
 
-    /** @private @type {number | null} */
+    /**
+     * @private
+     * @type {number | null}
+     */
     this.fps = null;
-    /** @private @type {Chapters | null} */
+
+    /**
+     * @private
+     * @type {Chapters | null}
+     */
     this.chapters = null;
+
     /**
      * Thumbnail tracks, ordered by quality/bandwidth descending.
      * @private
      * @type {dlf.media.ThumbnailTrack[]}
      */
     this.thumbnailTracks = [];
+
     /**
      * Thumbnail track to which cursor is currently snapped.
      *
      * This is also used for downloading thumbnail images, so that the thumbnail
      * segmentation cannot change during snap.
      *
-     * @private
      * @type {dlf.media.ThumbnailTrack | null}
+     *
+     * @private
      */
     this.snapToThumbnail = null;
-    /** @private @type {LastRendered | null} */
+
+    /**
+     * @type {LastRendered | null}
+     *
+     * @private
+     */
     this.lastRendered = null;
-    /** @private @type {boolean} */
+
+    /**
+     * @type {boolean}
+     *
+     * @private
+     */
     this.isChanging = false;
-    /** @private @type {{ clientX: number; seconds: number } | null} */
+
+    /**
+     * @type {{ clientX: number; seconds: number } | null}
+     *
+     * @private
+     */
     this.deltaStart = null;
-    /** @private @type {Current | null} */
+
+    /**
+     * @type {Current | null}
+     *
+     * @private
+     */
     this.current = null;
-    /** @private @type {number | null} */
+
+    /**
+     * @type {number | null}
+     *
+     * @private
+     */
     this.renderAnimationFrame = null;
-    /** @private @type {SeekMode} */
+
+    /**
+     * @type {SeekMode}
+     *
+     * @private
+     */
     this.seekMode = 'wide';
+
     /** @private */
     this.openDisplayTimeout = null;
 
@@ -246,8 +287,9 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * @private
    * @param {PointerEvent} e
+   *
+   * @private
    */
   async onPointerMove(e) {
     const rawSeekPosition = this.mouseEventToPosition(e);
@@ -283,8 +325,9 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * @private
    * @param {PointerEvent} e
+   *
+   * @private
    */
   async onPointerDown(e) {
     // Check primary button
@@ -302,8 +345,9 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * @private
    * @param {PointerEvent} e
+   *
+   * @private
    */
   onPointerUpOrCancel(e) {
     this.endChange();
@@ -316,10 +360,11 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * @private
    * @param {MouseEvent} e
    * @param {boolean} allowWideSeekArea
    * @returns {RawSeekPosition | undefined}
+   *
+   * @private
    */
   mouseEventToPosition(e, allowWideSeekArea = true) {
     const duration = this.saneVideoDuration();
@@ -422,9 +467,10 @@ export default class ThumbnailPreview {
   /**
    * Resizes display to match aspect ratio of given thumbnail size.
    *
-   * @private
    * @param {number} thumbWidth
    * @param {number} thumbHeight
+   *
+   * @private
    */
   ensureDisplaySize(thumbWidth, thumbHeight) {
     const previewHeight = Math.floor(DISPLAY_WIDTH / thumbWidth * thumbHeight);
@@ -436,8 +482,9 @@ export default class ThumbnailPreview {
   /**
    * Renders best available thumbnail at current position.
    *
-   * @private
    * @param {boolean} isOpening
+   *
+   * @private
    */
   currentRenderBest(isOpening = false) {
     // We don't wan't the thumbnail preview to be opened when the user is just
@@ -491,11 +538,12 @@ export default class ThumbnailPreview {
   /**
    * Renders the specified thumbnail to the display and shows it to the user.
    *
-   * @private
    * @param {string} uri
    * @param {dlf.media.ThumbnailOnTrack} thumb
    * @param {HTMLImageElement} tilesetImage
    * @param {SeekPosition} seekPosition
+   *
+   * @private
    */
   renderImageAndShow(uri, thumb, tilesetImage, seekPosition) {
     this.ensureDisplaySize(thumb.width, thumb.height);
@@ -513,11 +561,12 @@ export default class ThumbnailPreview {
   /**
    * Renders the specified thumbnail to the display.
    *
-   * @private
    * @param {string} uri
    * @param {dlf.media.ThumbnailOnTrack} thumb
    * @param {HTMLImageElement} tilesetImage
    * @param {boolean} force
+   *
+   * @private
    */
   renderImage(uri, thumb, tilesetImage, force = false) {
     // Check if it's another thumbnail (`imageTime` and `bandwidth` as proxy)
@@ -548,8 +597,9 @@ export default class ThumbnailPreview {
   /**
    * Positions the thumbnail container to match {@link seekPosition}.
    *
-   * @private
    * @param {SeekPosition} seekPosition
+   *
+   * @private
    */
   positionContainer(seekPosition) {
     // Align the container so that the mouse underneath is centered,
@@ -568,9 +618,10 @@ export default class ThumbnailPreview {
    * - Sets chapter and timecode texts
    * - Positions the container
    *
-   * @private
    * @param {SeekPosition} seekPosition
    * @param {dlf.media.Thumbnail | null} thumb
+   *
+   * @private
    */
   renderSeekPosition(seekPosition, thumb = null) {
     const duration = this.saneVideoDuration();
@@ -617,8 +668,9 @@ export default class ThumbnailPreview {
   /**
    * Starts seeking and scrubbing.
    *
-   * @public
    * @param {number | null} clientX
+   *
+   * @public
    */
   beginChange(clientX = null) {
     if (!this.isChanging) {
@@ -632,8 +684,9 @@ export default class ThumbnailPreview {
 
   /**
    *
-   * @private
    * @param {number | null} clientX
+   *
+   * @private
    */
   convertDelta(clientX) {
     if (clientX === null) {
@@ -664,7 +717,7 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * Whether or not the thumbnail preview container is currently shown.
+   * Whether the thumbnail preview container is currently shown.
    *
    * @type {boolean}
    */
@@ -695,10 +748,11 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * @private
    * @param {number} position
    * @param {number} maximumBandwidth
    * @returns {Promise<dlf.media.ThumbnailOnTrack[]>}
+   *
+   * @private
    */
   async getThumbnails(position, maximumBandwidth) {
     /** @type {dlf.media.ThumbnailTrack[]} */
@@ -730,10 +784,11 @@ export default class ThumbnailPreview {
 
   /**
    *
-   * @private
    * @param {dlf.media.ThumbnailTrack} track
    * @param {number} position
    * @returns {Promise<dlf.media.ThumbnailOnTrack | null>}
+   *
+   * @private
    */
   async getSingleThumbnail(track, position) {
     const thumbRaw = await track.getThumb(position);
@@ -747,10 +802,11 @@ export default class ThumbnailPreview {
   }
 
   /**
-   * Whether or not to show a thumbnail image (if available).
+   * Whether to show a thumbnail image (if available).
+   *
+   * @returns {boolean}
    *
    * @private
-   * @returns {boolean}
    */
   showThumbnailImage() {
     const video = this.player.getMediaElement();
@@ -764,8 +820,9 @@ export default class ThumbnailPreview {
    * Returns either the video duration as finite, non-negative number,
    * or `undefined` otherwise.
    *
-   * @private
    * @returns {number | undefined}
+   *
+   * @private
    */
   saneVideoDuration() {
     const duration = this.player.getMediaElement()?.duration;

--- a/Resources/Private/JavaScript/DlfMediaPlayer/VariantGroups.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/VariantGroups.js
@@ -39,32 +39,37 @@ export default class VariantGroups {
    */
   constructor(player) {
     /**
-     * @private
      * @type {import('shaka-player/dist/shaka-player.ui').default.Player}
+     *
+     * @private
      */
     this.player = player;
 
     /**
-     * @private
      * @type {import('shaka-player/dist/shaka-player.ui').default.extern.Manifest | null}
+     *
+     * @private
      */
     this.manifest = player.getManifest();
 
     /**
-     * @private
      * @type {GroupKey[]}
+     *
+     * @private
      */
     this.groupKeys = [];
 
     /**
-     * @private
      * @type {Group[]}
+     *
+     * @private
      */
     this.groups = [];
 
     /**
-     * @private
      * @type {Record<GroupKey, Group>}
+     *
+     * @private
      */
     this.keyToGroup = {};
 
@@ -231,9 +236,10 @@ export default class VariantGroups {
 
   /**
    *
-   * @protected
    * @param {Group | undefined} group
    * @returns {boolean}
+   *
+   * @protected
    */
   trySelectGroup(group) {
     if (group) {

--- a/Resources/Private/JavaScript/DlfMediaPlayer/components/waveform/WaveForm.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/components/waveform/WaveForm.js
@@ -52,10 +52,18 @@ export default class WaveForm extends DlfMediaPlugin {
 
     shadow.append(this.$style, this.$container);
 
-    /** @private @type {string | null} */
+    /**
+     * @type {string | null}
+     *
+     * @private
+     */
     this.nextUrl = null;
 
-    /** @private @type {import('peaks.js').PeaksInstance | null} */
+    /**
+     * @type {import('peaks.js').PeaksInstance | null}
+     *
+     * @private
+     */
     this.peaks_ = null;
 
     /** @private */
@@ -70,7 +78,11 @@ export default class WaveForm extends DlfMediaPlugin {
     /** @private */
     this.samplesPerPixel = 0;
 
-    /** @private @type {import('peaks.js').WaveformZoomView | null} */
+    /**
+     * @type {import('peaks.js').WaveformZoomView | null}
+     *
+     * @private
+     */
     this.zoomview = null;
 
     /** @private */
@@ -79,7 +91,11 @@ export default class WaveForm extends DlfMediaPlugin {
       onResize: this.onResize.bind(this),
     };
 
-    /** @private @type {Partial<import('peaks.js').PeaksEvents>} */
+    /**
+     * @type {Partial<import('peaks.js').PeaksEvents>}
+     *
+     * @private
+     */
     this.peaksHandlers = {
       'points.dragend': (event) => {
         if (this.player !== null && event.point.id !== undefined) {
@@ -106,7 +122,11 @@ export default class WaveForm extends DlfMediaPlugin {
       },
     }
 
-    /** @private @type {Partial<import('DlfMediaPlayer/Markers').Handlers>} */
+    /**
+     * @type {Partial<import('DlfMediaPlayer/Markers').Handlers>}
+     *
+     * @private
+     */
     this.markersHandlers = {
       'remove': (event) => {
         for (const segment of event.detail.segments) {
@@ -195,8 +215,9 @@ export default class WaveForm extends DlfMediaPlugin {
   }
 
   /**
-   * @override
    * @inheritdoc
+   * @override
+   *
    * @param {DlfMediaPlayer} player
    */
   async attachToPlayer(player) {
@@ -228,8 +249,9 @@ export default class WaveForm extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {string} url
+   *
+   * @private
    */
   async load(url) {
     this.nextUrl = url;
@@ -319,8 +341,9 @@ export default class WaveForm extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {import('DlfMediaPlayer/Markers').Segment[]} segments
+   *
+   * @private
    */
   peaksAddSegments(segments) {
     if (this.peaks_ !== null) {
@@ -348,8 +371,9 @@ export default class WaveForm extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {WheelEvent} e
+   *
+   * @private
    */
   onWheel(e) {
     const zoomInFactor = 1.5 ** (-e.deltaY / 100);
@@ -365,8 +389,9 @@ export default class WaveForm extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {number} samplesPerPixel
+   *
+   * @private
    */
   updateZoom(samplesPerPixel = this.samplesPerPixel) {
     if (this.waveformdata === null) {

--- a/Resources/Private/JavaScript/DlfMediaPlayer/controls/ControlPanelButton.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/controls/ControlPanelButton.js
@@ -51,7 +51,11 @@ export default class ControlPanelButton extends shaka.ui.Element {
 
     parent.appendChild(element);
 
-    /** @protected Avoid naming conflicts with parent class */
+    /**
+     * Avoid naming conflicts with parent class
+     *
+     * @protected
+     */
     this.dlf = { config, element };
 
     const { onClickAction } = config;

--- a/Resources/Private/JavaScript/DlfMediaPlayer/controls/FlatSeekBar.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/controls/FlatSeekBar.js
@@ -198,9 +198,10 @@ export default class FlatSeekBar extends shaka.ui.Element {
   /**
    * Adds chapter marker elements to the seekbar.
    *
-   * @private
    * @param {Chapters} chapters
    * @param {number} duration Duration of the video to be assumed.
+   *
+   * @private
    */
   renderChapterMarkers(chapters, duration) {
     // Clear chapter markers, which would allow a full refresh

--- a/Resources/Private/JavaScript/DlfMediaPlayer/controls/OverflowMenuButton.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/controls/OverflowMenuButton.js
@@ -40,7 +40,11 @@ export default class OverflowMenuButton extends shaka.ui.SettingsMenu {
   constructor(parent, controls, config = {}) {
     super(parent, controls, config.material_icon ?? "");
 
-    /** @protected Avoid naming conflicts with parent class */
+    /**
+     * Avoid naming conflicts with parent class
+     *
+     * @protected
+     */
     this.dlf = { config };
 
     if (this.eventManager) {

--- a/Resources/Private/JavaScript/DlfMediaPlayer/frontend/ShakaFrontend.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/frontend/ShakaFrontend.js
@@ -57,7 +57,10 @@ export default class ShakaFrontend {
     /** @private */
     this.media = media;
 
-    /** @private @type {dlf.media.MediaProperties} */
+    /**
+     * @private
+     * @type {dlf.media.MediaProperties}
+     */
     this.mediaProperties = {
       poster: null,
       chapters: null,
@@ -68,7 +71,11 @@ export default class ShakaFrontend {
     /** @private */
     this.lastReadyState = 0;
 
-    /** @private @type {dlf.media.PlayerProperties} */
+    /**
+     * @type {dlf.media.PlayerProperties}
+     *
+     * @private
+     */
     this.playerProperties = {
       mode: 'audio',
       locale: '',
@@ -79,16 +86,32 @@ export default class ShakaFrontend {
       playerView: null,
     };
 
-    /** @private @type {string[]} */
+    /**
+     * @type {string[]}
+     *
+     * @private
+     */
     this.overflowMenuButtons = [];
 
-    /** @private @type {HTMLElement | null} */
+    /**
+     * @type {HTMLElement | null}
+     *
+     * @private
+     */
     this.shakaBottomControls = null;
 
-    /** @private @type {HTMLElement[]} */
+    /**
+     * @type {HTMLElement[]}
+     *
+     * @private
+     */
     this.shakaBottomControlElements = [];
 
-    /** @private @type {FlatSeekBar | null} */
+    /**
+     * @type {FlatSeekBar | null}
+     *
+     * @private
+     */
     this.seekBar_ = null;
 
     /** @private */
@@ -112,10 +135,18 @@ export default class ShakaFrontend {
     /** @private */
     this.ui = new shaka.ui.Overlay(this.player, this.$videoBox, this.media);
 
-    /** @private */
-    this.controls = /** @type {shaka.ui.Controls} */(this.ui.getControls());
+    /**
+     * @type {shaka.ui.Controls
+     *
+     * @private
+     */
+    this.controls = (this.ui.getControls());
 
-    /** @private @type {ReturnType<setTimeout> | null} */
+    /**
+     * @type {ReturnType<setTimeout> | null}
+     *
+     * @private
+     */
     this.configureTimeout = null;
 
     /** @private */
@@ -184,9 +215,10 @@ export default class ShakaFrontend {
   }
 
   /**
-   * @private
    * @param {dlf.media.MediaProperties} fullProps
    * @param {Partial<dlf.media.MediaProperties>} updateProps
+   *
+   * @private
    */
   notifyMediaProperties(
     fullProps = this.mediaProperties,
@@ -481,8 +513,9 @@ export default class ShakaFrontend {
    * Determine whether or not {@link event} should be interpreted as (part of)
    * a gesture. See configuration of {@link Gestures} for more information.
    *
-   * @private
    * @param {PointerEvent} event
+   *
+   * @private
    */
   allowGesture(event) {
     // Don't allow gestures over Shaka bottom controls
@@ -537,8 +570,9 @@ export default class ShakaFrontend {
   }
 
   /**
-   * @private
    * @param {number} readyState
+   *
+   * @private
    */
   updateBottomControlsVisibility(readyState) {
     // When readyState is strictly between 0 and minBottomControlsReadyState,

--- a/Resources/Private/JavaScript/DlfMediaPlayer/lib/thumbnails/ShakaThumbnailTrack.js
+++ b/Resources/Private/JavaScript/DlfMediaPlayer/lib/thumbnails/ShakaThumbnailTrack.js
@@ -24,6 +24,7 @@ export default class ShakaThumbnailTrack {
   /**
    *
    * @param {number} position
+   *
    * @returns {Promise<dlf.media.ThumbnailOnTrack | null>}
    */
   async getThumb(position) {

--- a/Resources/Private/JavaScript/SlubMediaPlayer/SlubMediaPlayer.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/SlubMediaPlayer.js
@@ -33,7 +33,11 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
     /** @type {MetadataArray} */
     this.metadata = {};
 
-    /** @private @type {Keybinding<KeyboardScope, keyof SlubMediaPlayer['actions']>[]} */
+    /**
+     * @type {Keybinding<KeyboardScope, keyof SlubMediaPlayer['actions']>[]}
+     *
+     * @private
+     */
     this.keybindings = /** @type {any} */(keybindings);
 
     /** @private */
@@ -45,16 +49,28 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
       onCloseModal: this.onCloseModal.bind(this),
     };
 
-    /** @private @type {ChapterLinkElement[]} */
+    /**
+     * @type {ChapterLinkElement[]}
+     *
+     * @private
+     */
     this.chapterLinks = [];
 
-    /** @private @type {HTMLSelectElement | null} */
+    /**
+     * @type {HTMLSelectElement | null}
+     *
+     * @private
+     */
     this.pageSelect = null;
 
     /** @private */
     this.modals = null;
 
-    /** @private @type {Partial<AppConstantsConfig>} */
+    /**
+     * @type {Partial<AppConstantsConfig>}
+     *
+     * @private
+     */
     this.appConstants = {};
   }
 
@@ -234,9 +250,10 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
    * Extracts chapter to jump to when clicking on {@link link},
    * or `null` if none could be determined.
    *
-   * @private
    * @param {HTMLAnchorElement} link
    * @returns {ChapterLink | null}
+   *
+   * @private
    */
   getChapterLink(link) {
     // Attempt: Parse data-timecode attribute
@@ -339,8 +356,9 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @returns {KeyboardScope}
+   *
+   * @private
    */
   getKeyboardScope() {
     if (this.modals?.hasOpen()) {
@@ -358,8 +376,9 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @param {KeyboardEvent} e
+   *
+   * @private
    */
   onKeyDown(e) {
     if (!this.hasVideo) {
@@ -370,8 +389,9 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @param {KeyboardEvent} e
+   *
+   * @private
    */
   onKeyUp(e) {
     // Stopping propagation is a hack against the keyup handler in
@@ -389,9 +409,10 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @param {KeyboardEvent} e
    * @param {KeyEventMode} mode
+   *
+   * @private
    */
   handleKey(e, mode) {
     const curKbScope = this.getKeyboardScope();
@@ -423,8 +444,9 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @param {MouseEvent} e
+   *
+   * @private
    */
   onClickChapterLink(e) {
     // Use `currentTarget` to get the <a> element to which the handler has
@@ -467,8 +489,9 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @param {ValueOf<AppModals>} modal
+   *
+   * @private
    */
   onCloseModal(modal) {
     if ('$startAtVariants' in modal) {
@@ -552,9 +575,10 @@ export default class SlubMediaPlayer extends DlfMediaPlayer {
   }
 
   /**
-   * @private
    * @param {ValueOf<AppModals>=} modal
    * @param {boolean} pause
+   *
+   * @private
    */
   openModal(modal, pause = false) {
     if (modal == null) {

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/Equalizer.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/Equalizer.js
@@ -30,7 +30,11 @@ export default class Equalizer {
     /** @private */
     this.fftData_ = new Float32Array(this.fftSize_);
 
-    /** @private @type {Connection | null} */
+    /**
+     * @type {Connection | null}
+     *
+     * @private
+     */
     this.connection_ = null;
 
     /** @private */
@@ -45,7 +49,7 @@ export default class Equalizer {
   }
 
   /**
-   * Whether or not the equalizer is active.
+   * Whether the equalizer is active.
    */
   get active() {
     return this.active_;

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/EqualizerPlugin.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/EqualizerPlugin.js
@@ -20,13 +20,25 @@ export default class EqualizerPlugin extends DlfMediaPlugin {
   constructor() {
     super();
 
-    /** @private @type {dlf.media.eq.FilterPreset[]} */
+    /**
+     * @type {dlf.media.eq.FilterPreset[]}
+     *
+     * @private
+     */
     this.presets_ = [];
 
-    /** @private @type {string | null} */
+    /**
+     * @type {string | null}
+     *
+     * @private
+     */
     this.defaultPreset_ = null;
 
-    /** @private @type {EqualizerView | null} */
+    /**
+     * @type {EqualizerView | null}
+     *
+     * @private
+     */
     this.eqView_ = null;
 
     /** @private */
@@ -34,16 +46,27 @@ export default class EqualizerPlugin extends DlfMediaPlugin {
       onStorePreset: this.onStorePreset.bind(this),
     };
 
-    /** @private */
-    /** @private @type {AudioContext | null} */
+    /**
+     * @type {AudioContext | null}
+     *
+     * @private
+     */
     // Don't create AudioContext eagerly: some browsers block creation before
     // a user gesture (autoplay policies). Create / resume it on demand in resumeAudioContext().
     this.context = null;
 
-    /** @private @type {(value?: any) => void} */
+    /**
+     * @type {(value?: any) => void}
+     *
+     * @private
+     */
     this.markAsResumed = (/* value */) => { };
 
-    /** @private @type {HTMLElement | null} */
+    /**
+     * @type {HTMLElement | null}
+     *
+     * @private
+     */
     this.resumeHintEl_ = null;
 
     /** @private */
@@ -99,8 +122,9 @@ export default class EqualizerPlugin extends DlfMediaPlugin {
    * `attachToPlayer` so initialization can be deferred until the panel is
    * visible.
    *
-   * @private
    * @param {DlfMediaPlayer} player
+   *
+   * @private
    */
   async initForPlayer(player) {
     if (window.location.protocol !== 'https:') {
@@ -290,8 +314,9 @@ export default class EqualizerPlugin extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {import('SlubMediaPlayer/components/equalizer/EqualizerView').EqualizerViewEvent<'store_preset'>} event
+   *
+   * @private
    */
   onStorePreset(event) {
     const { key, preset } = event.detail;
@@ -299,8 +324,9 @@ export default class EqualizerPlugin extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @returns {Record<string, dlf.media.eq.FilterPreset>}
+   *
+   * @private
    */
   getLocalPresets() {
     /** @type {Record<string, dlf.media.eq.FilterPreset>} */

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/EqualizerView.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/EqualizerView.js
@@ -51,7 +51,7 @@ import Scale, { Linear, Logarithmic } from 'SlubMediaPlayer/components/equalizer
  */
 
 /**
- * @extends {EventTarget<Events>}
+ * @augments {EventTarget<Events>}
  */
 export default class EqualizerView extends EventTarget {
   /**
@@ -166,13 +166,25 @@ export default class EqualizerView extends EventTarget {
     /** @private */
     this.eqBox = this.calcEqBox();
 
-    /** @private @type {ReturnType<requestAnimationFrame> | null} */
+    /**
+     * @type {ReturnType<requestAnimationFrame> | null}
+     *
+     * @private
+     */
     this.resizeAnimationFrame = null;
 
-    /** @private @type {ReturnType<requestAnimationFrame> | null} */
+    /**
+     * @type {ReturnType<requestAnimationFrame> | null}
+     *
+     * @private
+     */
     this.renderAnimationFrame = null;
 
-    /** @private @type {Hovered | null} */
+    /**
+     * @type {Hovered | null}
+     *
+     * @private
+     */
     this.hovered = null;
 
     /** @private */
@@ -273,8 +285,9 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {MouseEvent} e
+   *
+   * @private
    */
   onCanvasMouseMove(e) {
     /** @type {Position} */
@@ -320,8 +333,9 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {MouseEvent} e
+   *
+   * @private
    */
   onCanvasMouseDown(e) {
     if (this.hovered !== null) {
@@ -376,8 +390,9 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {WheelEvent} e
+   *
+   * @private
    */
   onCanvasWheel(e) {
     if (this.hovered !== null && this.hovered.grabbed === null) {
@@ -393,8 +408,9 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {Hovered | null} hovered
+   *
+   * @private
    */
   setHovered(hovered) {
     this.hovered = hovered;
@@ -409,28 +425,31 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {dlf.media.eq.Param} param
    * @param {(oldValue: number) => number} fn
+   *
+   * @private
    */
   updateFilterGain(param, fn) {
     this.updateEqValue(param.gain, fn, [-24, 24]);
   }
 
   /**
-   * @private
    * @param {dlf.media.eq.Param} param
    * @param {(oldValue: number) => number} fn
+   *
+   * @private
    */
   updateFilterFreq(param, fn) {
     this.updateEqValue(param.frequency, fn, [10, this.freq.max]);
   }
 
   /**
-   * @private
    * @param {dlf.media.eq.ParamValue} param
    * @param {(oldValue: number) => number} fn
    * @param {[number, number]} bounds
+   *
+   * @private
    */
   updateEqValue(param, fn, bounds) {
     if (param.editable) {
@@ -558,8 +577,9 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {string} group
+   *
+   * @private
    */
   addPresetOptgroup(group) {
     const optgroup = e('optgroup', {
@@ -718,9 +738,10 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {dlf.media.eq.Curve} curve
    * @param {'gain' | 'phase'} part
+   *
+   * @private
    */
   fillEqCurve(curve, part = 'gain') {
     if (this.$ctx === null) {
@@ -747,9 +768,10 @@ export default class EqualizerView extends EventTarget {
   }
 
   /**
-   * @private
    * @param {dlf.media.eq.Curve} curve
    * @param {'gain' | 'phase'} part
+   *
+   * @private
    */
   drawEqCurve(curve, part = 'gain') {
     if (this.$ctx === null) {

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/FrequencyResponse.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/FrequencyResponse.js
@@ -91,10 +91,11 @@ export default class FrequencyResponse {
   }
 
   /**
-   * @private
    * @param {number[]} coefficients
    * @param {number} w
    * @returns {[number, number]}
+   *
+   * @private
    */
   fft(coefficients, w) {
     let real = 0;

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/MultiIirProcessor.no-babel.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/MultiIirProcessor.no-babel.js
@@ -67,7 +67,11 @@ export default function registerMultiIirProcessor() {
     constructor() {
       super();
 
-      /** @private @type {Record<string, Filter>} */
+      /**
+       * @type {Record<string, Filter>}
+       *
+       * @private
+       */
       this.filters = {};
 
       /** @private */
@@ -80,8 +84,9 @@ export default function registerMultiIirProcessor() {
     }
 
     /**
-     * @private
      * @param {MessageEvent} event
+     *
+     * @private
      */
     onmessage(event) {
       const data = event.data;

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/filtersets/BandEq.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/filtersets/BandEq.js
@@ -38,10 +38,18 @@ export default class BandEq {
     /** @private */
     this.audioContext_ = context;
 
-    /** @private @type {Band[]} */
+    /**
+     * @type {Band[]}
+     *
+     * @private
+     */
     this.bands_ = [];
 
-    /** @private @type {AudioNode | null} */
+    /**
+     * @type {AudioNode | null}
+     *
+     * @private
+     */
     this.prevNode_ = null;
 
     /** @private */

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/filtersets/RiaaEq.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/equalizer/filtersets/RiaaEq.js
@@ -58,7 +58,11 @@ export default class RiaaEq {
     /** @private */
     this.processorNode = new AudioWorkletNode(context, 'multi-iir-processor');
 
-    /** @private @type {Record<RiaaParamKey, dlf.media.eq.Param<ParamValue>>} */
+    /**
+     * @type {Record<RiaaParamKey, dlf.media.eq.Param<ParamValue>>}
+     *
+     * @private
+     */
     this.pp = {
       deepBaseRolloff: this.makeParam('base', 50),
       baseBoostRolloff: this.makeParam('mid', 1000, () => [0, this.pp.baseBoost.frequency.value - 0.01]),
@@ -66,7 +70,11 @@ export default class RiaaEq {
       trebleCut: this.makeParam('treble', 5000),
     };
 
-    /** @private @type {dlf.media.eq.Param[]} */
+    /**
+     * @type {dlf.media.eq.Param[]}
+     *
+     * @private
+     */
     this.parameters_ = [
       this.pp.deepBaseRolloff,
       this.pp.baseBoostRolloff,
@@ -77,7 +85,11 @@ export default class RiaaEq {
     /** @private */
     this.gain_ = 1;
 
-    /** @private @type {Record<NodeKey, IIRFilter>} */
+    /**
+     * @type {Record<NodeKey, IIRFilter>}
+     *
+     * @private
+     */
     this.keyedFilters_ = this.createFilters();
 
     this.updateFilters();
@@ -179,11 +191,12 @@ export default class RiaaEq {
   }
 
   /**
-   * @private
    * @param {NodeKey} nodeKey
    * @param {number} initialFrequency
    * @param {() => [number, number]} rangeFn TODO?
    * @returns {dlf.media.eq.Param<ParamValue>}
+   *
+   * @private
    */
   makeParam(nodeKey, initialFrequency, rangeFn = () => [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) {
     return {
@@ -242,9 +255,10 @@ export default class RiaaEq {
 
   /**
    *
-   * @private
    * @param {NodeKey} nodeKey
    * @returns {IIRFilter}
+   *
+   * @private
    */
   makeFilter(nodeKey) {
     switch (nodeKey) {
@@ -331,8 +345,9 @@ export default class RiaaEq {
   /**
    * Get target gain at given {@link frequency}.
    *
-   * @private
    * @param {number} frequency
+   *
+   * @private
    */
   single(frequency) {
     let result = 0;

--- a/Resources/Private/JavaScript/SlubMediaPlayer/components/marker-table/MarkerTable.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/components/marker-table/MarkerTable.js
@@ -45,7 +45,11 @@ export default class MarkerTable extends DlfMediaPlugin {
   constructor() {
     super();
 
-    /** @private @type {Record<string, Row>} */
+    /**
+     * @type {Record<string, Row>}
+     *
+     * @private
+     */
     this.rows = {};
 
     /** @private */
@@ -54,7 +58,11 @@ export default class MarkerTable extends DlfMediaPlugin {
     /** @type {HTMLElement | null} */
     this.$container = null;
 
-    /** @private @type {Partial<import('DlfMediaPlayer/Markers').Handlers>} */
+    /**
+     * @type {Partial<import('DlfMediaPlayer/Markers').Handlers>}
+     *
+     * @private
+     */
     this.markersHandlers = {
       'remove': (event) => {
         for (const segment of event.detail.segments) {
@@ -142,9 +150,10 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
    * @param {KeyboardEvent} event
+   *
+   * @private
    */
   onLabelEditKeydown(row, event) {
     // TODO: Use global keybindings table?
@@ -154,9 +163,10 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
    * @param {Event} event
+   *
+   * @private
    */
   onLabelEditInput(row, event) {
     if (this.player === null) {
@@ -170,8 +180,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
+   *
+   * @private
    */
   onDeleteRow(row) {
     if (this.player === null) {
@@ -182,8 +193,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
+   *
+   * @private
    */
   onBookmarkRow(row) {
     if (this.player instanceof SlubMediaPlayer) {
@@ -192,8 +204,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
+   *
+   * @private
    */
   onSeekToStartTime(row) {
     if (this.player === null) {
@@ -205,8 +218,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
+   *
+   * @private
    */
   onSeekToEndTime(row) {
     if (this.player === null) {
@@ -218,8 +232,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {MouseEvent} event
+   *
+   * @private
    */
   onClear(event) {
     event.preventDefault();
@@ -235,8 +250,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {MouseEvent} event
+   *
+   * @private
    */
   onDownloadCsv(event) {
     event.preventDefault();
@@ -259,10 +275,12 @@ export default class MarkerTable extends DlfMediaPlugin {
    * Transform an event handler using a {@link Row} into an event handler that
    * can be attached to a {@link WithRow} DOM object.
    *
-   * @private
    * @template {Event} EventT
+   *
    * @param {(row: Row, event: EventT) => void} handler
    * @returns {(e: EventT) => void}
+   *
+   * @private
    */
   rowEvent(handler) {
     return (e) => {
@@ -283,8 +301,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   /**
    * Update rows for the given {@link segments}, and create rows as necessary.
    *
-   * @private
    * @param {import('DlfMediaPlayer/Markers').Segment[]} segments
+   *
+   * @private
    */
   syncSegments(segments) {
     for (const segment of segments) {
@@ -296,8 +315,9 @@ export default class MarkerTable extends DlfMediaPlugin {
    * Update row for the given {@link segment}. If no such row exists yet,
    * create one.
    *
-   * @private
    * @param {import('DlfMediaPlayer/Markers').Segment} segment
+   *
+   * @private
    */
   syncSegment(segment) {
     let isNew = false;
@@ -330,9 +350,10 @@ export default class MarkerTable extends DlfMediaPlugin {
   /**
    * Create table row object (without yet inserting).
    *
-   * @private
    * @param {import('DlfMediaPlayer/Markers').Segment} segment
    * @returns {Row}
+   *
+   * @private
    */
   createRow(segment) {
     let $tr, $id, $startTime, $endTime;
@@ -405,8 +426,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   /**
    * Insert or rearrange row into table.
    *
-   * @private
    * @param {Row} row
+   *
+   * @private
    */
   insertRow(row) {
     if (this.$body === undefined) {
@@ -429,8 +451,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {string | undefined} id
+   *
+   * @private
    */
   removeRowById(id) {
     if (id === undefined) {
@@ -458,8 +481,9 @@ export default class MarkerTable extends DlfMediaPlugin {
   }
 
   /**
-   * @private
    * @param {Row} row
+   *
+   * @private
    */
   removeRow(row) {
     row.$tr.remove();
@@ -514,10 +538,11 @@ export default class MarkerTable extends DlfMediaPlugin {
   /**
    * Compare segments for sorting in UI.
    *
-   * @private
    * @param {import('DlfMediaPlayer/Markers').Segment} lhs
    * @param {import('DlfMediaPlayer/Markers').Segment} rhs
    * @returns {number}
+   *
+   * @private
    */
   cmpSegment(lhs, rhs) {
     return (

--- a/Resources/Private/JavaScript/SlubMediaPlayer/lib/Component.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/lib/Component.js
@@ -14,26 +14,30 @@ export default class Component extends EventEmitter {
     super();
 
     /**
-     * @protected
      * @type {State}
+     *
+     * @protected
      */
     this.state = state;
 
     /**
-     * @private
      * @type {((prevState: State) => Partial<State>)[]}
+     *
+     * @private
      */
     this.pendingStateUpdates = [];
 
     /**
-     * @private
      * @type {ReturnType<setTimeout> | null}
+     *
+     * @private
      */
     this.renderTimeout = null;
 
     /**
-     * @private
      * @type {Promise<void>}
+     *
+     * @private
      */
     this.renderPromise = Promise.resolve();
   }
@@ -74,8 +78,9 @@ export default class Component extends EventEmitter {
   }
 
   /**
-   * @private
    * @returns {State}
+   *
+   * @private
    */
   squashStateUpdates() {
     const newState = Object.assign({}, this.state);
@@ -93,8 +98,10 @@ export default class Component extends EventEmitter {
    * which you may use to detect state changes.
    *
    * @abstract
-   * @protected
+   *
    * @param {State} state The updated state
+   *
+   * @protected
    */
   render(state) {
     //

--- a/Resources/Private/JavaScript/SlubMediaPlayer/modals/BookmarkModal.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/modals/BookmarkModal.js
@@ -37,7 +37,7 @@ const START_AT_MODES = /** @type {const} */(['current-time', 'marker', 'begin'])
  */
 
 /**
- * @extends {SimpleModal<State>}
+ * @auguments {SimpleModal<State>}
  */
 export default class BookmarkModal extends SimpleModal {
   /**
@@ -59,7 +59,11 @@ export default class BookmarkModal extends SimpleModal {
       showMastodonShare: false,
     });
 
-    /** @private @type {string | null} */
+    /**
+     * @type {string | null}
+     *
+     * @private
+     */
     this.lastRenderedUrl = null;
 
     /** @private */
@@ -146,9 +150,10 @@ export default class BookmarkModal extends SimpleModal {
 
   /**
    *
-   * @private
    * @param {string} radioGroup
    * @param {StartAtMode} mode
+   *
+   * @private
    */
   makeStartAtVariant(radioGroup, mode) {
     const id = this.env.mkid();
@@ -234,8 +239,9 @@ export default class BookmarkModal extends SimpleModal {
   }
 
   /**
-   * @private
    * @param {State} state
+   *
+   * @private
    */
   generateUrl(state) {
     const timerange = this.getActiveTimeRange(state);
@@ -243,9 +249,10 @@ export default class BookmarkModal extends SimpleModal {
   }
 
   /**
-   * @private
    * @param {State} state
    * @returns {dlf.media.TimeRange | null}
+   *
+   * @private
    */
   getActiveTimeRange(state) {
     switch (this.getStartAtMode(state)) {
@@ -275,6 +282,7 @@ export default class BookmarkModal extends SimpleModal {
 
   /**
    * @override
+   *
    * @param {import('SlubMediaPlayer/lib/SimpleModal').BaseState & State} state
    */
   render(state) {
@@ -360,9 +368,10 @@ export default class BookmarkModal extends SimpleModal {
   }
 
   /**
-   * @private
    * @param {Pick<State, 'startAtMode' | 'timing'>} state
    * @returns {StartAtMode}
+   *
+   * @private
    */
   getStartAtMode(state) {
     return this.isStartAtModeAllowed(state.startAtMode, state)
@@ -371,10 +380,11 @@ export default class BookmarkModal extends SimpleModal {
   }
 
   /**
-   * @private
    * @param {StartAtMode} mode
    * @param {Pick<State, 'timing'>} state
    * @returns {boolean}
+   *
+   * @private
    */
   isStartAtModeAllowed(mode, state) {
     switch (mode) {

--- a/Resources/Private/JavaScript/SlubMediaPlayer/modals/HelpModal.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/modals/HelpModal.js
@@ -85,7 +85,11 @@ export default class HelpModal extends SimpleModal {
     /** @private */
     this.config = config;
 
-    /** @private @type {TableSection[]} */
+    /**
+     * @type {TableSection[]}
+     *
+     * @private
+     */
     this.tableSections = [];
 
     this.createBodyDom();

--- a/Resources/Private/JavaScript/SlubMediaPlayer/modals/ScreenshotModal.js
+++ b/Resources/Private/JavaScript/SlubMediaPlayer/modals/ScreenshotModal.js
@@ -35,7 +35,7 @@ import UrlGenerator from 'SlubMediaPlayer/lib/UrlGenerator';
  */
 
 /**
- * @extends {SimpleModal<State>}
+ * @auguments {SimpleModal<State>}
  */
 export default class ScreenshotModal extends SimpleModal {
   /**
@@ -60,12 +60,20 @@ export default class ScreenshotModal extends SimpleModal {
 
     /** @private */
     this.env = env;
+
     /** @private */
     this.gen = new UrlGenerator(env);
-    /** @private @type {HTMLVideoElement | null} */
+
+    /**
+     * @type {HTMLVideoElement | null}
+     *
+     * @private
+     */
     this.videoDomElement = null;
+
     /** @private */
     this.config = config;
+
     /** @private */
     this.constants = typoConstants(config.constants, {
       screenshotFilenameTemplate: 'Screenshot',
@@ -196,8 +204,9 @@ export default class ScreenshotModal extends SimpleModal {
   }
 
   /**
-   * @private
    * @param {Event} e
+   *
+   * @private
    */
   handleChangeShowMetadata(e) {
     if (!(e.target instanceof HTMLInputElement)) {
@@ -210,8 +219,9 @@ export default class ScreenshotModal extends SimpleModal {
   }
 
   /**
-   * @private
    * @param {MouseEvent} e
+   *
+   * @private
    */
   async handleDownloadImage(e) {
     e.preventDefault();
@@ -296,7 +306,7 @@ export default class ScreenshotModal extends SimpleModal {
    *
    * @param {MetadataArray} metadata
    * @param {ImageFormatDesc} selectedImageFormat
-   * @return {string}
+   * @returns {string}
    */
   getFilename(metadata, selectedImageFormat) {
     const template = this.constants.screenshotFilenameTemplate;
@@ -338,6 +348,7 @@ export default class ScreenshotModal extends SimpleModal {
 
   /**
    * @override
+   *
    * @param {import('SlubMediaPlayer/lib/SimpleModal').BaseState & State} state
    */
   render(state) {

--- a/Resources/Private/JavaScript/lib/EventManager.js
+++ b/Resources/Private/JavaScript/lib/EventManager.js
@@ -18,7 +18,11 @@ import { EventTarget as FakeEventTarget } from 'DlfMediaPlayer/3rd-party/EventTa
  */
 export default class EventManager {
   constructor() {
-    /** @private @type {Listener[]} */
+    /**
+     * @type {Listener[]}
+     *
+     * @private
+     */
     this.listeners_ = [];
   }
 

--- a/Resources/Private/JavaScript/lib/Gestures.js
+++ b/Resources/Private/JavaScript/lib/Gestures.js
@@ -67,7 +67,11 @@ export default class Gestures {
    * @param {Partial<Config>} config
    */
   constructor(config = {}) {
-    /** @private @type {Config} */
+    /**
+     * @type {Config}
+     *
+     * @private
+     */
     this.config = {
       tapMaxDelay: 200,
       tapMaxDistance: 20,
@@ -77,14 +81,27 @@ export default class Gestures {
       ...config
     };
 
-    /** @private @type {Record<TapEvent['type'], Stat | null>} */
+    /**
+     * @type {Record<TapEvent['type'], Stat | null>}
+     *
+     * @private
+     */
     this.last = {
       'tapdown': null,
       'tapup': null,
     }
-    /** @private @type {ReturnType<setTimeout> | null} */
+    /**
+     * @type {ReturnType<setTimeout> | null}
+     *
+     * @private
+     * */
     this.holdTimeout = null;
-    /** @private @type {number} */
+
+    /**
+     * @type {number}
+     *
+     * @private
+     */
     this.tapCount = 0;
 
     /** @private */
@@ -137,8 +154,9 @@ export default class Gestures {
   }
 
   /**
-   * @private
    * @param {MouseEvent} _e
+   *
+   * @private
    */
   handleContextMenu(_e) {
     // Release if non-left mouse button is clicked
@@ -146,8 +164,9 @@ export default class Gestures {
   }
 
   /**
-   * @private
    * @param {PointerEvent} e
+   *
+   * @private
    */
   handlePointerDown(e) {
     // Release if non-left mouse button is clicked
@@ -182,8 +201,9 @@ export default class Gestures {
   }
 
   /**
-   * @private
    * @param {PointerEvent} e
+   *
+   * @private
    */
   handlePointerUp(e) {
     if (e.button !== 0 || !this.config.allowGesture(e)) {
@@ -236,16 +256,18 @@ export default class Gestures {
   }
 
   /**
-   * @private
    * @param {PointerEvent} _e
+   *
+   * @private
    */
   handlePointerCancel(_e) {
     this.release();
   }
 
   /**
-   * @private
    * @param {PointerEvent} _e
+   *
+   * @private
    */
   handlePointerLeave(_e) {
     const { tapdown, tapup } = this.last;
@@ -256,10 +278,11 @@ export default class Gestures {
   }
 
   /**
-   * @private
    * @param {TapEvent['type']} type
    * @param {PointerEvent} event
    * @param {Stat} stat
+   *
+   * @private
    */
   emitTap(type, event, stat) {
     this.events.emit('gesture', /** @type {TapEvent} */({
@@ -303,9 +326,10 @@ export default class Gestures {
   }
 
   /**
-   * @private
    * @param {MouseEvent} e
    * @returns {Stat}
+   *
+   * @private
    */
   getStat(e) {
     const bounding = /** @type {HTMLElement} */(e.target).getBoundingClientRect();

--- a/Resources/Public/JavaScript/PageView/AltoParser.js
+++ b/Resources/Public/JavaScript/PageView/AltoParser.js
@@ -17,7 +17,14 @@
  */
 
 /**
- * @constructor
+ * This class parses an ALTO XML document and creates OpenLayers features with geometries and properties for the page,
+ * print space, text blocks, text lines and strings.
+ * The parser can be initialized with an image object, width, height and offset for rescaling the coordinates of the features.
+ * If the page dimensions are given in the ALTO, they will be used for rescaling the coordinates.
+ * Otherwise, the provided width and height will be used. If no dimensions are given, the coordinates will not be rescaled.
+ *
+ * @class
+ *
  * @param {Object=} optImageObj
  * @param {number=} optWidth
  * @param {number=} optHeight
@@ -26,25 +33,29 @@
 var dlfAltoParser = function(optImageObj, optWidth, optHeight, optOffset) {
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.image_ = dlfUtils.exists(optImageObj) ? optImageObj : undefined;
 
     /**
      * @type {number|undefined}
+     *
      * @private
      */
     this.width_ = dlfUtils.exists(optWidth) ? optWidth : undefined;
 
     /**
      * @type {number|undefined}
+     *
      * @private
      */
     this.height_ = dlfUtils.exists(optHeight) ? optHeight : undefined;
 
     /**
      * @type {number|undefined}
+     *
      * @private
      */
     this.offset_ = dlfUtils.exists(optOffset) ? optOffset : undefined;
@@ -53,6 +64,8 @@ var dlfAltoParser = function(optImageObj, optWidth, optHeight, optOffset) {
 /**
  * @param {number} hpos
  * @param {number} vpos
+ * @returns {string}
+ *
  * @private
  */
 dlfAltoParser.prototype.generateId_ = function(hpos, vpos) {
@@ -61,8 +74,10 @@ dlfAltoParser.prototype.generateId_ = function(hpos, vpos) {
 
 /**
  * Parse from an alto element a OpenLayers feature object. This function does reproduce the parsing hierarchy of this parser.
+ *
  * @param {Element} node
- * @return {ol.Feature}
+ * @returns {ol.Feature}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseAltoFeature_ = function(node) {
@@ -113,7 +128,7 @@ dlfAltoParser.prototype.parseAltoFeature_ = function(node) {
 
 /**
  * @param {XMLDocument|string} document
- * @return {Array.<FullTextFeature>}
+ * @returns {array.<FullTextFeature>}
  */
 dlfAltoParser.prototype.parseFeatures = function(document) {
     var parsedDoc = this.parseXML_(document),
@@ -125,8 +140,9 @@ dlfAltoParser.prototype.parseFeatures = function(document) {
         var feature = this.parseAltoFeature_(pageElements[i]);
 
         /**
-         * Attach function for a better access of of string elements
-         * @return {Array}
+         * Attach function for a better access of string elements
+         *
+         * @returns {array}
          */
         feature.getStringFeatures = function() {
             var textblockFeatures = this.get('printspace').get('textblocks'),
@@ -160,7 +176,8 @@ dlfAltoParser.prototype.parseFeatures = function(document) {
 
         /**
          * Add function for getting the text blocks
-         * @return {Array}
+         *
+         * @returns {array}
          */
         feature.getTextblocks = function() {
             if (this.get('printspace') !== undefined && this.get('printspace').get('textblocks')) {
@@ -171,7 +188,8 @@ dlfAltoParser.prototype.parseFeatures = function(document) {
 
         /**
          * Adding function for getting the textline
-         * @return {Array}
+         *
+         * @returns {array}
          */
         feature.getTextlines = function() {
             var textlines = [];
@@ -189,8 +207,10 @@ dlfAltoParser.prototype.parseFeatures = function(document) {
 
 /**
  * Parse from an alto element a OpenLayers feature object
+ *
  * @param {Element} node
- * @return {ol.Feature}
+ * @returns {ol.Feature}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseFeatureWithGeometry_ = function(node) {
@@ -217,8 +237,10 @@ dlfAltoParser.prototype.parseFeatureWithGeometry_ = function(node) {
 
 /**
  * Parse from an alto element a OpenLayers geometry object
+ *
  * @param {Element} node
  * @return {ol.geom.Polygon|undefined}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseGeometry_ = function(node) {
@@ -256,7 +278,8 @@ dlfAltoParser.prototype.parseGeometry_ = function(node) {
 
 /**
  * @param {Element} node
- * @return {ol.Feature|undefined}
+ * @returns {ol.Feature|undefined}
+ *
  * @private
  */
 dlfAltoParser.prototype.parsePrintSpaceFeature_ = function(node) {
@@ -271,6 +294,7 @@ dlfAltoParser.prototype.parsePrintSpaceFeature_ = function(node) {
 /**
  * @param {Element} node
  * @return {Array.<ol.Feature>}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseTextBlockFeatures_ = function(node) {
@@ -297,6 +321,7 @@ dlfAltoParser.prototype.parseTextBlockFeatures_ = function(node) {
 /**
  * @param {Element} node
  * @return {Array.<ol.Feature>}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseTextLineFeatures_ = function(node) {
@@ -322,7 +347,8 @@ dlfAltoParser.prototype.parseTextLineFeatures_ = function(node) {
 
 /**
  * @param {Element} node
- * @return {Array.<ol.Feature>}
+ * @return {array.<ol.Feature>}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseContentFeatures_ = function(node) {
@@ -357,8 +383,9 @@ dlfAltoParser.prototype.parseContentFeatures_ = function(node) {
 
 /**
  *
- * @param {Element}
- * @return {string}
+ * @param {Element} textLineContentElement
+ * @returns {string}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseString_ = function(textLineContentElement) {
@@ -374,8 +401,9 @@ dlfAltoParser.prototype.parseString_ = function(textLineContentElement) {
 
 /**
  *
- * @param {XMLDocument|string}
- * @return {XMLDocument}
+ * @param {XMLDocument|string} document
+ * @returns {XMLDocument}
+ *
  * @private
  */
 dlfAltoParser.prototype.parseXML_ = function(document) {

--- a/Resources/Public/JavaScript/PageView/AnnotationParser.js
+++ b/Resources/Public/JavaScript/PageView/AnnotationParser.js
@@ -20,25 +20,29 @@ var DlfIiifAnnotationParser = function(optImageObj, optWidth, optHeight, optOffs
     // get width and height either from image info.json or from canvas information
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.image_ = dlfUtils.exists(optImageObj) ? optImageObj : undefined;
 
     /**
      * @type {number|undefined}
+     *
      * @private
      */
     this.width_ = dlfUtils.exists(optWidth) ? optWidth : undefined;
 
     /**
      * @type {number|undefined}
+     *
      * @private
      */
     this.height_ = dlfUtils.exists(optHeight) ? optHeight : undefined;
 
     /**
      * @type {number|undefined}
+     *
      * @private
      */
     this.offset_ = dlfUtils.exists(optOffset) ? optOffset : undefined;
@@ -49,6 +53,7 @@ var DlfIiifAnnotationParser = function(optImageObj, optWidth, optHeight, optOffs
  * @param {number} height
  * @param {number} hpos
  * @param {number} vpos
+ *
  * @private
  */
 DlfIiifAnnotationParser.prototype.generateId_ = function(width, height, hpos, vpos) {
@@ -59,7 +64,8 @@ DlfIiifAnnotationParser.prototype.generateId_ = function(width, height, hpos, vp
 /**
  * Create an OpenLayers Feature from a IIIF Annotation
  * @param {Object} annotation
- * @return {ol.Feature}
+ * @returns {ol.Feature}
+ *
  * @private
  */
 DlfIiifAnnotationParser.prototype.parseAnnotation = function(annotation) {
@@ -170,7 +176,7 @@ DlfIiifAnnotationParser.prototype.parseGeometry = function(annotation) {
 /**
  * Get position and dimension from the fragment identifier of the on-uri or from the canvas dimension
  * @param {Object} annotation
- * @return {Object}
+ * @returns {Object}
  * @private
  */
 DlfIiifAnnotationParser.prototype.getXYWHForAnnotation = function (annotation) {
@@ -200,7 +206,7 @@ DlfIiifAnnotationParser.prototype.getXYWHForAnnotation = function (annotation) {
 /**
  * Remove any fragment from the uri
  * @param {string} uri
- * @return {string|null}
+ * @returns {string|null}
  * @private
  */
 DlfIiifAnnotationParser.getTargetIdentifierWithoutFragment = function(uri) {

--- a/Resources/Public/JavaScript/PageView/FullTextUtility.js
+++ b/Resources/Public/JavaScript/PageView/FullTextUtility.js
@@ -15,7 +15,7 @@
  /**
  * Base namespace for utility functions used by the dlf module.
  *
- * @const
+ * @constant
  */
 var dlfFullTextUtils;
 dlfFullTextUtils = dlfFullTextUtils || {};
@@ -23,7 +23,7 @@ dlfFullTextUtils = dlfFullTextUtils || {};
 /**
  * Get feature from given source
  * @param {Object} source
- * @return {ol.Feature|undefined}
+ * @returns {ol.Feature|undefined}
  * @static
  */
 dlfFullTextUtils.getFeature = function(source){
@@ -34,7 +34,7 @@ dlfFullTextUtils.getFeature = function(source){
  * Check if given element is equal to given feature
  * @param {Object} element
  * @param {Object} feature
- * @return {boolean}
+ * @returns {boolean}
  * @static
  */
 dlfFullTextUtils.isFeatureEqual = function(element, feature){
@@ -82,7 +82,7 @@ dlfFullTextUtils.fetchFullTextDataFromServer = function(fulltext, image, optOffs
  * @param {Object} image
  * @param {number=} offset
  * @param {Object} request
- * @return {FullTextFeature | undefined}
+ * @returns {FullTextFeature | undefined}
  * @static
  */
 dlfFullTextUtils.parseAltoData = function(image, offset, request){

--- a/Resources/Public/JavaScript/PageView/FulltextControl.js
+++ b/Resources/Public/JavaScript/PageView/FulltextControl.js
@@ -67,7 +67,7 @@ dlfFulltextSegments.prototype.coordinateToFeature = function (coordinate) {
 
 /**
  * Encapsulates especially the fulltext behavior
- * @constructor
+ * @class
  * @param {ol.Map} map
  */
 var dlfViewerFullTextControl = function(map) {
@@ -85,7 +85,7 @@ var dlfViewerFullTextControl = function(map) {
     this.map = map;
 
     /**
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this.dic = $(this.button).length > 0 && $(this.button).data('dic') ?
@@ -123,7 +123,7 @@ var dlfViewerFullTextControl = function(map) {
     }
 
     /**
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this.layers_ = {
@@ -186,7 +186,7 @@ var dlfViewerFullTextControl = function(map) {
     this.textblocks_ = new dlfFulltextSegments();
 
     /**
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this.handlers_ = {
@@ -534,7 +534,7 @@ dlfViewerFullTextControl.prototype.deactivate = function() {
 /**
  * Disable Fulltext Features
  *
- * @return void
+ * @returns {void}
  */
 dlfViewerFullTextControl.prototype.disableFulltextSelect = function() {
 
@@ -606,7 +606,7 @@ dlfTmplFulltext.space.className = "sp";
 /**
  * Show full text
  *
- * @param {Array.<ol.Feature>|undefined} features
+ * @param {array.<ol.Feature>|undefined} features
  */
 dlfViewerFullTextControl.prototype.showFulltext = function(features) {
     if (features === undefined) {

--- a/Resources/Public/JavaScript/PageView/ImageManipulationControl.js
+++ b/Resources/Public/JavaScript/PageView/ImageManipulationControl.js
@@ -9,7 +9,7 @@
  */
 
 /**
- * @constructor
+ * @class
  * @param {Object=} options Control options.
  *  {Element} target
  *  {ol.Map} map
@@ -23,7 +23,7 @@ dlfViewerImageManipulationControl = function(options) {
     this.counter = dlfUtils.exists(options.counter) ? options.counter : 0;
 
     /**
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this.dic = $('#tx-dlf-tools-imagemanipulation').length > 0 && $('#tx-dlf-tools-imagemanipulation').attr('data-dic') ?
@@ -80,13 +80,13 @@ dlfViewerImageManipulationControl = function(options) {
     };
 
     /**
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this.filters_ = $.extend({}, FILTERS_DEFAULT_);
 
     /**
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this.handler_ = {
@@ -236,7 +236,7 @@ dlfViewerImageManipulationControl.prototype.createFilters_ = function() {
  * @param {string} className
  * @param {string} orientation
  * @param {string} key
- * @param {Array.<number>|undefined} opt_baseValue
+ * @param {array.<number>|undefined} optBaseValues
  * @param {string=} optTitle
  * @param {Function=} optLabelFn
  * @return {Element}
@@ -314,7 +314,7 @@ dlfViewerImageManipulationControl.prototype.deactivate = function(){
 /**
  * Function checks if the image manipulation is in active state or not.
  *
- * @return {boolean}
+ * @returns {boolean}
  */
 dlfViewerImageManipulationControl.prototype.isActive = function() {
     return $(this.anchor_).hasClass('active');
@@ -336,8 +336,10 @@ dlfViewerImageManipulationControl.prototype.setFilter_ = function (filter, value
  *
  * @param {string} filter
  * @param {number} value
+ *
+ * @returns {string}
+ *
  * @private
- * @return {string}
  */
 dlfViewerImageManipulationControl.prototype.valueToCss_ = function (filter, value) {
     switch (filter) {

--- a/Resources/Public/JavaScript/PageView/OL.js
+++ b/Resources/Public/JavaScript/PageView/OL.js
@@ -9,7 +9,7 @@
  */
 
 /**
- * @return {number|undefined}
+ * @returns {number|undefined}
  */
 ol.Map.prototype.getZoom = function(){
     return this.getView().getZoom();

--- a/Resources/Public/JavaScript/PageView/OLSources.js
+++ b/Resources/Public/JavaScript/PageView/OLSources.js
@@ -23,7 +23,8 @@ dlfViewerSource.IIIF = {};
  * Returns an iiif compatible metadata url.
  *
  * @param {string} baseUrl
- * @return {string}
+ *
+ * @returns {string}
  */
 dlfViewerSource.IIIF.getMetdadataURL = function(baseUrl) {
     var pathString = baseUrl.lastIndexOf('/') + 1 === baseUrl.length
@@ -42,7 +43,8 @@ dlfViewerSource.IIP = {};
  * Returns an iip compatible metadata url.
  *
  * @param {string} baseUrl
- * @return {string}
+ *
+ * @returns {string}
  */
 dlfViewerSource.IIP.getMetdadataURL = function(baseUrl) {
     var queryString = '&obj=IIP,1.0&obj=Max-size&obj=Tile-size&obj=Resolution-number',
@@ -56,7 +58,8 @@ dlfViewerSource.IIP.getMetdadataURL = function(baseUrl) {
  * Function parses a given string response for a iip metadata request.
  *
  * @param {string} metadataString
- * @return {Object}
+ *
+ * @returns {object}
  */
 dlfViewerSource.IIP.parseMetadata = function(metadataString) {
 

--- a/Resources/Public/JavaScript/PageView/OLStyles.js
+++ b/Resources/Public/JavaScript/PageView/OLStyles.js
@@ -9,13 +9,14 @@
  */
 
 /**
- * @const
  * @namespace
+ *
+ * @constant
  */
 dlfViewerOLStyles = {};
 
 /**
- * @return {ol.style.Style}
+ * @returns {ol.style.Style}
  */
 dlfViewerOLStyles.defaultStyle = function() {
 
@@ -32,7 +33,7 @@ dlfViewerOLStyles.defaultStyle = function() {
 };
 
 /**
- * @return {ol.style.Style}
+ * @returns {ol.style.Style}
  */
 dlfViewerOLStyles.hoverStyle = function() {
 
@@ -49,7 +50,7 @@ dlfViewerOLStyles.hoverStyle = function() {
 };
 
 /**
- * @return {ol.style.Style}
+ * @returns {ol.style.Style}
  */
 dlfViewerOLStyles.invisibleStyle = function() {
 
@@ -66,7 +67,7 @@ dlfViewerOLStyles.invisibleStyle = function() {
 };
 
 /**
- * @return {ol.style.Style}
+ * @returns {ol.style.Style}
  */
 dlfViewerOLStyles.selectStyle = function() {
 
@@ -83,7 +84,7 @@ dlfViewerOLStyles.selectStyle = function() {
 };
 
 /**
- * @return {ol.style.Style}
+ * @returns {ol.style.Style}
  */
 dlfViewerOLStyles.textlineStyle = function() {
 
@@ -97,7 +98,7 @@ dlfViewerOLStyles.textlineStyle = function() {
 };
 
 /**
- * @return {ol.style.Style}
+ * @returns {ol.style.Style}
  */
 dlfViewerOLStyles.wordStyle = function() {
 

--- a/Resources/Public/JavaScript/PageView/PageView.js
+++ b/Resources/Public/JavaScript/PageView/PageView.js
@@ -42,21 +42,26 @@
  */
 
 /**
- * @TODO Trigger resize map event after fullscreen is toggled
+ * @class
+ *
  * @param {DlfViewerConfig} settings
- * @constructor
+ *
+ * @todo Trigger resize map event after fullscreen is toggled
  */
 var dlfViewer = function (settings) {
 
     /**
      * The element id of the map container
+     *
      * @type {string}
+     *
      * @private
      */
     this.div = dlfUtils.exists(settings.div) ? settings.div : "tx-dlf-map";
 
     /**
      * @type {Record<'overview-map', string>}
+     *
      * @private
      */
     this.dic = $.extend({
@@ -65,28 +70,36 @@ var dlfViewer = function (settings) {
 
     /**
      * Openlayers map object
+     *
      * @type {ol.Map|null}
+     *
      * @private
      */
     this.map = null;
 
     /**
      * Contains image information (e.g. URL, width, height)
+     *
      * @type {DlfViewerConfig['images']}
+     *
      * @private
      */
     this.imageUrls = dlfUtils.exists(settings.images) ? settings.images : [];
 
     /**
      * Contains image information (e.g. URL, width, height)
+     *
      * @type {Array.<{src: *, width: *, height: *}>}
+     *
      * @private
      */
     this.images = [];
 
     /**
      * Score information (e.g. URL)
+     *
      * @type {string}
+     *
      * @private
      */
     this.score = dlfUtils.exists(settings.score['url']) ? settings.score['url'] : '';
@@ -111,141 +124,168 @@ var dlfViewer = function (settings) {
 
     /**
      * Id of pagebeginning in score
+     *
      * @type {string}
+     *
      * @private
      */
     this.pagebeginning = dlfUtils.exists(settings.score['pagebeginning']) ? settings.score['pagebeginning'] : '';
 
     /**
      * The <progress> element for loading indicator.
+     *
      * @type {LoadingIndicator}
+     *
      * @private
      */
     this.loadingIndicator = this.makeLoadingIndicator(settings.progressElementId);
 
     /**
      * Fulltext information (e.g. URL)
+     *
      * @type {Array.<string|?>}
+     *
      * @private
      */
     this.fulltexts = dlfUtils.exists(settings.fulltexts) ? settings.fulltexts : [];
 
     /**
      * Loaded scores (as jQuery deferred object).
+     *
      * @type {svg}
+     *
      * @private
      */
     this.scoresLoaded_ = null;
 
     /**
      * Loaded fulltexts (as jQuery deferred object).
+     *
      * @type {JQueryStatic.Deferred[]}
+     *
      * @private
      */
     this.fulltextsLoaded_ = [];
 
     /**
      * IIIF annotation lists URLs for the current canvas
-     * @type {Array.<string|?>}
+     *
+     * @type {array.<string|?>}
+     *
      * @private
      */
     this.annotationContainers = dlfUtils.exists(settings.annotationContainers) ? settings.annotationContainers : [];
 
     /**
-     * @type {Array.<number>}
+     * @type {array.<number>}
+     *
      * @private
      */
     this.highlightFields = [];
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.highlightFieldParams = undefined;
 
     /**
      * @type {string|undefined}
+     *
      * @private
      */
      this.highlightWords = null;
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.imageManipulationControl = undefined;
 
     this.syncControl = undefined;
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.selection = undefined;
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.source = undefined;
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.selectionLayer = undefined;
 
     /**
-     * @type {Object|undefined}
+     * @type {object|undefined}
+     *
      * @private
      */
     this.draw = undefined;
 
     /**
-     * @type {Object|null}
+     * @type {object|null}
+     *
      * @private
      */
     this.source = null;
 
     /**
-     * @type {Object|null}
+     * @type {object|null}
+     *
      * @private
      */
     this.view = null;
 
     /**
-     * @type {Object|null}
+     * @type {object|null}
+     *
      * @private
      */
     this.ovView = null;
 
     /**
-     * @type {Boolean|false}
+     * @type {boolean|false}
+     *
      * @private
      */
     this.magnifierEnabled = false;
 
-
     /**
-     * @type {Object}
+     * @type {object}
+     *
      * @public
      */
      this.tk = null;
 
     /**
-     * @type {Boolean|false}
+     * @type {boolean|false}
+     *
      * @private
      */
     this.initMagnifier = false;
 
     /**
      *
-     * @type {Object|null}
+     * @type {object|null}
      */
     this.view = null;
 
     /**
      * use internal proxy setting
+     *
      * @type {boolean}
+     *
      * @private
      */
     this.useInternalProxy = dlfUtils.exists(settings.useInternalProxy) ? settings.useInternalProxy : false;
@@ -255,7 +295,7 @@ var dlfViewer = function (settings) {
 
 /**
  *
- * @param {string | undefined}
+ * @param {string|undefined} progressElementId
  * @returns {LoadingIndicator}
  */
 dlfViewer.prototype.makeLoadingIndicator = function (progressElementId) {
@@ -650,12 +690,11 @@ dlfViewer.prototype.addCustomControls = function(image) {
 /**
  * Add highlight field
  *
- * @param {Array.<number>} highlightField
+ * @param {array.<number>} highlightField
  * @param {number} imageIndex
  * @param {number} width
  * @param {number} height
- *
- * @returns void
+ * @returns {void}
  */
 dlfViewer.prototype.addHighlightField = function(highlightField, imageIndex, width, height) {
 
@@ -674,9 +713,11 @@ dlfViewer.prototype.addHighlightField = function(highlightField, imageIndex, wid
 
 /**
  * Creates OpenLayers controls
- * @param {Array.<string>} controlNames
- * @param {Array.<ol.layer.Layer>} layers
- * @returns {Array.<ol.control.Control>}
+ *
+ * @param {array.<string>} controlNames
+ * @param {array.<ol.layer.Layer>} layers
+ * @returns {array.<ol.control.Control>}
+ *
  * @private
  */
 dlfViewer.prototype.createControls_ = function(controlNames, layers) {
@@ -699,8 +740,9 @@ dlfViewer.prototype.createControls_ = function(controlNames, layers) {
  * If `null` is returned, the control is omitted.
  *
  * @param {string} controlName
- * @param {Array.<ol.layer.Layer>} layers
+ * @param {array.<ol.layer.Layer>} layers
  * @returns {ol.control.Control | null}
+ *
  * @protected
  */
 dlfViewer.prototype.createControl = function(controlName, layers) {
@@ -743,9 +785,10 @@ dlfViewer.prototype.createControl = function(controlName, layers) {
 /**
  * Forwards the search to dlfUtils.searchFeatureCollectionForWords
  *
- * @param {Array.<ol.Feature>} stringFeatures - Array of features containing text information
+ * @param {array.<ol.Feature>} stringFeatures - Array of features containing text information
  * @param {string} value - Search term
- * @returns {Array.<ol.Feature>|undefined} Array of OpenLayers features containing found words
+ * @returns {array.<ol.Feature>|undefined} Array of OpenLayers features containing found words
+ *
  * @see dlfUtils.searchFeatureCollectionForWords
  */
 dlfViewer.prototype.searchFeatures = function(stringFeatures, value) {
@@ -834,7 +877,8 @@ dlfViewer.prototype.displayHighlightWord = function(highlightWords = null) {
 /**
  * Start the init process of loading the map, etc.
  *
- * @param {Array.<string>} controlNames
+ * @param {array.<string>} controlNames
+ *
  * @private
  */
 dlfViewer.prototype.init = function(controlNames) {
@@ -946,7 +990,8 @@ dlfViewer.prototype.updateLayerSize = function() {
  * Generate the OpenLayers layer objects for given image sources. Returns a promise / jQuery deferred object.
  *
  * @param {ImageDesc[]} imageSourceObjs
- * @returns {jQuery.Deferred.<function(Array.<ol.layer.Layer>)>}
+ * @returns {jQuery.Deferred.<function(array.<ol.layer.Layer>)>}
+ *
  * @private
  */
 dlfViewer.prototype.initLayer = function(imageSourceObjs) {
@@ -954,8 +999,8 @@ dlfViewer.prototype.initLayer = function(imageSourceObjs) {
     // use deferred for async behavior
     var deferredResponse = new $.Deferred(),
       /**
-       * @param {Array.<{src: *, width: *, height: *}>} imageSourceData
-       * @param {Array.<ol.layer.Layer>} layers
+       * @param {array.<{src: *, width: *, height: *}>} imageSourceData
+       * @param {array.<ol.layer.Layer>} layers
        */
       resolveCallback = $.proxy(function(imageSourceData, layers) {
             this.images = imageSourceData;
@@ -1191,26 +1236,29 @@ function Drag() {
 
     /**
      * @type {ol.Pixel}
+     *
      * @private
      */
     this.coordinate_ = null;
 
     /**
      * @type {string|undefined}
+     *
      * @private
      */
     this.cursor_ = 'pointer';
 
     /**
      * @type {ol.Feature}
+     *
      * @private
      */
     this.feature_ = null;
 
     /**
      * @type {string|undefined}
+     *
      * @private
      */
     this.previousCursor_ = undefined;
-
-};
+}

--- a/Resources/Public/JavaScript/PageView/ScoreControl.js
+++ b/Resources/Public/JavaScript/PageView/ScoreControl.js
@@ -116,7 +116,9 @@ dlfScoreUtil.fetchScoreDataFromServer = function (image, scoreUrl, pagebeginning
 
 /**
  * Encapsulates especially the score behavior
+ *
  * @class
+ *
  * @param dlfViewer
  * @param pagebeginning
  * @param pagecount
@@ -126,24 +128,27 @@ const dlfViewerScoreControl = function (dlfViewer, pagebeginning, pagecount) {
   this.dlfViewer = dlfViewer;
 
   /**
-   *@ type(number)
+   * @type {number}
    */
   this.pagecount = pagecount;
 
   /**
    * @type {number}
+   *
    * @private
    */
   this.position = 0;
 
   /**
    * @type {string}
+   *
    * @private
    */
   this.pagebeginning = pagebeginning;
 
   /**
-   * @type {Object}
+   * @type {object}
+   *
    * @private
    */
   this.dic = $('#tx-dlf-tools-score-' + this.dlfViewer.counter).length > 0 && $('#tx-dlf-tools-score-' + this.dlfViewer.counter).attr('data-dic') ?
@@ -366,6 +371,7 @@ dlfViewerScoreControl.prototype.loadScoreData = function (image, scoreData, tk) 
 
     /**
      * Get the font name
+     *
      * @param {string} family
      * @param {string} bold
      * @param {string} italic
@@ -526,7 +532,7 @@ dlfViewerScoreControl.prototype.deactivate = function () {
 /**
  * Disable Score Features
  *
- * @return void
+ * @returns {void}
  */
 dlfViewerScoreControl.prototype.disableScoreSelect = function () {
 

--- a/Resources/Public/JavaScript/PageView/ScoreUtility.js
+++ b/Resources/Public/JavaScript/PageView/ScoreUtility.js
@@ -13,7 +13,7 @@
 /**
  * Base namespace for utility functions used by the dlf module.
  *
- * @const
+ * @constant
  */
 let dlfScoreUtils;
 dlfScoreUtils = dlfScoreUtils || {};
@@ -59,6 +59,7 @@ dlfScoreUtil.parseGeometry_ = function(node) {
  * Parse from an alto element a OpenLayers feature object ulx, uly, lrx, lry
  * @param {Element} node
  * @returns {ol.Feature}
+ *
  * @private
  */
 dlfScoreUtil.parseFeatureWithGeometry_ = function(node) {

--- a/Resources/Public/JavaScript/PageView/SearchInDocument.js
+++ b/Resources/Public/JavaScript/PageView/SearchInDocument.js
@@ -12,7 +12,7 @@
  * This function increases the start parameter of the search form and submits
  * the form.
  *
- * @returns void
+ * @returns {void}
  */
 function nextResultPage() {
     var currentStart = $("#tx-dlf-toolbox-searchindocument-form input[id='tx-dlf-toolbox-searchindocument-input-start']").val();
@@ -25,7 +25,7 @@ function nextResultPage() {
  * This function decreases the start parameter of the search form and submits
  * the form.
  *
- * @returns void
+ * @returns {void}
  */
 function previousResultPage() {
     var currentStart = $("#tx-dlf-toolbox-searchindocument-form input[id='tx-dlf-toolbox-searchindocument-input-start']").val();
@@ -37,7 +37,7 @@ function previousResultPage() {
 /**
  * This function resets the start parameter on new queries.
  *
- * @returns void
+ * @returns {void}
  */
 function resetStart() {
     $("#tx-dlf-toolbox-searchindocument-form input[id='tx-dlf-toolbox-searchindocument-input-start']").val(0);
@@ -45,9 +45,9 @@ function resetStart() {
 
 /**
  * Add highlight effect for found search phrase.
- * @param {array} highlightIds
  *
- * @returns void
+ * @param {array} highlightIds
+ * @returns {void}
  */
 function addHighlightEffect(highlightIds) {
     if (highlightIds.length > 0) {
@@ -175,8 +175,7 @@ function getCurrentPage() {
  *
  * @param {array} data
  * @param {string} word
- *
- * @returns void
+ * @returns {void}
  */
 function addImageHighlight(data, word) {
     var page = getCurrentPage();
@@ -202,7 +201,7 @@ function addImageHighlight(data, word) {
 /**
  * Trigger search for document loaded from hit list.
  *
- * @returns void
+ * @returns {void}
  */
 function triggerSearchAfterHitLoad() {
     var queryParams = getCurrentQueryParams(getBaseUrl(" "));

--- a/Resources/Public/JavaScript/PageView/TeiParser.js
+++ b/Resources/Public/JavaScript/PageView/TeiParser.js
@@ -66,6 +66,7 @@ dlfTeiParser.prototype.parse = function(document) {
 
 /**
  * @returns {string}
+ *
  * @private
  */
 dlfTeiParser.prototype.getFacsMapId = function() {
@@ -79,6 +80,7 @@ dlfTeiParser.prototype.getFacsMapId = function() {
  *
  * @param {XMLDocument|string} document
  * @returns {XMLDocument}
+ *
  * @private
  */
 dlfTeiParser.prototype.parseXML = function(document) {

--- a/Resources/Public/JavaScript/PageView/Utility.js
+++ b/Resources/Public/JavaScript/PageView/Utility.js
@@ -25,7 +25,7 @@ if (String.prototype.endsWith === undefined) {
 /**
  * Base namespace for utility functions used by the dlf module.
  *
- * @const
+ * @constant
  */
 var dlfUtils;
 dlfUtils = dlfUtils || {};
@@ -535,7 +535,7 @@ dlfUtils.getUrlParam = function (param) {
 /**
  * Check if an array (possibly nested) contains at least one non-empty value.
  *
- * @param {Array} arr - The array to check (may be nested).
+ * @param {array} arr - The array to check (may be nested).
  * @returns {boolean} True if at least one non-empty value exists, false otherwise.
  */
 dlfUtils.hasContent = function(arr) {
@@ -555,6 +555,7 @@ dlfUtils.hasContent = function(arr) {
 
 /**
  * Returns true if the specified value is null.
+ *
  * @param {?} val
  * @returns {boolean}
  */
@@ -564,6 +565,7 @@ dlfUtils.isNull = function (val) {
 
 /**
  * Returns true if the specified value is null, empty or undefined.
+ *
  * @param {?} val
  * @returns {boolean}
  */
@@ -589,6 +591,7 @@ dlfUtils.isFulltextDescriptor = function (obj) {
 
 /**
  * Check if body has the class 'multiviewembedded'
+ *
  * @returns {boolean}
  */
 dlfUtils.isMultiViewEmbedded = function () {
@@ -619,7 +622,6 @@ dlfUtils.parseDataDic = function (element) {
  * @param {string} name The key of the value
  * @param {?} value The value to save
  * @param {string} samesite Sets the SameSite attribute: lax, strict or none
- *
  */
 dlfUtils.setCookie = function (name, value, samesite) {
     switch(samesite) {
@@ -639,13 +641,13 @@ dlfUtils.setCookie = function (name, value, samesite) {
 /**
  * Scales down the given features geometries.
  * As a further improvement this function adds a unique ID to every feature.
- * @param {Array.<ol.Feature>} features
- * @param {Object} imageObj
+ * @param {array.<ol.Feature>} features
+ * @param {object} imageObj
  * @param {number} width
  * @param {number} height
  * @param {number=} optOffset
  * @deprecated
- * @returns {Array.<ol.Feature>}
+ * @returns {array.<ol.Feature>}
  */
 dlfUtils.scaleToImageSize = function (features, imageObj, width, height, optOffset) {
 
@@ -692,6 +694,7 @@ dlfUtils.scaleToImageSize = function (features, imageObj, width, height, optOffs
 
 /**
  * Search a feature collection for a feature with the given coordinates
+ *
  * @param {Array.<ol.Feature>} featureCollection
  * @param {string} coordinates for highlighting
  * @returns {Array.<ol.Feature>|undefined}
@@ -710,6 +713,7 @@ dlfUtils.searchFeatureCollectionForCoordinates = function (featureCollection, co
 
 /**
  * Search a feature collection for a feature with the given word in its fulltext
+ *
  * @param {Array.<ol.Feature>} featureCollection
  * @param {string} word for highlighting
  * @returns {Array.<ol.Feature>|undefined}
@@ -728,6 +732,7 @@ dlfUtils.searchFeatureCollectionForWords = function (featureCollection, word) {
 
 /**
  * Append dlf url parameter and reload
+ *
  * @param {string} parameterName Name of the dlf parameter
  * @param {string} parameterValue Value of the dlf parameter
  * @param {boolean} forceDelete Delete parameter before appending

--- a/Resources/Public/JavaScript/ValidationForm/ValidationForm.js
+++ b/Resources/Public/JavaScript/ValidationForm/ValidationForm.js
@@ -86,7 +86,7 @@ dlfValidationForms.forEach((validationForm) => {
     }
 
     /**
-     * Create the messages container.
+     * Create the messages' container.
      *
      * @param {string} type of callout class
      * @param {Array} messages of type

--- a/Resources/Public/JavaScript/Verovio/pdfkit.js
+++ b/Resources/Public/JavaScript/Verovio/pdfkit.js
@@ -15081,7 +15081,7 @@ module.exports = deprecate;
  * will invoke `console.trace()` instead of `console.error()`.
  *
  * @param {Function} fn - the function to deprecate
- * @param {String} msg - the string to print to the console when `fn` is invoked
+ * @param {string} msg - the string to print to the console when `fn` is invoked
  * @returns {Function} a new "deprecated" version of `fn`
  * @api public
  */
@@ -15112,8 +15112,8 @@ function deprecate (fn, msg) {
 /**
  * Checks `localStorage` for boolean values for the given `name`.
  *
- * @param {String} name
- * @returns {Boolean}
+ * @param {string} name
+ * @returns {boolean}
  * @api private
  */
 
@@ -21332,8 +21332,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Creates shortcut functions to a cipher's object interface.
 	         *
 	         * @param {Cipher} cipher The cipher to create a helper for.
-	         *
-	         * @return {Object} An object with encrypt and decrypt shortcut functions.
+	         * @returns {object} An object with encrypt and decrypt shortcut functions.
 	         *
 	         * @static
 	         *
@@ -21393,7 +21392,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Creates this mode for encryption.
 	         *
 	         * @param {Cipher} cipher A block cipher instance.
-	         * @param {Array} iv The IV words.
+	         * @param {array} iv The IV words.
 	         *
 	         * @static
 	         *
@@ -21409,7 +21408,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Creates this mode for decryption.
 	         *
 	         * @param {Cipher} cipher A block cipher instance.
-	         * @param {Array} iv The IV words.
+	         * @param {array} iv The IV words.
 	         *
 	         * @static
 	         *
@@ -21425,7 +21424,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Initializes a newly created mode.
 	         *
 	         * @param {Cipher} cipher A block cipher instance.
-	         * @param {Array} iv The IV words.
+	         * @param {array} iv The IV words.
 	         *
 	         * @example
 	         *
@@ -21453,7 +21452,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	            /**
 	             * Processes the data block at offset.
 	             *
-	             * @param {Array} words The data words to operate on.
+	             * @param {array} words The data words to operate on.
 	             * @param {number} offset The offset where the block starts.
 	             *
 	             * @example
@@ -21481,7 +21480,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	            /**
 	             * Processes the data block at offset.
 	             *
-	             * @param {Array} words The data words to operate on.
+	             * @param {array} words The data words to operate on.
 	             * @param {number} offset The offset where the block starts.
 	             *
 	             * @example
@@ -21709,8 +21708,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts this cipher params object to a string.
 	         *
 	         * @param {Format} formatter (Optional) The formatting strategy to use.
-	         *
-	         * @return {string} The stringified cipher params.
+	         * @returns {string} The stringified cipher params.
 	         *
 	         * @throws Error If neither the formatter nor the default formatter is set.
 	         *
@@ -21738,8 +21736,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a cipher params object to an OpenSSL-compatible string.
 	         *
 	         * @param {CipherParams} cipherParams The cipher params object.
-	         *
-	         * @return {string} The OpenSSL-compatible string.
+	         * @returns {string} The OpenSSL-compatible string.
 	         *
 	         * @static
 	         *
@@ -21768,8 +21765,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts an OpenSSL-compatible string to a cipher params object.
 	         *
 	         * @param {string} openSSLStr The OpenSSL-compatible string.
-	         *
-	         * @return {CipherParams} The cipher params object.
+	         * @returns {CipherParams} The cipher params object.
 	         *
 	         * @static
 	         *
@@ -21820,8 +21816,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * @param {WordArray|string} message The message to encrypt.
 	         * @param {WordArray} key The key.
 	         * @param {Object} cfg (Optional) The configuration options to use for this operation.
-	         *
-	         * @return {CipherParams} A cipher params object.
+	         * @returns {CipherParams} A cipher params object.
 	         *
 	         * @static
 	         *
@@ -21862,8 +21857,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * @param {CipherParams|string} ciphertext The ciphertext to decrypt.
 	         * @param {WordArray} key The key.
 	         * @param {Object} cfg (Optional) The configuration options to use for this operation.
-	         *
-	         * @return {WordArray} The plaintext.
+	         * @returns {WordArray} The plaintext.
 	         *
 	         * @static
 	         *
@@ -21891,8 +21885,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         *
 	         * @param {CipherParams|string} ciphertext The ciphertext.
 	         * @param {Formatter} format The formatting strategy to use to parse serialized ciphertext.
-	         *
-	         * @return {CipherParams} The unserialized ciphertext.
+	         * @returns {CipherParams} The unserialized ciphertext.
 	         *
 	         * @static
 	         *
@@ -21925,8 +21918,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * @param {number} keySize The size in words of the key to generate.
 	         * @param {number} ivSize The size in words of the IV to generate.
 	         * @param {WordArray|string} salt (Optional) A 64-bit salt to use. If omitted, a salt will be generated randomly.
-	         *
-	         * @return {CipherParams} A cipher params object with the key, IV, and salt.
+	         * @returns {CipherParams} A cipher params object with the key, IV, and salt.
 	         *
 	         * @static
 	         *
@@ -22167,8 +22159,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	             * Creates a new object that inherits from this object.
 	             *
 	             * @param {Object} overrides Properties to copy into the new object.
-	             *
-	             * @return {Object} The new object.
+	             * @returns {object} The new object.
 	             *
 	             * @static
 	             *
@@ -22210,7 +22201,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	             * Extends this object and runs the init method.
 	             * Arguments to create() will be passed to init().
 	             *
-	             * @return {Object} The new object.
+	             * @returns {object} The new object.
 	             *
 	             * @static
 	             *
@@ -22267,7 +22258,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	            /**
 	             * Creates a copy of this object.
 	             *
-	             * @return {Object} The clone.
+	             * @returns {object} The clone.
 	             *
 	             * @example
 	             *
@@ -22289,7 +22280,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	        /**
 	         * Initializes a newly created word array.
 	         *
-	         * @param {Array} words (Optional) An array of 32-bit words.
+	         * @param {array} words (Optional) An array of 32-bit words.
 	         * @param {number} sigBytes (Optional) The number of significant bytes in the words.
 	         *
 	         * @example
@@ -22312,8 +22303,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts this word array to a string.
 	         *
 	         * @param {Encoder} encoder (Optional) The encoding strategy to use. Default: CryptoJS.enc.Hex
-	         *
-	         * @return {string} The stringified word array.
+	         * @returns {string} The stringified word array.
 	         *
 	         * @example
 	         *
@@ -22329,8 +22319,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Concatenates a word array to this word array.
 	         *
 	         * @param {WordArray} wordArray The word array to append.
-	         *
-	         * @return {WordArray} This word array.
+	         * @returns {WordArray} This word array.
 	         *
 	         * @example
 	         *
@@ -22435,8 +22424,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a hex string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
-	         * @return {string} The hex string.
+	         * @returns {string} The hex string.
 	         *
 	         * @static
 	         *
@@ -22464,8 +22452,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a hex string to a word array.
 	         *
 	         * @param {string} hexStr The hex string.
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -22495,8 +22482,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a Latin1 string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
-	         * @return {string} The Latin1 string.
+	         * @returns {string} The Latin1 string.
 	         *
 	         * @static
 	         *
@@ -22523,8 +22509,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a Latin1 string to a word array.
 	         *
 	         * @param {string} latin1Str The Latin1 string.
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -22554,8 +22539,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a UTF-8 string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
-	         * @return {string} The UTF-8 string.
+	         * @returns {string} The UTF-8 string.
 	         *
 	         * @static
 	         *
@@ -22575,8 +22559,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a UTF-8 string to a word array.
 	         *
 	         * @param {string} utf8Str The UTF-8 string.
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -22637,8 +22620,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * This method invokes _doProcessBlock(offset), which must be implemented by a concrete subtype.
 	         *
 	         * @param {boolean} doFlush Whether all blocks and partial blocks should be processed.
-	         *
-	         * @return {WordArray} The processed data.
+	         * @returns {WordArray} The processed data.
 	         *
 	         * @example
 	         *
@@ -22691,7 +22673,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	        /**
 	         * Creates a copy of this object.
 	         *
-	         * @return {Object} The clone.
+	         * @returns {object} The clone.
 	         *
 	         * @example
 	         *
@@ -22754,8 +22736,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Updates this hasher with a message.
 	         *
 	         * @param {WordArray|string} messageUpdate The message to append.
-	         *
-	         * @return {Hasher} This hasher.
+	         * @returns {Hasher} This hasher.
 	         *
 	         * @example
 	         *
@@ -22778,8 +22759,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Note that the finalize operation is effectively a destructive, read-once operation.
 	         *
 	         * @param {WordArray|string} messageUpdate (Optional) A final message update.
-	         *
-	         * @return {WordArray} The hash.
+	         * @returns {WordArray} The hash.
 	         *
 	         * @example
 	         *
@@ -22805,8 +22785,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Creates a shortcut function to a hasher's object interface.
 	         *
 	         * @param {Hasher} hasher The hasher to create a helper for.
-	         *
-	         * @return {Function} The shortcut function.
+	         * @returns {Function} The shortcut function.
 	         *
 	         * @static
 	         *
@@ -22824,8 +22803,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Creates a shortcut function to the HMAC's object interface.
 	         *
 	         * @param {Hasher} hasher The hasher to use in this HMAC helper.
-	         *
-	         * @return {Function} The shortcut function.
+	         * @returns {Function} The shortcut function.
 	         *
 	         * @static
 	         *
@@ -22884,8 +22862,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a Base64 string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
-	         * @return {string} The Base64 string.
+	         * @returns {string} The Base64 string.
 	         *
 	         * @static
 	         *
@@ -22931,8 +22908,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a Base64 string to a word array.
 	         *
 	         * @param {string} base64Str The Base64 string.
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -23021,10 +22997,8 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a Base64url string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
 	         * @param {boolean} urlSafe Whether to use url safe
-	         *
-	         * @return {string} The Base64url string.
+	         * @returns {string} The Base64url string.
 	         *
 	         * @static
 	         *
@@ -23070,10 +23044,8 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a Base64url string to a word array.
 	         *
 	         * @param {string} base64Str The Base64url string.
-	         *
 	         * @param {boolean} urlSafe Whether to use url safe
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -23162,8 +23134,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a UTF-16 BE string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
-	         * @return {string} The UTF-16 BE string.
+	         * @returns {string} The UTF-16 BE string.
 	         *
 	         * @static
 	         *
@@ -23190,8 +23161,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a UTF-16 BE string to a word array.
 	         *
 	         * @param {string} utf16Str The UTF-16 BE string.
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -23221,8 +23191,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a word array to a UTF-16 LE string.
 	         *
 	         * @param {WordArray} wordArray The word array.
-	         *
-	         * @return {string} The UTF-16 LE string.
+	         * @returns {string} The UTF-16 LE string.
 	         *
 	         * @static
 	         *
@@ -23249,8 +23218,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a UTF-16 LE string to a word array.
 	         *
 	         * @param {string} utf16Str The UTF-16 LE string.
-	         *
-	         * @return {WordArray} The word array.
+	         * @returns {WordArray} The word array.
 	         *
 	         * @static
 	         *
@@ -23344,8 +23312,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         *
 	         * @param {WordArray|string} password The password.
 	         * @param {WordArray|string} salt A salt.
-	         *
-	         * @return {WordArray} The derived key.
+	         * @returns {WordArray} The derived key.
 	         *
 	         * @example
 	         *
@@ -23396,8 +23363,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	     * @param {WordArray|string} password The password.
 	     * @param {WordArray|string} salt A salt.
 	     * @param {Object} cfg (Optional) The configuration options to use for this computation.
-	     *
-	     * @return {WordArray} The derived key.
+	     * @returns {WordArray} The derived key.
 	     *
 	     * @static
 	     *
@@ -23446,8 +23412,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts the ciphertext of a cipher params object to a hexadecimally encoded string.
 	         *
 	         * @param {CipherParams} cipherParams The cipher params object.
-	         *
-	         * @return {string} The hexadecimally encoded string.
+	         * @returns {string} The hexadecimally encoded string.
 	         *
 	         * @static
 	         *
@@ -23463,8 +23428,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Converts a hexadecimally encoded ciphertext string to a cipher params object.
 	         *
 	         * @param {string} input The hexadecimally encoded string.
-	         *
-	         * @return {CipherParams} The cipher params object.
+	         * @returns {CipherParams} The cipher params object.
 	         *
 	         * @static
 	         *
@@ -23582,8 +23546,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Updates this HMAC with a message.
 	         *
 	         * @param {WordArray|string} messageUpdate The message to append.
-	         *
-	         * @return {HMAC} This HMAC instance.
+	         * @returns {HMAC} This HMAC instance.
 	         *
 	         * @example
 	         *
@@ -23602,8 +23565,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	         * Note that the finalize operation is effectively a destructive, read-once operation.
 	         *
 	         * @param {WordArray|string} messageUpdate (Optional) A final message update.
-	         *
-	         * @return {WordArray} The HMAC.
+	         * @returns {WordArray} The HMAC.
 	         *
 	         * @example
 	         *
@@ -25697,8 +25659,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	     * Shortcut function to the hasher's object interface.
 	     *
 	     * @param {WordArray|string} message The message to hash.
-	     *
-	     * @return {WordArray} The hash.
+	     * @returns {WordArray} The hash.
 	     *
 	     * @static
 	     *
@@ -25714,8 +25675,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	     *
 	     * @param {WordArray|string} message The message to hash.
 	     * @param {WordArray|string} key The secret key.
-	     *
-	     * @return {WordArray} The HMAC.
+	     * @returns {WordArray} The HMAC.
 	     *
 	     * @static
 	     *
@@ -25897,8 +25857,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	     * Shortcut function to the hasher's object interface.
 	     *
 	     * @param {WordArray|string} message The message to hash.
-	     *
-	     * @return {WordArray} The hash.
+	     * @returns {WordArray} The hash.
 	     *
 	     * @static
 	     *
@@ -25914,8 +25873,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	     *
 	     * @param {WordArray|string} message The message to hash.
 	     * @param {WordArray|string} key The secret key.
-	     *
-	     * @return {WordArray} The HMAC.
+	     * @returns {WordArray} The HMAC.
 	     *
 	     * @static
 	     *
@@ -27671,7 +27629,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
 	        /**
 	         * Initializes a newly created word array.
 	         *
-	         * @param {Array} words (Optional) An array of CryptoJS.x64.Word objects.
+	         * @param {array} words (Optional) An array of CryptoJS.x64.Word objects.
 	         * @param {number} sigBytes (Optional) The number of significant bytes in the words.
 	         *
 	         * @example
@@ -60652,8 +60610,10 @@ class PDFNameTree extends PDFTree {
 
 /**
  * Check if value is in a range group.
+ *
  * @param {number} value
  * @param {number[]} rangeGroup
+ *
  * @returns {boolean}
  */
 function inRange(value, rangeGroup) {
@@ -60970,11 +60930,10 @@ const last = x => x[x.length - 1];
  * Convert provided string into an array of Unicode Code Points.
  * Based on https://stackoverflow.com/a/21409165/1556249
  * and https://www.npmjs.com/package/code-point-at.
+ *
  * @param {string} input
  * @returns {number[]}
  */
-
-
 function toCodePoints(input) {
   const codepoints = [];
   const size = input.length;
@@ -60999,13 +60958,12 @@ function toCodePoints(input) {
 }
 /**
  * SASLprep.
+ *
  * @param {string} input
  * @param {Object} opts
  * @param {boolean} opts.allowUnassigned
  * @returns {string}
  */
-
-
 function saslprep(input, opts = {}) {
   if (typeof input !== 'string') {
     throw new TypeError('Expected string.');


### PR DESCRIPTION
Standardizes type casing (e.g., number instead of Number), fixes various tags like @augments and @returns, and improves the formatting of JSDoc annotations across the codebase for better consistency and tool compatibility.