### PR TITLE
[MAINTENANCE] Migrate `FormatRepository` to use Extbase Query API

### DIFF
--- a/Classes/Common/AbstractDocument.php
+++ b/Classes/Common/AbstractDocument.php
@@ -13,6 +13,7 @@
 namespace Kitodo\Dlf\Common;
 
 use Kitodo\Dlf\Configuration\UseGroupsConfiguration;
+use Kitodo\Dlf\Domain\Model\Format;
 use Kitodo\Dlf\Domain\Repository\DocumentRepository;
 use Kitodo\Dlf\Domain\Repository\FormatRepository;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -731,14 +732,14 @@ abstract class AbstractDocument
     protected function loadFormats(): void
     {
         if (!$this->formatsLoaded && $this->configPid > 0) {
-            // TODO: it should work with findBy(['pid' => this->configPid]) or findAll(), but returns empty result
-            $formats = $this->formatRepository->findByPid($this->configPid);
+            $formats = $this->formatRepository->findAll();
 
+            /** @var Format $format */
             foreach ($formats as $format) {
-                $this->formats[$format['type']] = [
-                    'rootElement' => $format['root'],
-                    'namespaceURI' => $format['namespace'],
-                    'class' => $format['class']
+                $this->formats[$format->getType()] = [
+                    'rootElement' => $format->getRoot(),
+                    'namespaceURI' => $format->getNamespace(),
+                    'class' => $format->getClass()
                 ];
             }
 
@@ -1029,6 +1030,7 @@ abstract class AbstractDocument
         $this->configPid = $storagePid;
         $this->useGroupsConfiguration = UseGroupsConfiguration::getInstance();
         $this->formatRepository = GeneralUtility::makeInstance(FormatRepository::class);
+        $this->formatRepository->useStoragePid($storagePid);
         $this->setPreloadedDocument($preloadedDocument);
         $this->init($location, $settings);
         $this->establishRecordId($storagePid);

--- a/Classes/Domain/Repository/FormatRepository.php
+++ b/Classes/Domain/Repository/FormatRepository.php
@@ -12,10 +12,7 @@
 
 namespace Kitodo\Dlf\Domain\Repository;
 
-use Doctrine\DBAL\Exception;
 use Kitodo\Dlf\Domain\Model\Format;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Format repository.
@@ -29,35 +26,4 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class FormatRepository extends AbstractRepository
 {
-
-    /**
-     * Find all formats by given pid.
-     *
-     * @access public
-     *
-     * @param int $pid
-     *
-     * @return list<array<string,mixed>>
-     *
-     * @throws Exception
-     */
-    public function findByPid(int $pid): array
-    {
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tx_dlf_formats');
-
-        // Get available data formats from database.
-        return $queryBuilder
-            ->select(
-                'type',
-                'root',
-                'namespace',
-                'class'
-            )
-            ->from('tx_dlf_formats')
-            ->where(
-                $queryBuilder->expr()->eq('pid', $pid)
-            )
-            ->executeQuery()->fetchAllAssociative();
-    }
 }

--- a/Tests/Functional/Common/SolrIndexingTest.php
+++ b/Tests/Functional/Common/SolrIndexingTest.php
@@ -84,7 +84,7 @@ class SolrIndexingTest extends FunctionalTestCase
         $document->setSolrcore($core->model->getUid());
         $this->persistenceManager->persistAll();
 
-        $doc = AbstractDocument::getInstance($document->getLocation(), ['useExternalApisForMetadata' => 0]);
+        $doc = AbstractDocument::getInstance($document->getLocation(), ['useExternalApisForMetadata' => 0, 'storagePid' => $document->getPid()]);
         $document->setCurrentDocument($doc);
 
         $indexingSuccessful = Indexer::add($document, $this->documentRepository);

--- a/Tests/Functional/Repository/FormatRepositoryTest.php
+++ b/Tests/Functional/Repository/FormatRepositoryTest.php
@@ -57,20 +57,4 @@ class FormatRepositoryTest extends FunctionalTestCase
         self::assertEquals(5201, $format->getUid());
         self::assertEquals('ALTO', $format->getType());
     }
-
-    /**
-     * @test
-     * @group find
-     */
-    public function canFindByPid(): void
-    {
-        $formats = $this->formatRepository->findByPid(20000);
-        self::assertNotNull($formats);
-        self::assertIsArray($formats);
-        self::assertCount(2, $formats);
-
-        $format = $formats[0];
-        self::assertEquals('ALTO', $format['type']);
-        self::assertEquals('alto', $format['root']);
-    }
 }


### PR DESCRIPTION
Removes the custom `findByPid` method from `FormatRepository`. Instead, the `AbstractDocument` configures the repository with the storage PID via `useStoragePid()`, enabling `findAll()` to correctly retrieve `Format` objects for the specified PID. This aligns the repository with standard Extbase practices.