### PR TITLE
[FEATURE] Introduce global debug mode for Fluid templates

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -207,6 +207,19 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     }
 
     /**
+     * Activate debug mode for the view in the controller,
+     * which allows to output the debug of all variables in the template.
+     *
+     * @access protected
+     *
+     * @return void
+     */
+    protected function activateDebugMode(): void
+    {
+        $this->view->assign('debugActive', true);
+    }
+
+    /**
      * Build the multiview documents.
      *
      * @param string $docUrl The URL of the document.

--- a/Documentation/Developers/Debugging.rst
+++ b/Documentation/Developers/Debugging.rst
@@ -1,0 +1,53 @@
+=========
+Debugging
+=========
+
+Kitodo.Presentation allows developers to debug their code by calling the debug functions, which outputs in a human-readable format.
+
+Database Queries
+================
+
+The SQL queries executed by the database connection can be logged by calling the ``activateDebugMode()`` function from the repositories. This will output the queries in the frontend, which can be useful for debugging and optimizing database interactions.
+
+.. code-block:: php
+
+    public function activateDebugMode(): void
+    {
+        $this->debug = true;
+    }
+
+.. code-block:: php
+
+    protected function debugQuery(QueryInterface $query): void
+    {
+        if ($this->debug) {
+            $typo3DbQueryParser = GeneralUtility::makeInstance(Typo3DbQueryParser::class);
+            $queryBuilder = $typo3DbQueryParser->convertQueryToDoctrineQueryBuilder($query);
+            DebuggerUtility::var_dump($queryBuilder->getSQL());
+            DebuggerUtility::var_dump($queryBuilder->getParameters());
+        }
+    }
+
+.. code-block:: php
+
+    protected function debugQueryBuilder(QueryBuilder $queryBuilder): void
+    {
+        if ($this->debug) {
+            DebuggerUtility::var_dump($queryBuilder->getSQL());
+            DebuggerUtility::var_dump($queryBuilder->getParameters());
+        }
+    }
+
+
+Fluid Templates
+===============
+
+The Fluid templates can be debugged by calling the ``activateDebugMode()`` function in the controller, which outputs the variables in a human-readable format. This can be useful for debugging the data passed to the templates and the logic within the templates.
+
+.. code-block:: php
+
+    protected function activateDebugMode(): void
+    {
+        $this->view->assign('debugActive', true);
+    }
+

--- a/Documentation/Developers/Index.rst
+++ b/Documentation/Developers/Index.rst
@@ -8,5 +8,6 @@ These pages are aimed at developers working on Kitodo.Presentation.
 
    Metadata
    Database
+   Debugging
    Validation
    Embedded3DViewer

--- a/Resources/Private/Templates/Annotation/Main.html
+++ b/Resources/Private/Templates/Annotation/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <ul class="tx-dlf-annotation-list">
     <f:for each="{annotations}" as="annotation">
         <f:if condition="{kitodo:isInArray(needle: currentPage, haystack: annotation.pageNumbers)}">

--- a/Resources/Private/Templates/Basket/Main.html
+++ b/Resources/Private/Templates/Basket/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <p class="tx-dlf-basket-counts">
     <f:if condition="{countDocs} > 0">
         <f:then>

--- a/Resources/Private/Templates/Calendar/Calendar.html
+++ b/Resources/Private/Templates/Calendar/Calendar.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-calendar">
     <div class="tx-dlf-calendar-meta-header">
         <div class="tx-dlf-calendar-year-anchor">

--- a/Resources/Private/Templates/Calendar/Years.html
+++ b/Resources/Private/Templates/Calendar/Years.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-calendar-years">
     <div class="tx-dlf-calendar-meta-header">
         <div class="tx-dlf-calendar-year-anchor">

--- a/Resources/Private/Templates/Collection/List.html
+++ b/Resources/Private/Templates/Collection/List.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-collection">
     <ul class="tx-dlf-collection-list">
         <f:for each="{collections}" as="item">

--- a/Resources/Private/Templates/Collection/Show.html
+++ b/Resources/Private/Templates/Collection/Show.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-listview">
     <h2 class="tx-dlf-listview-label">{collection.label}</h2>
 

--- a/Resources/Private/Templates/Embedded3dViewer/Main.html
+++ b/Resources/Private/Templates/Embedded3dViewer/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-embedded3dviewer">
     <iframe src="{embedded3dViewerUrl}" ></iframe>
 </div>

--- a/Resources/Private/Templates/ListView/Main.html
+++ b/Resources/Private/Templates/ListView/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-listview">
     <h2 class="tx-dlf-listview-label">
         <f:translate key="search.search"  />

--- a/Resources/Private/Templates/MediaPlayer/Main.html
+++ b/Resources/Private/Templates/MediaPlayer/Main.html
@@ -3,6 +3,10 @@
       data-namespace-typo3-fluid="true"
       lang="en">
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <f:if condition="{media}">
     <script>
         document.body.setAttribute("data-mediaplayer", "yes");
@@ -24,7 +28,7 @@
                         </div>
                     </div>
                 </f:if>
-                
+
                 <div id="panel-equalizer" class="panel panel-equalizer" data-panel="equalizer" hidden>
                     <f:if condition="{settings.equalizer.enabled}">
                         <dlf-equalizer id="{settings.elementId}-equalizer" forPlayer="{settings.elementId}"></dlf-equalizer>

--- a/Resources/Private/Templates/Metadata/Main.html
+++ b/Resources/Private/Templates/Metadata/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <f:comment>
     <dl>
         {metadata -> f:format.html()}

--- a/Resources/Private/Templates/MultiView/Main.html
+++ b/Resources/Private/Templates/MultiView/Main.html
@@ -12,6 +12,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="page-control">
     <div class="backs">
         <span class="prev">

--- a/Resources/Private/Templates/Navigation/Main.html
+++ b/Resources/Private/Templates/Navigation/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <f:comment>Render all navigation features in the given order.</f:comment>
 <f:for each="{features}" key="feature" as="enabled">
     <f:if condition="{feature}">

--- a/Resources/Private/Templates/OaiPmh/Main.xml
+++ b/Resources/Private/Templates/OaiPmh/Main.xml
@@ -12,6 +12,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <f:if condition="{settings.stylesheet}">
     <f:then>
         <?xml-stylesheet type="text/xsl" href="{f:uri.typolink(parameter:'{settings.stylesheet}', absolute:'1')}"?>

--- a/Resources/Private/Templates/PageGrid/Main.html
+++ b/Resources/Private/Templates/PageGrid/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-pagegrid">
     <ol class="tx-dlf-pagegrid-list">
         <f:for each="{paginator.paginatedItems}" as="entry" iteration="iterator">

--- a/Resources/Private/Templates/PageView/Main.html
+++ b/Resources/Private/Templates/PageView/Main.html
@@ -12,6 +12,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div id="tx-dlf-map" class="tx-dlf-map" data-dic="overview-map:{f:translate(key: 'pageview.overview-map')}">
     <div id="tx-dlf-annotationselection"></div>
 </div>

--- a/Resources/Private/Templates/Search/Main.html
+++ b/Resources/Private/Templates/Search/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <f:render partial="Search/Form" arguments="{_all}" />
 
 <f:if condition="{settings.targetPid} == '' && {documents}">

--- a/Resources/Private/Templates/Statistics/Main.html
+++ b/Resources/Private/Templates/Statistics/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-statistics">
     <f:comment>We need to use the lib.parseFunc here, as the default lib.parseFunc_RTE keeps empty lines.</f:comment>
     <f:format.html parseFuncTSPath="lib.parseFunc_RTE">

--- a/Resources/Private/Templates/TableOfContents/Main.html
+++ b/Resources/Private/Templates/TableOfContents/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <div class="tx-dlf-tableofcontents">
     <ul class="tx-dlf-tableofcontents-list">
         <f:render partial="TableOfContents/Children" arguments="{children: toc, viewData: viewData}"/>

--- a/Resources/Private/Templates/Toolbox/Main.html
+++ b/Resources/Private/Templates/Toolbox/Main.html
@@ -11,6 +11,10 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
 <f:if condition="{settings.showAsList}">
     <ul>
 </f:if>

--- a/Resources/Private/Templates/ValidationForm/Main.html
+++ b/Resources/Private/Templates/ValidationForm/Main.html
@@ -1,26 +1,42 @@
 <html data-namespace-typo3-fluid="true"
       xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
-    <div class="tx-dlf-validationform" >
-        <form action="{url}"
-            data-i18n-headline-error="<f:translate key='validationForm.headline.error' extensionName='dlf' />"
-            data-i18n-headline-notice="<f:translate key='validationForm.headline.notice' extensionName='dlf' />"
-            data-i18n-headline-success="<f:translate key='validationForm.headline.success' extensionName='dlf' />"
-            data-i18n-headline-warning="<f:translate key='validationForm.headline.warning' extensionName='dlf'/>"
-            >
-            <input type="hidden" name="type" value="{settings.type}">
-            <label>
-                <f:format.raw><f:translate key='validationForm.label' extensionName='dlf' /></f:format.raw>
-                <input type="text" name="url" class="url" value="" required>
-            </label>
-            <div class="disabled-validators">
-                <f:for each="{disabledValidators}" as="value" key="key" >
-                    <label title="{f:translate(key: value.shortdescription)}">
-                        <input type="checkbox" name="enableValidator[]" class="checkbox" value="{key}"/>
-                        {f:translate(key: value.title)}
-                    </label>
-                </f:for>
-            </div>
-            <input type="submit" class="submit" value="<f:translate key='validationForm.validate' extensionName='dlf' />">
-        </form>
-    </div>
+
+<f:comment>
+    (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+
+    This file is part of the Kitodo and TYPO3 projects.
+
+    @license GNU General Public License version 3 or later.
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+</f:comment>
+
+<f:if condition="{debugActive}">
+    <f:debug title="all">{_all}</f:debug>
+</f:if>
+
+<div class="tx-dlf-validationform" >
+    <form action="{url}"
+          data-i18n-headline-error="<f:translate key='validationForm.headline.error' extensionName='dlf' />"
+          data-i18n-headline-notice="<f:translate key='validationForm.headline.notice' extensionName='dlf' />"
+          data-i18n-headline-success="<f:translate key='validationForm.headline.success' extensionName='dlf' />"
+          data-i18n-headline-warning="<f:translate key='validationForm.headline.warning' extensionName='dlf'/>"
+    >
+        <input type="hidden" name="type" value="{settings.type}">
+        <label>
+            <f:format.raw><f:translate key='validationForm.label' extensionName='dlf' /></f:format.raw>
+            <input type="text" name="url" class="url" value="" required>
+        </label>
+        <div class="disabled-validators">
+            <f:for each="{disabledValidators}" as="value" key="key" >
+                <label title="{f:translate(key: value.shortdescription)}">
+                    <input type="checkbox" name="enableValidator[]" class="checkbox" value="{key}"/>
+                    {f:translate(key: value.title)}
+                </label>
+            </f:for>
+        </div>
+        <input type="submit" class="submit" value="<f:translate key='validationForm.validate' extensionName='dlf' />">
+    </form>
+</div>
+
 </html>


### PR DESCRIPTION
This change adds an `activateDebugMode()` method to `AbstractController` which assigns a `debugActive` flag to the view. Numerous Fluid templates are updated to conditionally render `f:debug title="all">{_all}` when `debugActive` is true.

This provides a centralized way for developers to easily inspect all variables passed to a template during development by activating debug mode in the relevant controller.