### PR TITLE
[MAINTENANCE] Delegate persistence calls to specific repositories

### DIFF
--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -333,6 +333,7 @@ class NewTenantController extends AbstractController
         // load language file in own array
         $beLabels = $this->languageFactory->getParsedData('EXT:dlf/Resources/Private/Language/locallang_be.xlf', $this->siteLanguages[0]->getLocale()->getLanguageCode());
 
+        // @phpstan-ignore-next-line findAll() returns QueryResultInterface and there is function getFirst()
         if ($this->solrCoreRepository->findAll()->getFirst() === null) {
             $newRecord = GeneralUtility::makeInstance(SolrCore::class);
             $newRecord->setLabel($this->getLLL('flexform.solrcore', $this->siteLanguages[0]->getLocale()->getLanguageCode(), $beLabels). ' (PID ' . $this->pid . ')');

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -16,7 +16,9 @@ use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr\Solr;
 use Kitodo\Dlf\Controller\AbstractController;
 use Kitodo\Dlf\Domain\Model\Format;
+use Kitodo\Dlf\Domain\Model\Metadata;
 use Kitodo\Dlf\Domain\Model\SolrCore;
+use Kitodo\Dlf\Domain\Model\Structure;
 use Kitodo\Dlf\Domain\Repository\FormatRepository;
 use Kitodo\Dlf\Domain\Repository\MetadataRepository;
 use Kitodo\Dlf\Domain\Repository\SolrCoreRepository;
@@ -24,19 +26,12 @@ use Kitodo\Dlf\Domain\Repository\StructureRepository;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Localization\LocalizationFactory;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
-use TYPO3\CMS\Core\Page\PageRenderer;
-use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Mvc\Request;
-use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
-use TYPO3\CMS\Fluid\View\TemplateView;
-use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
  * Controller class for the backend module 'New Tenant'.
@@ -180,6 +175,11 @@ class NewTenantController extends AbstractController
     {
         $this->pid = (int) ($this->request->getQueryParams()['id'] ?? null);
 
+        $this->formatRepository->useStoragePid($this->pid);
+        $this->metadataRepository->useStoragePid($this->pid);
+        $this->solrCoreRepository->useStoragePid($this->pid);
+        $this->structureRepository->useStoragePid($this->pid);
+
         $frameworkConfiguration = $this->configurationManager->getConfiguration($this->configurationManager::CONFIGURATION_TYPE_FRAMEWORK);
         $frameworkConfiguration['persistence']['storagePid'] = $this->pid;
         $this->configurationManager->setConfiguration($frameworkConfiguration);
@@ -225,8 +225,7 @@ class NewTenantController extends AbstractController
 
         // We must persist here, if we changed anything.
         if ($doPersist === true) {
-            $persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
-            $persistenceManager->persistAll();
+            $this->formatRepository->persistAll();
         }
 
         return $this->redirect('index');
@@ -290,7 +289,7 @@ class NewTenantController extends AbstractController
 
         $insertedMetadata = [];
         foreach ($metadataIds as $id => $uid) {
-            /** @var \Kitodo\Dlf\Domain\Model\Metadata $metadata */
+            /** @var Metadata $metadata */
             $metadata = $this->metadataRepository->findByUid($uid);
             // id array contains also ids of formats
             if ($metadata != null) {
@@ -334,7 +333,7 @@ class NewTenantController extends AbstractController
         // load language file in own array
         $beLabels = $this->languageFactory->getParsedData('EXT:dlf/Resources/Private/Language/locallang_be.xlf', $this->siteLanguages[0]->getLocale()->getLanguageCode());
 
-        if ($this->solrCoreRepository->findOneBy(['pid' => $this->pid]) === null) {
+        if ($this->solrCoreRepository->findAll()->getFirst() === null) {
             $newRecord = GeneralUtility::makeInstance(SolrCore::class);
             $newRecord->setLabel($this->getLLL('flexform.solrcore', $this->siteLanguages[0]->getLocale()->getLanguageCode(), $beLabels). ' (PID ' . $this->pid . ')');
             $indexName = Solr::createCore('');
@@ -349,8 +348,7 @@ class NewTenantController extends AbstractController
 
         // We must persist here, if we changed anything.
         if ($doPersist === true) {
-            $persistenceManager = GeneralUtility::makeInstance(PersistenceManager::class);
-            $persistenceManager->persistAll();
+            $this->solrCoreRepository->persistAll();
         }
 
         return $this->redirect('index');
@@ -386,7 +384,7 @@ class NewTenantController extends AbstractController
 
         $insertedStructures = [];
         foreach ($structureIds as $id => $uid) {
-            /** @var \Kitodo\Dlf\Domain\Model\Structure $structure */
+            /** @var Structure $structure */
             $structure = $this->structureRepository->findByUid($uid);
             $insertedStructures[$uid] = $structure->getIndexName();
         }
@@ -435,14 +433,14 @@ class NewTenantController extends AbstractController
         $recordInfos['formats']['numDefault'] = count($formatsDefaults);
 
         $structuresDefaults = $this->getRecords('Structure');
-        $recordInfos['structures']['numCurrent'] = $this->structureRepository->count(['pid' => $this->pid]);
+        $recordInfos['structures']['numCurrent'] = $this->structureRepository->countAll();
         $recordInfos['structures']['numDefault'] = count($structuresDefaults);
 
         $metadataDefaults = $this->getRecords('Metadata');
-        $recordInfos['metadata']['numCurrent'] = $this->metadataRepository->count(['pid' => $this->pid]);
+        $recordInfos['metadata']['numCurrent'] = $this->metadataRepository->countAll();
         $recordInfos['metadata']['numDefault'] = count($metadataDefaults);
 
-        $recordInfos['solrcore']['numCurrent'] = $this->solrCoreRepository->count(['pid' => $this->pid]);
+        $recordInfos['solrcore']['numCurrent'] = $this->solrCoreRepository->countAll();
 
         $viewData = ['recordInfos' => $recordInfos];
 

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -17,6 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\Storage\Typo3DbQueryParser;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
@@ -47,9 +48,38 @@ class AbstractRepository extends Repository
      *
      * @return void
      */
+
     public function activateDebugMode(): void
     {
         $this->debug = true;
+    }
+
+    /**
+     * Sets deleted records to be not returned by the find methods in the repository.
+     *
+     * @access public
+     *
+     * @return void
+        */
+    public function ignoreDeleted(): void
+    {
+        $querySettings = $this->getDefaultQuerySettings();
+        $querySettings->setIncludeDeleted(false);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
+     * Sets hidden records to be not returned by the find methods in the repository.
+     *
+     * @access public
+     *
+     * @return void
+     */
+    public function ignoreHidden(): void
+    {
+        $querySettings = $this->getDefaultQuerySettings();
+        $querySettings->setIgnoreEnableFields(false);
+        $this->setDefaultQuerySettings($querySettings);
     }
 
     /**
@@ -61,7 +91,7 @@ class AbstractRepository extends Repository
      */
     public function ignoreStoragePid(): void
     {
-        $querySettings = $this->createQuery()->getQuerySettings();
+        $querySettings = $this->getDefaultQuerySettings();
         $querySettings->setRespectStoragePage(false);
         $this->setDefaultQuerySettings($querySettings);
     }
@@ -77,7 +107,7 @@ class AbstractRepository extends Repository
      */
     public function useStoragePid(int $storagePid): void
     {
-        $querySettings = $this->createQuery()->getQuerySettings();
+        $querySettings = $this->getDefaultQuerySettings();
         $querySettings->setRespectStoragePage(true);
         $querySettings->setStoragePageIds([$storagePid]);
         $this->setDefaultQuerySettings($querySettings);
@@ -117,5 +147,47 @@ class AbstractRepository extends Repository
             DebuggerUtility::var_dump($queryBuilder->getSQL());
             DebuggerUtility::var_dump($queryBuilder->getParameters());
         }
+    }
+
+    /**
+     * Sets deleted records to be returned by the find methods in the repository.
+     *
+     * @access public
+     *
+     * @return void
+     */
+    public function showDeleted(): void
+    {
+        $querySettings = $this->getDefaultQuerySettings();
+        $querySettings->setIncludeDeleted(true);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
+     * Sets hidden records to be not returned by the find methods in the repository.
+     *
+     * @access public
+     *
+     * @return void
+     */
+    public function showHidden(): void
+    {
+        $querySettings = $this->getDefaultQuerySettings();
+        $querySettings->setIgnoreEnableFields(true);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
+     * Get default settings for repository, if not set create the new one.
+     *
+     * @return QuerySettingsInterface
+     */
+    protected function getDefaultQuerySettings(): QuerySettingsInterface
+    {
+        // @phpstan-ignore-next-line (defaultQuerySettings can be null)
+        if (empty($this->defaultQuerySettings)) {
+            return $this->createQuery()->getQuerySettings();
+        }
+        return $this->defaultQuerySettings;
     }
 }

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -178,6 +178,28 @@ class AbstractRepository extends Repository
     }
 
     /**
+     * Sets settings for queries in the repository.
+     *
+     * @access public
+     *
+     * @param int $storagePid
+     * @param bool $showHidden
+     * @param bool $showDeleted
+     * @param bool $useStoragePid
+     *
+     * @return void
+     */
+    public function setSettings(int $storagePid, bool $showHidden = false, bool $showDeleted = false, bool $useStoragePid = true): void
+    {
+        $querySettings = $this->getDefaultQuerySettings();
+        $querySettings->setIgnoreEnableFields($showHidden);
+        $querySettings->setIncludeDeleted($showDeleted);
+        $querySettings->setRespectStoragePage($useStoragePid);
+        $querySettings->setStoragePageIds([$storagePid]);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
      * Get default settings for repository, if not set create the new one.
      *
      * @return QuerySettingsInterface


### PR DESCRIPTION
Replaces global `PersistenceManager::persistAll()` calls with repository-specific `persistAll()` methods. This provides more granular control over persistence operations, ensuring only relevant changes are persisted by the respective repository.

Additionally, this commit removes various unused `use` statements and consistently applies storage PID configuration to all relevant repositories using `useStoragePid()`, enabling the use of `countAll()` methods which now respect the configured storage PID.

Depends on #1953 