### PR TITLE
[BUGFIX] Ensure repositories use configured storage PID

### DIFF
--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -691,6 +691,7 @@ final class IiifManifest extends AbstractDocument
     {
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(static::class);
         $this->metadataRepository = GeneralUtility::makeInstance(MetadataRepository::class);
+        $this->metadataRepository->useStoragePid($this->configPid);
     }
 
     /**

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -17,6 +17,7 @@ use DOMElement;
 use DOMNode;
 use DOMNodeList;
 use DOMXPath;
+use Kitodo\Dlf\Domain\Repository\FormatRepository;
 use Kitodo\Dlf\Domain\Repository\MetadataRepository;
 use Kitodo\Dlf\Domain\Repository\StructureRepository;
 use Kitodo\Dlf\Hooks\KitodoProductionHacks;
@@ -1121,8 +1122,12 @@ final class MetsDocument extends AbstractDocument
     protected function init(string $location, array $settings): void
     {
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(get_class($this));
+        $this->formatRepository = GeneralUtility::makeInstance(FormatRepository::class);
         $this->metadataRepository = GeneralUtility::makeInstance(MetadataRepository::class);
         $this->structureRepository = GeneralUtility::makeInstance(StructureRepository::class);
+        $this->formatRepository->useStoragePid($this->configPid);
+        $this->metadataRepository->useStoragePid($this->configPid);
+        $this->structureRepository->useStoragePid($this->configPid);
         $this->settings = $settings;
         // Get METS node from XML file.
         $this->registerNamespaces($this->xml);


### PR DESCRIPTION
Repositories for metadata, format, and structure were not explicitly configured to use the document's `configPid`. This could lead to incorrect data access by fetching or storing records from an unintended storage location. By applying `useStoragePid($this->configPid)`, repositories are now correctly scoped, resolving potential access issues.

The issue has appeared for the cached documents, as there call of the `init()` function happens in `wakeup()` function instead in the constructor.

```
(1/1) Error
Typed property Kitodo\Dlf\Common\AbstractDocument::$formatRepository must not be accessed before initialization
at Kitodo\Dlf\Common\MetsDocument->init('', array())
in /var/www/html/vendor/kitodo/presentation/Classes/Common/MetsDocument.php line 1678
```

```
    public function __wakeup(): void
    {
        $xml = Helper::getXmlFileAsString($this->asXML);
        if ($xml !== false) {
            $this->asXML = '';
            $this->xml = $xml;
            // Rebuild the unserializable properties.
            $this->init('', $this->settings);
        } else {
            $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(static::class);
            $this->logger->error('Could not load XML after deserialization');
        }
    }
```