### PR TITLE
[MAINTENANCE] Introduce `AbstractRepository` for unified storage PID management

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -131,8 +131,6 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             $this->pageUid = $request->getAttribute('routing')->getPageId();
         }
 
-        $this->documentRepository->setStoragePid($this->settings['storagePid']);
-
         // Sanitize user input to prevent XSS attacks.
         $this->sanitizeRequestData();
 
@@ -260,6 +258,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     {
         // Sanitize FlexForm settings to avoid later casting.
         $this->sanitizeSettings();
+
+        $this->documentRepository->setStoragePid($this->settings['storagePid']);
 
         // Get document ID from request data if not passed as parameter.
         if (!$documentId && !empty($this->requestData['id'])) {

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -131,6 +131,8 @@ abstract class AbstractController extends ActionController implements LoggerAwar
             $this->pageUid = $request->getAttribute('routing')->getPageId();
         }
 
+        $this->documentRepository->setStoragePid($this->settings['storagePid']);
+
         // Sanitize user input to prevent XSS attacks.
         $this->sanitizeRequestData();
 

--- a/Classes/Controller/BasketController.php
+++ b/Classes/Controller/BasketController.php
@@ -240,6 +240,8 @@ class BasketController extends AbstractController
      */
     protected function getBasketData(): Basket
     {
+        $this->basketRepository->setStoragePid($this->settings['storagePid']);
+
         // get user session
         $feUser = $this->request->getAttribute('frontend.user');
         $userSession = $feUser->getSession();

--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -111,6 +111,8 @@ class CalendarController extends AbstractController
             return $this->htmlResponse();
         }
 
+        $this->structureRepository->setStoragePid($this->settings['storagePid']);
+
         $calendarData = $this->buildCalendar();
 
         // Prepare list as alternative view.
@@ -158,6 +160,8 @@ class CalendarController extends AbstractController
             // Quit without doing anything if required variables are not set.
             return $this->htmlResponse();
         }
+
+        $this->structureRepository->setStoragePid($this->settings['storagePid']);
 
         // Get all children of anchor. This should be the year anchor documents
         $documents = $this->documentRepository->getChildrenOfYearAnchor(

--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -83,6 +83,9 @@ class CollectionController extends AbstractController
             return $this->htmlResponse();
         }
 
+        $this->collectionRepository->setStoragePid($this->settings['storagePid']);
+        $this->metadataRepository->setStoragePid($this->settings['storagePid']);
+
         // Sort collections according to order in plugin flexform configuration
         if ($this->settings['collections']) {
             $sortedCollections = [];

--- a/Classes/Controller/FeedsController.php
+++ b/Classes/Controller/FeedsController.php
@@ -66,6 +66,8 @@ class FeedsController extends AbstractController
         // access to GET parameter tx_dlf_feeds['collection']
         $requestData = $this->request->getArguments();
 
+        $this->libraryRepository->setStoragePid($this->settings['storagePid']);
+
         // get library information
         /** @var \Kitodo\Dlf\Domain\Model\Library|null $library */
         $library = $this->libraryRepository->findByUid($this->settings['library']);

--- a/Classes/Controller/ListViewController.php
+++ b/Classes/Controller/ListViewController.php
@@ -81,6 +81,9 @@ class ListViewController extends AbstractController
     {
         $this->search = $this->getArrayParameterSafely('search');
 
+        $this->collectionRepository->setStoragePid($this->settings['storagePid']);
+        $this->metadataRepository->setStoragePid($this->settings['storagePid']);
+
         // extract collection(s) from collection parameter
         $collections = [];
         if (array_key_exists('collection', $this->search)) {

--- a/Classes/Controller/MetadataController.php
+++ b/Classes/Controller/MetadataController.php
@@ -113,6 +113,10 @@ class MetadataController extends AbstractController
 
         $this->setPage();
 
+        $this->collectionRepository->setStoragePid($this->settings['storagePid']);
+        $this->metadataRepository->setStoragePid($this->settings['storagePid']);
+        $this->structureRepository->setStoragePid($this->settings['storagePid']);
+
         $this->currentDocument = $this->document->getCurrentDocument();
         $this->useOriginalIiifManifestMetadata = $this->settings['originalIiifMetadata'] == 1 && $this->currentDocument instanceof IiifManifest;
 

--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -276,6 +276,10 @@ class OaiPmhController extends AbstractController
         // Get allowed GET and POST variables.
         $this->getUrlParams($this->request);
 
+        $this->collectionRepository->setStoragePid((int) $this->settings['storagePid']);
+        $this->libraryRepository->setStoragePid((int) $this->settings['storagePid']);
+        $this->tokenRepository->setStoragePid((int) $this->settings['storagePid']);
+
         // Delete expired resumption tokens.
         $this->deleteExpiredTokens();
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -113,6 +113,9 @@ class SearchController extends AbstractController
             return $this->htmlResponse();
         }
 
+        $this->collectionRepository->setStoragePid($this->settings['storagePid']);
+        $this->metadataRepository->setStoragePid($this->settings['storagePid']);
+
         $this->addFieldsForExtendedSearch();
 
         $this->enableSuggester();

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Domain\Repository;
+
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * Abstract Repository for allowing setting the storage pid.
+ *
+ * @package TYPO3
+ * @subpackage dlf
+ *
+ * @access public
+ *
+ * @template T of DomainObjectInterface
+ * @extends Repository<T>
+ */
+class AbstractRepository extends Repository
+{
+    /**
+     * Sets the storage pid for the repository.
+     *
+     * @access public
+     *
+     * @param int $storagePid
+     *
+     * @return void
+     */
+    public function setStoragePid(int $storagePid): void
+    {
+        $querySettings = $this->createQuery()->getQuerySettings();
+        $querySettings->setStoragePageIds([$storagePid]);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+}

--- a/Classes/Domain/Repository/ActionLogRepository.php
+++ b/Classes/Domain/Repository/ActionLogRepository.php
@@ -23,8 +23,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @access public
  *
- * @extends Repository<ActionLog>
+ * @extends AbstractRepository<ActionLog>
  */
-class ActionLogRepository extends Repository
+class ActionLogRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/ActionLogRepository.php
+++ b/Classes/Domain/Repository/ActionLogRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\ActionLog;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * (Basket Plugin) Action log repository for mails and printouts.

--- a/Classes/Domain/Repository/BasketRepository.php
+++ b/Classes/Domain/Repository/BasketRepository.php
@@ -25,8 +25,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @method Basket|null findOneBy(array $criteria) Get a basket by criteria
  *
- * @extends Repository<Basket>
+ * @extends AbstractRepository<Basket>
  */
-class BasketRepository extends Repository
+class BasketRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/BasketRepository.php
+++ b/Classes/Domain/Repository/BasketRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\Basket;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * (Basket Plugin) Basket repository.

--- a/Classes/Domain/Repository/CollectionRepository.php
+++ b/Classes/Domain/Repository/CollectionRepository.php
@@ -31,9 +31,9 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  *
  * @method Collection|null findOneBy(array $criteria) Get a collection by criteria
  *
- * @extends Repository<Collection>
+ * @extends AbstractRepository<Collection>
  */
-class CollectionRepository extends Repository
+class CollectionRepository extends AbstractRepository
 {
     /**
      * @access protected

--- a/Classes/Domain/Repository/CollectionRepository.php
+++ b/Classes/Domain/Repository/CollectionRepository.php
@@ -17,7 +17,6 @@ use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Domain\Model\Collection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -39,9 +39,9 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  * @method Document|null findByUid(int|null $uid) Get a document by its UID
  * @method Document|null findOneBy(array $criteria) Get a document by criteria
  *
- * @extends Repository<Document>
+ * @extends AbstractRepository<Document>
  */
-class DocumentRepository extends Repository
+class DocumentRepository extends AbstractRepository
 {
     /**
      * @access protected

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -24,7 +24,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 

--- a/Classes/Domain/Repository/FormatRepository.php
+++ b/Classes/Domain/Repository/FormatRepository.php
@@ -16,7 +16,6 @@ use Doctrine\DBAL\Exception;
 use Kitodo\Dlf\Domain\Model\Format;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Format repository.

--- a/Classes/Domain/Repository/FormatRepository.php
+++ b/Classes/Domain/Repository/FormatRepository.php
@@ -26,9 +26,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @access public
  *
- * @extends Repository<Format>
+ * @extends AbstractRepository<Format>
  */
-class FormatRepository extends Repository
+class FormatRepository extends AbstractRepository
 {
 
     /**

--- a/Classes/Domain/Repository/LibraryRepository.php
+++ b/Classes/Domain/Repository/LibraryRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\Library;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Library repository.

--- a/Classes/Domain/Repository/LibraryRepository.php
+++ b/Classes/Domain/Repository/LibraryRepository.php
@@ -26,8 +26,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  * @method Library|null findByUid(int|null $uid) Get a library by its UID
  * @method Library|null findOneBy(array $criteria) Get a library by criteria
  *
- * @extends Repository<Library>
+ * @extends AbstractRepository<Library>
  */
-class LibraryRepository extends Repository
+class LibraryRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -26,9 +26,9 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  *
  * @access public
  *
- * @extends Repository<Mail>
+ * @extends AbstractRepository<Mail>
  */
-class MailRepository extends Repository
+class MailRepository extends AbstractRepository
 {
     /**
      * Find all mails by pid.

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -15,7 +15,6 @@ namespace Kitodo\Dlf\Domain\Repository;
 use Kitodo\Dlf\Domain\Model\Mail;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 /**

--- a/Classes/Domain/Repository/MetadataFormatRepository.php
+++ b/Classes/Domain/Repository/MetadataFormatRepository.php
@@ -23,8 +23,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @access public
  *
- * @extends Repository<MetadataFormat>
+ * @extends AbstractRepository<MetadataFormat>
  */
-class MetadataFormatRepository extends Repository
+class MetadataFormatRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/MetadataFormatRepository.php
+++ b/Classes/Domain/Repository/MetadataFormatRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\MetadataFormat;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Metadata format repository.

--- a/Classes/Domain/Repository/MetadataRepository.php
+++ b/Classes/Domain/Repository/MetadataRepository.php
@@ -18,7 +18,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 

--- a/Classes/Domain/Repository/MetadataRepository.php
+++ b/Classes/Domain/Repository/MetadataRepository.php
@@ -30,9 +30,9 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  *
  * @access public
  *
- * @extends Repository<Metadata>
+ * @extends AbstractRepository<Metadata>
  */
-class MetadataRepository extends Repository
+class MetadataRepository extends AbstractRepository
 {
     const TABLE = 'tx_dlf_metadata';
 

--- a/Classes/Domain/Repository/MetadataSubentryRepository.php
+++ b/Classes/Domain/Repository/MetadataSubentryRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\MetadataSubentry;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Metadata subentry repository.

--- a/Classes/Domain/Repository/MetadataSubentryRepository.php
+++ b/Classes/Domain/Repository/MetadataSubentryRepository.php
@@ -23,8 +23,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @access public
  *
- * @extends Repository<MetadataSubentry>
+ * @extends AbstractRepository<MetadataSubentry>
  */
-class MetadataSubentryRepository extends Repository
+class MetadataSubentryRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/PrinterRepository.php
+++ b/Classes/Domain/Repository/PrinterRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\Printer;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Printer repository.

--- a/Classes/Domain/Repository/PrinterRepository.php
+++ b/Classes/Domain/Repository/PrinterRepository.php
@@ -25,8 +25,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @method Printer|null findOneBy(array $criteria) Get a printer by criteria
  *
- * @extends Repository<Printer>
+ * @extends AbstractRepository<Printer>
  */
-class PrinterRepository extends Repository
+class PrinterRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/SolrCoreRepository.php
+++ b/Classes/Domain/Repository/SolrCoreRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\SolrCore;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * SOLR core repository.

--- a/Classes/Domain/Repository/SolrCoreRepository.php
+++ b/Classes/Domain/Repository/SolrCoreRepository.php
@@ -23,8 +23,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @access public
  *
- * @extends Repository<SolrCore>
+ * @extends AbstractRepository<SolrCore>
  */
-class SolrCoreRepository extends Repository
+class SolrCoreRepository extends AbstractRepository
 {
 }

--- a/Classes/Domain/Repository/StructureRepository.php
+++ b/Classes/Domain/Repository/StructureRepository.php
@@ -29,9 +29,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @method Structure|null findOneBy(array $criteria) Get a structure by criteria
  *
- * @extends Repository<Structure>
+ * @extends AbstractRepository<Structure>
  */
-class StructureRepository extends Repository
+class StructureRepository extends AbstractRepository
 {
 
     /**

--- a/Classes/Domain/Repository/StructureRepository.php
+++ b/Classes/Domain/Repository/StructureRepository.php
@@ -17,7 +17,6 @@ use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Domain\Model\Structure;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Structure repository.

--- a/Classes/Domain/Repository/TokenRepository.php
+++ b/Classes/Domain/Repository/TokenRepository.php
@@ -23,9 +23,9 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @access public
  *
- * @extends Repository<Token>
+ * @extends AbstractRepository<Token>
  */
-class TokenRepository extends Repository
+class TokenRepository extends AbstractRepository
 {
     /**
      * Delete all expired token

--- a/Classes/Domain/Repository/TokenRepository.php
+++ b/Classes/Domain/Repository/TokenRepository.php
@@ -13,7 +13,6 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use Kitodo\Dlf\Domain\Model\Token;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * Token repository.

--- a/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/Tests/Functional/Controller/CollectionControllerTest.php
@@ -84,7 +84,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
             'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
-            'showSingle' => 'some_value',
+            'showSingle' => '0',
             'randomize' => ''
         ];
         $templateHtml = '<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"><f:for each="{documents.solrResults.documents}" as="page" iteration="docIterator">{page.title},</f:for></html>';

--- a/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/Tests/Functional/Controller/CollectionControllerTest.php
@@ -39,6 +39,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
     public function canListAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
             'showSingle' => '1',
@@ -61,6 +62,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
     public function canListActionForwardToShow()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
             'randomize' => ''
@@ -79,11 +81,11 @@ class CollectionControllerTest extends AbstractControllerTestCase
     public function canShowAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
-            'showSingle' => '0',
-            'randomize' => '',
-            'storagePid' => self::$storagePid
+            'showSingle' => 'some_value',
+            'randomize' => ''
         ];
         $templateHtml = '<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"><f:for each="{documents.solrResults.documents}" as="page" iteration="docIterator">{page.title},</f:for></html>';
 
@@ -104,6 +106,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
     public function canShowSortedAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
             'showSingle' => '0',

--- a/Tests/Functional/Controller/NavigationControllerTest.php
+++ b/Tests/Functional/Controller/NavigationControllerTest.php
@@ -37,6 +37,7 @@ class NavigationControllerTest extends AbstractControllerTestCase
     public function canMainAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
         ];
 
@@ -67,6 +68,7 @@ class NavigationControllerTest extends AbstractControllerTestCase
     public function canPageSelectAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
         ];
 

--- a/Tests/Functional/Controller/PageGridControllerTest.php
+++ b/Tests/Functional/Controller/PageGridControllerTest.php
@@ -36,13 +36,17 @@ class PageGridControllerTest extends AbstractControllerTestCase
      */
     public function canMainAction()
     {
+        $settings = [
+            'storagePid' => self::$storagePid
+        ];
+
         $templateHtml = '<html>
             pageGridEntries:<f:count subject="{paginator.paginatedItems}"/>
             pageGridEntries[0]:{paginator.paginatedItems.0.pagination}, {paginator.paginatedItems.0.thumbnail}
             pageGridEntries[1]:{paginator.paginatedItems.1.pagination}, {paginator.paginatedItems.1.thumbnail}
             docUid:{docUid}
         </html>';
-        $controller = $this->setUpController(PageGridController::class, [], $templateHtml);
+        $controller = $this->setUpController(PageGridController::class, $settings, $templateHtml);
         $request = $this->setUpRequest('main', ['tx_dlf' => [ 'id' => 2001 ] ]);
 
         $response = $controller->processRequest($request);

--- a/Tests/Functional/Controller/PageViewControllerTest.php
+++ b/Tests/Functional/Controller/PageViewControllerTest.php
@@ -37,6 +37,7 @@ class PageViewControllerTest extends AbstractControllerTestCase
     public function canMainAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId
         ];
 

--- a/Tests/Functional/Controller/SearchControllerTest.php
+++ b/Tests/Functional/Controller/SearchControllerTest.php
@@ -57,8 +57,8 @@ class SearchControllerTest extends AbstractControllerTestCase
             ]
         ];
         $settings = [
-            'solrcore' => self::$solrCoreId,
             'storagePid' => self::$storagePid,
+            'solrcore' => self::$solrCoreId,
             'extendedFields' => 'field1,field2,field3',
             'extendedSlotCount' => 1
         ];
@@ -128,8 +128,8 @@ class SearchControllerTest extends AbstractControllerTestCase
             'query' => '*'
         ];
         $settings = [
-            'solrcore' => self::$solrCoreId,
             'storagePid' => self::$storagePid,
+            'solrcore' => self::$solrCoreId,
             'facets' => 'type',
             'facetCollections' => '1'
         ];
@@ -188,7 +188,10 @@ class SearchControllerTest extends AbstractControllerTestCase
      */
     public function canSearchAction()
     {
-        $controller = $this->setUpController(SearchController::class, [], '');
+        $settings = [
+            'storagePid' => self::$storagePid,
+        ];
+        $controller = $this->setUpController(SearchController::class, $settings, '');
         $request = $this->setUpRequest('search');
         $request = $request->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
 

--- a/Tests/Functional/Controller/ToolboxControllerTest.php
+++ b/Tests/Functional/Controller/ToolboxControllerTest.php
@@ -38,6 +38,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canFulltextDownloadTool()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'tools' => 'fulltextDownloadTool'
         ];
         $templateHtml = '<html>fulltextDownload:{fulltextDownload}</html>';
@@ -58,6 +59,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canFulltextTool()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'tools' => 'fulltextTool',
             'activateFullTextInitially' => 1
         ];
@@ -79,6 +81,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canImageDownloadTool()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'tools' => 'imageDownloadTool'
         ];
         $templateHtml = '<html>imageDownload:<f:for each="{imageDownload}" as="image">
@@ -104,6 +107,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canImageManipulationTool()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'tools' => 'imageManipulationTool',
             'parentContainer' => '.parent-container'
         ];
@@ -125,6 +129,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canMainAction()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'library' => 1,
             'tools' => 'annotationTool',
@@ -149,6 +154,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canPdfDownloadTool()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'tools' => 'pdfDownloadTool'
         ];
         $templateHtml = '<html>pageLinks:<f:for each="{pageLinks}" as="link">
@@ -176,6 +182,7 @@ class ToolboxControllerTest extends AbstractControllerTestCase
     public function canSearchInDocumentTool()
     {
         $settings = [
+            'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'tools' => 'searchInDocumentTool',
             'queryInputName' => 'queryInputName',

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -17,6 +17,7 @@ use GuzzleHttp\Client as HttpClient;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Indexer;
 use Kitodo\Dlf\Common\Solr\Solr;
+use Kitodo\Dlf\Domain\Repository\AbstractRepository;
 use Kitodo\Dlf\Domain\Repository\SolrCoreRepository;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -24,8 +25,6 @@ use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
-use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 
@@ -234,20 +233,18 @@ class FunctionalTestCase extends \TYPO3\TestingFramework\Core\Functional\Functio
      *
      * @access protected
      *
-     * @template T
+     * @template T of AbstractRepository
      *
      * @param class-string<T> $className The fully qualified class name of the repository
      * @param int $storagePid The storage PID to set in the query settings
      *
      * @return T The initialized repository
      */
-    protected function initializeRepository(string $className, int $storagePid): Repository
+    protected function initializeRepository(string $className, int $storagePid): AbstractRepository
     {
-        /* @var Repository $repository */
+        /* @var AbstractRepository $repository */
         $repository = GeneralUtility::makeInstance($className);
-        $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
-        $querySettings->setStoragePageIds([$storagePid]);
-        $repository->setDefaultQuerySettings($querySettings);
+        $repository->setStoragePid($storagePid);
 
         return $repository;
     }


### PR DESCRIPTION
Currently functions like `findAll()` and custom functions which use `createQuery()` do not work, becuase pid in the generated SQL is always 0. It is necessary to set up `storagePid`.

See:
https://docs.typo3.org/permalink/t3coreapi:extbase-repository-query-setting
https://docs.typo3.org/permalink/t3coreapi:typo3-cms-extbase-persistence-repository-setdefaultquerysettings