### PR TITLE
[FEATURE] Add a standalone Basic Viewer

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -22,6 +22,12 @@ if (!defined('TYPO3')) {
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'dlf',
+    'Configuration/TypoScript/BasicViewer/',
+    'Basic Viewer Configuration'
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'dlf',
     'Configuration/TypoScript/Plugins/Feeds/',
     'RSS Feed Plugin Configuration'
 );

--- a/Configuration/TypoScript/BasicViewer/constants.typoscript
+++ b/Configuration/TypoScript/BasicViewer/constants.typoscript
@@ -1,0 +1,6 @@
+plugin.tx_dlf {
+    basicViewer {
+        rootPid =
+        viewerPid =
+    }
+}

--- a/Configuration/TypoScript/BasicViewer/setup.typoscript
+++ b/Configuration/TypoScript/BasicViewer/setup.typoscript
@@ -1,0 +1,84 @@
+page = PAGE
+page {
+    typeNum = 0
+    meta.viewport = width=device-width, initial-scale=1
+    includeCSS.dlfBasicViewer = EXT:dlf/Resources/Public/Stylesheets/default-viewer.css
+
+    10 = FLUIDTEMPLATE
+    10 {
+        templateRootPaths.10 = EXT:dlf/Resources/Private/Templates/Bootstrap/
+        file = EXT:dlf/Resources/Private/Templates/Bootstrap/Landing.html
+
+        variables {
+            rootPid = TEXT
+            rootPid.value = {$plugin.tx_dlf.basicViewer.rootPid}
+
+            viewerPid = TEXT
+            viewerPid.value = {$plugin.tx_dlf.basicViewer.viewerPid}
+
+            documentId = TEXT
+            documentId.data = GP:tx_dlf|id
+        }
+    }
+}
+
+plugin.tx_dlf_navigation = EXTBASEPLUGIN
+plugin.tx_dlf_navigation {
+    extensionName = Dlf
+    pluginName = Navigation
+    settings {
+        pageStep = 10
+        features = pagesBackward,pageSelect,pagesForward
+    }
+}
+
+plugin.tx_dlf_metadata = EXTBASEPLUGIN
+plugin.tx_dlf_metadata {
+    extensionName = Dlf
+    pluginName = Metadata
+    settings {
+        linkTitle = 0
+        getTitle = 0
+        showFull = 1
+        rootline = 1
+        separator = #
+    }
+}
+
+plugin.tx_dlf_pageview = EXTBASEPLUGIN
+plugin.tx_dlf_pageview {
+    extensionName = Dlf
+    pluginName = PageView
+    settings {
+        features =
+        elementId = tx-dlf-map
+    }
+}
+
+plugin.tx_dlf_tableofcontents = EXTBASEPLUGIN
+plugin.tx_dlf_tableofcontents {
+    extensionName = Dlf
+    pluginName = TableOfContents
+    settings {
+        targetPid = {$plugin.tx_dlf.basicViewer.viewerPid}
+    }
+}
+
+plugin.tx_dlf_toolbox = EXTBASEPLUGIN
+plugin.tx_dlf_toolbox {
+    extensionName = Dlf
+    pluginName = Toolbox
+    settings {
+        tools = rotationTool,zoomTool,imageDownloadTool,pdfDownloadTool,fulltextTool,fulltextDownloadTool
+        showAsList = 0
+        activateFullTextInitially = 0
+        fullTextScrollElement = #tx-dlf-toolbox-fulltext-selection
+    }
+}
+
+[getTSFE() && getTSFE().id == {$plugin.tx_dlf.basicViewer.viewerPid}]
+page {
+    bodyTag = <body class="tx-dlf-default-viewer tx-dlf-default-viewer-page">
+    10.file = EXT:dlf/Resources/Private/Templates/Bootstrap/Viewer.html
+}
+[END]

--- a/Documentation/User/Index.rst
+++ b/Documentation/User/Index.rst
@@ -16,6 +16,11 @@ User Manual
     :local:
     :depth: 2
 
+.. toctree::
+   :hidden:
+
+   ManualViewerSetup
+
 .. _indexing_documents:
 
 Indexing Documents

--- a/Documentation/User/ManualViewerSetup.rst
+++ b/Documentation/User/ManualViewerSetup.rst
@@ -1,0 +1,43 @@
+###################
+Manual Viewer Setup
+###################
+
+This document describes the verified manual backend setup for a standalone viewer page and configuration folder without using the root setup CLI command.
+
+Working Sequence
+================
+
+1. Create a root page (``Create a regular page > Edit page properties > Behavior > Use as root page``)
+2. Create or edit the TYPO3 site configuration for that root page in ``Site Management > Sites``.
+3. Create these children below the root page (the naming may differ):
+
+   * ``Viewer`` with page type ``Standard``
+   * ``Kitodo Configuration`` with page type ``Folder``
+
+4. Create a TypoScript template record (``sys_template``) on the root page:
+
+   * ``Site Management > TypoScript > Edit TypoScript Record (Top Dropdownmenu) > [select the root page] > Create a root TypoScript record``
+
+5. Edit the whole TypoScript record.
+
+   Under the tab ``General``:
+
+   * set the title
+   * clear any prefilled content in the ``Setup`` field
+   * set the ``Constants`` field to the required values:
+
+     .. code-block:: typoscript
+
+        plugin.tx_dlf.persistence.storagePid = <uid of Kitodo Configuration>
+        plugin.tx_dlf.basicViewer.rootPid = <uid of root page>
+        plugin.tx_dlf.basicViewer.viewerPid = <uid of Viewer page>
+
+   Under the tab ``Advanced Options``:
+
+   * enable ``Rootlevel``
+   * include these TypoScript sets:
+
+     * ``Basic Configuration``
+     * ``Basic Viewer Configuration``
+
+6. Apply tenant defaults to the configuration folder through the backend new-tenant module.

--- a/Resources/Private/Partials/Navigation/PageSelect.html
+++ b/Resources/Private/Partials/Navigation/PageSelect.html
@@ -12,28 +12,30 @@
 </f:comment>
 
 <li class="tx-dlf-navigation-pages">
-    <f:form method="post" action="pageSelect" controller="Navigation" name="pageSelectForm" object="{pageSelectForm}" addQueryString="untrusted">
+    <form method="get" action="{f:uri.page(pageUid: viewData.pageUid)}">
         <f:if condition="{viewData.requestData.id}">
-            <f:form.hidden property="id" value="{viewData.requestData.id}"/>
+            <input type="hidden" name="tx_dlf[id]" value="{viewData.requestData.id}" />
         </f:if>
         <f:if condition="{viewData.requestData.recordId}">
-            <f:form.hidden property="recordId" value="{viewData.requestData.recordId}"/>
+            <input type="hidden" name="tx_dlf[recordId]" value="{viewData.requestData.recordId}" />
         </f:if>
         <f:if condition="{viewData.requestData.double}">
-            <f:form.hidden property="double" value="{viewData.requestData.double}"/>
+            <input type="hidden" name="tx_dlf[double]" value="{viewData.requestData.double}" />
         </f:if>
         <f:if condition="{viewData.requestData.multiviewembedded} == 1">
-            <f:form.hidden name="tx_dlf[multiviewembedded]" value="{viewData.requestData.multiviewembedded}"/>
+            <input type="hidden" name="tx_dlf[multiviewembedded]" value="1" />
         </f:if>
         <label for="tx-dlf-page-{viewData.uniqueId}">
             <f:translate key="navigation.page.selectPage"/>
         </label>
-        <f:form.select id="tx-dlf-page-{viewData.uniqueId}" property="page"
-                       options="{pageOptions}"
-                       value="{viewData.requestData.page}"
-                       additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
-        </f:form.select>
-    </f:form>
+        <select id="tx-dlf-page-{viewData.uniqueId}"
+                name="tx_dlf[page]"
+                onchange="this.form.submit();">
+            <f:for each="{pageOptions}" as="pageLabel" key="pageNumber">
+                <option value="{pageNumber}" <f:if condition="{pageNumber} == {viewData.requestData.page}">selected="selected"</f:if>>{pageLabel}</option>
+            </f:for>
+        </select>
+    </form>
 </li>
 
 </html>

--- a/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
@@ -15,17 +15,17 @@
     <span class="tx-dlf-tools-imagedownload">
         <f:if condition="{double} === 0">
             <f:then>
-                <f:link.external uri="{imageDownload.0.url}">
+                <f:link.external uri="{imageDownload.0.url}" target="_blank">
                     <f:translate key="toolbox.general.downloadSinglePage" /> {imageDownload.0.mimetypeLabel}
                 </f:link.external>
             </f:then>
             <f:else>
-                <f:link.external uri="{imageDownload.0.url}">
+                <f:link.external uri="{imageDownload.0.url}" target="_blank">
                     <f:translate key="toolbox.general.downloadLeftPage" /> {imageDownload.0.mimetypeLabel}
                 </f:link.external>
                 <f:if condition="{imageDownload.1}">
                     <span class="tx-dlf-tools-imagedownload">
-                        <f:link.external uri="{imageDownload.1.url}">
+                        <f:link.external uri="{imageDownload.1.url}" target="_blank">
                             <f:translate key="toolbox.general.downloadRightPage" /> {imageDownload.1.mimetypeLabel}
                         </f:link.external>
                     </span>

--- a/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
@@ -16,22 +16,22 @@
         <f:if condition="{double} === 0">
             <f:then>
                 <f:if condition="{pageLinks.0}">
-                    <f:link.external uri="{pageLinks.0}"><f:translate key="toolbox.general.downloadSinglePage" /> (PDF)</f:link.external>
+                    <f:link.external uri="{pageLinks.0}" target="_blank"><f:translate key="toolbox.general.downloadSinglePage" /> (PDF)</f:link.external>
                 </f:if>
             </f:then>
             <f:else>
                 <f:if condition="{pageLinks.0}">
-                    <f:link.external uri="{pageLinks.0}"><f:translate key="toolbox.general.downloadLeftPage" /> (PDF)</f:link.external>
+                    <f:link.external uri="{pageLinks.0}" target="_blank"><f:translate key="toolbox.general.downloadLeftPage" /> (PDF)</f:link.external>
                 </f:if>
                 <f:if condition="{pageLinks.1}">
-                    <f:link.external uri="{pageLinks.1}"><f:translate key="toolbox.general.downloadRightPage" /> (PDF)</f:link.external>
+                    <f:link.external uri="{pageLinks.1}" target="_blank"><f:translate key="toolbox.general.downloadRightPage" /> (PDF)</f:link.external>
                 </f:if>
             </f:else>
         </f:if>
     </span>
     <span class="tx-dlf-tools-pdf-work">
         <f:if condition="{workLink}">
-            <f:link.external uri="{workLink}"><f:translate key="toolbox.pdfDownload.downloadWork"/> (PDF)</f:link.external>
+            <f:link.external uri="{workLink}" target="_blank"><f:translate key="toolbox.pdfDownload.downloadWork"/> (PDF)</f:link.external>
         </f:if>
     </span>
     <span class="tx-dlf-tools-score">

--- a/Resources/Private/Templates/Bootstrap/Landing.html
+++ b/Resources/Private/Templates/Bootstrap/Landing.html
@@ -1,0 +1,89 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<div class="tx-dlf-default-viewer-shell tx-dlf-default-viewer-landing">
+    <div class="tx-dlf-default-viewer-welcome">
+        <section class="tx-dlf-default-viewer-welcome-hero">
+            <p class="tx-dlf-default-viewer-kicker">Kitodo Presentation</p>
+            <h1>New viewer instance</h1>
+            <p class="tx-dlf-default-viewer-welcome-lead">
+                This installation already includes a working viewer page and a prepared configuration folder.
+            </p>
+
+            <form class="tx-dlf-default-viewer-input-form" action="{f:uri.page(pageUid: viewerPid)}" method="get" onsubmit="var input=this.querySelector('input[name='tx_dlf[id]']'); if(input){ input.value=input.value.trim(); }">
+                <label class="tx-dlf-default-viewer-input-label" for="tx-dlf-default-viewer-document-url">
+                    Enter a METS, OAI-PMH or other supported document URL
+                </label>
+                <div class="tx-dlf-default-viewer-input-row">
+                    <input id="tx-dlf-default-viewer-document-url"
+                           class="tx-dlf-default-viewer-input"
+                           type="url"
+                           name="tx_dlf[id]"
+                           placeholder="https://example.org/record.xml"
+                           inputmode="url"
+                           autocomplete="off" />
+                    <button type="submit" class="tx-dlf-default-viewer-button">Open</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="tx-dlf-default-viewer-welcome-section">
+            <div class="tx-dlf-default-viewer-welcome-header">
+                <p class="tx-dlf-default-viewer-kicker">Examples</p>
+                <h2>Examples of supported content types</h2>
+            </div>
+
+            <div class="tx-dlf-default-viewer-example-grid">
+                <article class="tx-dlf-default-viewer-example-card">
+                    <p class="tx-dlf-default-viewer-kicker">Classic documents</p>
+                    <h3>Prints, letters, newspapers</h3>
+                    <p>Representative METS/OAI-PMH document for traditional digitized materials such as prints, letters, newspapers and other classic sources.</p>
+                    <p>Examples:</p>
+                    <f:link.page pageUid="{viewerPid}" class="tx-dlf-default-viewer-link"
+                        additionalParams="{tx_dlf: {id: 'http://digital.slub-dresden.de/oai/?verb=GetRecord&metadataPrefix=mets&identifier=oai:de:slub-dresden:db:id-263566811'}}">
+                        "Der furnembsten, notwendigsten, der gantzen Architectur ..."
+                    </f:link.page>
+                    <f:link.page pageUid="{viewerPid}" class="tx-dlf-default-viewer-link"
+                        additionalParams="{tx_dlf: {id: 'http://daten.digitale-sammlungen.de/~db/mets/bsb00020619_mets.xml'}}">
+                        "Prima [- Undecima] pars librorum divi Aurelii Augustini ..."
+                    </f:link.page>
+                    <f:link.page pageUid="{viewerPid}" class="tx-dlf-default-viewer-link"
+                        additionalParams="{tx_dlf: {id: 'https://digi.bib.uni-mannheim.de/fileadmin/digi/428458289/428458289.xml'}}">
+                        "Historia Baetica"
+                    </f:link.page>
+                </article>
+
+                <article class="tx-dlf-default-viewer-example-card">
+                    <p class="tx-dlf-default-viewer-kicker">Musical sources</p>
+                    <h3>Scores and bar-by-bar navigation</h3>
+                    <p>Support for digitized musical sources in MEI format is stable. Musical scores are rendered with Verovio and can be navigated bar by bar.</p>
+                    <span class="tx-dlf-default-viewer-link tx-dlf-default-viewer-link-muted">Examples coming soon</span>
+                </article>
+
+                <article class="tx-dlf-default-viewer-example-card">
+                    <p class="tx-dlf-default-viewer-kicker">3D objects</p>
+                    <h3>Embedded model viewers</h3>
+                    <p>Support for 3D objects is now an official feature. Kitodo.Presentation integrates Google&apos;s open source model-viewer and also allows other viewers to be used instead.</p>
+                    <span class="tx-dlf-default-viewer-link tx-dlf-default-viewer-link-muted">Examples coming soon</span>
+                </article>
+            </div>
+        </section>
+
+        <section class="tx-dlf-default-viewer-welcome-section tx-dlf-default-viewer-welcome-section-compact">
+            <div class="tx-dlf-default-viewer-welcome-header">
+                <p class="tx-dlf-default-viewer-kicker">Formats</p>
+                <h2>Supported input formats</h2>
+            </div>
+            <ul class="tx-dlf-default-viewer-format-list">
+                <li>OAI-PMH endpoints delivering compatible records</li>
+                <li>METS documents</li>
+                                <li>OCR and full text via ALTO and TEI</li>
+                <li>MEI-based musical sources</li>
+                <li>3D object workflows through configured embedded viewers</li>
+            </ul>
+            <p>
+                Open documents on the viewer page by passing the source URL in <code>tx_dlf[id]</code>.
+            </p>
+        </section>
+    </div>
+</div>
+</html>

--- a/Resources/Private/Templates/Bootstrap/Viewer.html
+++ b/Resources/Private/Templates/Bootstrap/Viewer.html
@@ -1,0 +1,107 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<div class="tx-dlf-default-viewer-shell">
+            <div class="tx-dlf-default-viewer-viewframe">
+                <aside class="tx-dlf-default-viewer-control-bar">
+                    <section class="tx-dlf-default-viewer-control-panel tx-dlf-default-viewer-control-panel-metadata">
+                        <div class="tx-dlf-default-viewer-control-header">
+                            <p class="tx-dlf-default-viewer-panel-kicker">Document</p>
+                            <h2>Metadata</h2>
+                        </div>
+                        <f:cObject typoscriptObjectPath="plugin.tx_dlf_metadata" />
+                    </section>
+
+                    <section class="tx-dlf-default-viewer-control-panel tx-dlf-default-viewer-control-panel-toc">
+                        <div class="tx-dlf-default-viewer-control-header">
+                            <p class="tx-dlf-default-viewer-panel-kicker">Structure</p>
+                            <h2>Contents</h2>
+                        </div>
+                        <f:cObject typoscriptObjectPath="plugin.tx_dlf_tableofcontents" />
+                    </section>
+                </aside>
+
+                <main class="tx-dlf-default-viewer-main">
+                    <div class="document-view tx-dlf-default-viewer-document-view">
+                        <div class="document-functions tx-dlf-default-viewer-document-functions">
+                            <div class="tx-dlf-default-viewer-provider">
+                                <div>
+                                    <p class="tx-dlf-default-viewer-kicker">Kitodo Presentation</p>
+                                    <h1>Viewer</h1>
+                                </div>
+                                <div class="tx-dlf-default-viewer-provider-actions">
+                                    <f:link.page pageUid="{rootPid}" class="tx-dlf-default-viewer-button tx-dlf-default-viewer-button-secondary">Back</f:link.page>
+                                </div>
+                            </div>
+
+                            <div class="tx-dlf-default-viewer-submenu">
+                                <f:cObject typoscriptObjectPath="plugin.tx_dlf_navigation" />
+                                <f:cObject typoscriptObjectPath="plugin.tx_dlf_toolbox" />
+                            </div>
+                        </div>
+
+                        <f:if condition="{documentId}">
+                            <f:then>
+                                <f:cObject typoscriptObjectPath="plugin.tx_dlf_pageview" />
+                            </f:then>
+                            <f:else>
+                                <div class="tx-dlf-default-viewer-empty-state">
+                                    <div class="tx-dlf-default-viewer-empty-notice">
+                                        <p class="tx-dlf-default-viewer-kicker">No Document</p>
+                                        <h2>No document selected</h2>
+                                        <p>Pass a document URL in <code>tx_dlf[id]</code> to open a METS or IIIF document.</p>
+                                    </div>
+                                </div>
+                            </f:else>
+                        </f:if>
+                    </div>
+                </main>
+            </div>
+
+            <script>
+                (function () {
+                    function updateViewerSize() {
+                        if (window.tx_dlf_viewer && typeof window.tx_dlf_viewer.updateLayerSize === 'function') {
+                            window.setTimeout(function () { window.tx_dlf_viewer.updateLayerSize(); }, 0);
+                            window.setTimeout(function () { window.tx_dlf_viewer.updateLayerSize(); }, 250);
+                        }
+                    }
+
+                    function enterFullscreen() {
+                        document.body.classList.add('fullscreen');
+                        var button = document.querySelector('li.tx-dlf-tools-fullscreen a');
+                        if (button) {
+                            button.classList.add('active');
+                        }
+                        updateViewerSize();
+                    }
+
+                    function exitFullscreen() {
+                        document.body.classList.remove('fullscreen');
+                        var button = document.querySelector('li.tx-dlf-tools-fullscreen a');
+                        if (button) {
+                            button.classList.remove('active');
+                        }
+                        updateViewerSize();
+                    }
+
+                    function toggleFullscreen(event) {
+                        event.preventDefault();
+                        if (document.body.classList.contains('fullscreen')) {
+                            exitFullscreen();
+                        } else {
+                            enterFullscreen();
+                        }
+                    }
+
+                    window.addEventListener('load', function () {
+                        updateViewerSize();
+                        var fullscreenButton = document.querySelector('li.tx-dlf-tools-fullscreen a');
+                        if (fullscreenButton) {
+                            fullscreenButton.addEventListener('click', toggleFullscreen);
+                            fullscreenButton.addEventListener('touchstart', toggleFullscreen, { passive: false });
+                        }
+                    });
+                })();
+            </script>
+</div>
+</html>

--- a/Resources/Public/Stylesheets/default-viewer.css
+++ b/Resources/Public/Stylesheets/default-viewer.css
@@ -1,0 +1,596 @@
+body.tx-dlf-default-viewer-page {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.tx-dlf-default-viewer-shell {
+  --default-ink: #18212c;
+  --default-link: #1a4d8f;
+  --default-link-hover: #0f539f;
+  --default-accent: #213345;
+  --default-surface: rgba(255, 255, 255, 0.94);
+  --default-border: rgba(24, 33, 44, 0.1);
+  --default-shadow: 0 10px 24px rgba(7, 14, 21, 0.14);
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  color: var(--default-ink);
+  background: whitesmoke;
+}
+
+.tx-dlf-default-viewer-viewframe {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+
+.tx-dlf-default-viewer-landing {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.94)),
+    linear-gradient(120deg, rgba(26, 77, 143, 0.08), transparent 35%),
+    whitesmoke;
+}
+
+.tx-dlf-default-viewer-welcome {
+  width: min(1080px, calc(100% - 48px));
+  margin: 48px auto;
+  padding: 40px 44px 56px;
+  border: 1px solid var(--default-border);
+  border-radius: 20px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+}
+
+.tx-dlf-default-viewer-welcome-hero,
+.tx-dlf-default-viewer-welcome-section {
+  margin-bottom: 40px;
+  padding: 0;
+}
+
+.tx-dlf-default-viewer-welcome-hero h1,
+.tx-dlf-default-viewer-welcome-header h2,
+.tx-dlf-default-viewer-example-card h3 {
+  margin: 0;
+}
+
+.tx-dlf-default-viewer-welcome-lead {
+  max-width: 760px;
+  margin: 18px 0 0;
+  font-size: 18px;
+  line-height: 1.65;
+}
+
+.tx-dlf-default-viewer-welcome-header {
+  margin-bottom: 18px;
+}
+
+.tx-dlf-default-viewer-welcome-hero {
+  padding-bottom: 34px;
+  border-bottom: 1px solid var(--default-border);
+}
+
+
+.tx-dlf-default-viewer-example-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.tx-dlf-default-viewer-example-card {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 20px 18px;
+  border: 1px solid var(--default-border);
+  border-radius: 16px;
+  background: white;
+}
+
+.tx-dlf-default-viewer-example-card p,
+.tx-dlf-default-viewer-welcome-section p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.tx-dlf-default-viewer-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--default-link);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-link:hover {
+  color: var(--default-link-hover);
+}
+
+.tx-dlf-default-viewer-link-muted {
+  color: slategray;
+}
+
+.tx-dlf-default-viewer-link-muted:hover {
+  color: slategray;
+}
+
+.tx-dlf-default-viewer-format-list {
+  margin: 0 0 18px;
+  padding-left: 20px;
+}
+
+.tx-dlf-default-viewer-format-list li {
+  margin-bottom: 10px;
+  line-height: 1.6;
+}
+
+
+.tx-dlf-default-viewer-input-form {
+  display: grid;
+  gap: 14px;
+}
+
+.tx-dlf-default-viewer-input-label {
+  font-weight: 700;
+}
+
+.tx-dlf-default-viewer-input-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.tx-dlf-default-viewer-input {
+  min-width: 0;
+  min-height: 46px;
+  padding: 0 14px;
+  border: 1px solid var(--default-border);
+  border-radius: 12px;
+  background: white;
+  color: var(--default-ink);
+  font: inherit;
+}
+
+.tx-dlf-default-viewer-input:focus {
+  outline: 2px solid rgba(26, 77, 143, 0.22);
+  outline-offset: 1px;
+}
+
+.tx-dlf-default-viewer-welcome-section-compact {
+  max-width: 760px;
+  margin-bottom: 0;
+  padding-top: 10px;
+  border-top: 1px solid var(--default-border);
+}
+
+.tx-dlf-default-viewer-control-bar {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1px;
+  min-height: 100vh;
+  border-right: 1px solid var(--default-border);
+  background: rgba(24, 33, 44, 0.14);
+}
+
+.tx-dlf-default-viewer-control-panel,
+.tx-dlf-default-viewer-card {
+  border: 1px solid var(--default-border);
+  background: var(--default-surface);
+}
+
+.tx-dlf-default-viewer-control-panel {
+  min-width: 0;
+  padding: 22px 20px;
+  overflow: auto;
+}
+
+.tx-dlf-default-viewer-control-header {
+  margin-bottom: 16px;
+}
+
+.tx-dlf-default-viewer-main {
+  min-width: 0;
+}
+
+.tx-dlf-default-viewer-document-view {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.tx-dlf-default-viewer-empty-state {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.tx-dlf-default-viewer-empty-notice {
+  width: min(460px, 100%);
+  padding: 24px 28px;
+  border: 1px solid var(--default-border);
+  border-radius: 18px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+  text-align: center;
+}
+
+.tx-dlf-default-viewer-empty-notice h2,
+.tx-dlf-default-viewer-empty-notice p {
+  margin-top: 0;
+}
+
+.tx-dlf-default-viewer-empty-notice p:last-child {
+  margin-bottom: 0;
+}
+
+.tx-dlf-default-viewer-document-functions {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 20;
+  display: grid;
+  gap: 10px;
+  padding: 14px 18px;
+  pointer-events: none;
+}
+
+.tx-dlf-default-viewer-provider,
+.tx-dlf-default-viewer-submenu {
+  pointer-events: auto;
+  border: 1px solid var(--default-border);
+  border-radius: 10px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+}
+
+.tx-dlf-default-viewer-provider {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+}
+
+.tx-dlf-default-viewer-provider h1,
+.tx-dlf-default-viewer-control-header h2,
+.tx-dlf-default-viewer-card h2 {
+  margin: 0;
+}
+
+.tx-dlf-default-viewer-provider h1 {
+  font-size: 26px;
+  line-height: 1;
+}
+
+.tx-dlf-default-viewer-provider-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tx-dlf-default-viewer-kicker,
+.tx-dlf-default-viewer-panel-kicker {
+  margin: 0 0 4px;
+  color: slategray;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tx-dlf-default-viewer-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--default-accent);
+  border-radius: 999px;
+  background: var(--default-accent);
+  color: white;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-button-secondary {
+  background: white;
+  color: var(--default-accent);
+  border-color: rgba(33, 51, 69, 0.2);
+}
+
+.tx-dlf-default-viewer-submenu {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  padding: 10px 12px;
+  color: var(--default-accent);
+}
+
+.tx-dlf-default-viewer-submenu ul,
+.tx-dlf-default-viewer-submenu li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-dlf-default-viewer-submenu a,
+.tx-dlf-default-viewer-submenu span,
+.tx-dlf-default-viewer-submenu label,
+.tx-dlf-default-viewer-submenu select {
+  color: inherit;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward > div,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward > div,
+.tx-dlf-default-viewer-submenu li {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--default-border);
+  border-radius: 7px;
+  background: var(--default-surface);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.tx-dlf-default-viewer-submenu a:hover,
+.tx-dlf-default-viewer-submenu li.tx-dlf-tools-fullscreen a.active {
+  color: var(--default-link-hover);
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward span,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward span {
+  opacity: 0.46;
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages {
+  gap: 10px;
+  padding: 6px 10px;
+  background: var(--default-surface);
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages label {
+  font-weight: 700;
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages select {
+  min-width: 110px;
+  min-height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--default-border);
+  border-radius: 6px;
+  background: white;
+}
+
+.tx-dlf-default-viewer-submenu li[class^="tx-dlf-tools-"] span,
+.tx-dlf-default-viewer-submenu li[class^="tx-dlf-tools-"] a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-dlf-default-viewer-document-view .tx-dlf-map {
+  position: absolute;
+  inset: 0;
+}
+
+#tx-dlf-annotationselection,
+#tx-dlf-toolbox-fulltext-selection {
+  border-radius: 10px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+}
+
+#tx-dlf-annotationselection {
+  position: absolute;
+  top: 110px;
+  right: 24px;
+  z-index: 21;
+  max-width: 320px;
+  padding: 12px 14px;
+}
+
+#tx-dlf-annotationselection:empty,
+#tx-dlf-toolbox-fulltext-selection:empty {
+  display: none;
+}
+
+.tx-dlf-toolbox-fulltext-container {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  left: 24px;
+  z-index: 16;
+  pointer-events: none;
+}
+
+#tx-dlf-toolbox-fulltext-selection {
+  max-width: min(640px, 100%);
+  max-height: 28vh;
+  overflow: auto;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.55;
+  pointer-events: auto;
+}
+
+#tx-dlf-toolbox-fulltext-selection .textline,
+#tx-dlf-toolbox-fulltext-selection .sp {
+  display: inline;
+}
+
+#tx-dlf-toolbox-fulltext-selection .sp {
+  white-space: pre;
+}
+
+#tx-dlf-toolbox-fulltext-selection .highlight {
+  background: khaki;
+}
+
+#tx-dlf-toolbox-fulltext-selection .string,
+#tx-dlf-toolbox-fulltext-selection .hyp {
+  color: inherit;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents,
+.tx-dlf-default-viewer-control-panel .tx-dlf-metadata-titledata {
+  font-size: 14px;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents li {
+  margin-bottom: 8px;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a {
+  color: var(--default-link);
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a:hover {
+  text-decoration: underline;
+}
+
+.tx-dlf-metadata-titledata {
+  margin: 0;
+}
+
+.tx-dlf-metadata-titledata dt {
+  margin: 0 0 4px;
+  color: #425264;
+  font-weight: 700;
+}
+
+.tx-dlf-metadata-titledata dd {
+  margin: 0 0 14px;
+}
+
+.tx-dlf-default-viewer-card {
+  max-width: 760px;
+  margin: 12vh auto 0;
+  padding: 28px;
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(9, 16, 24, 0.14);
+}
+
+.tx-dlf-default-viewer-actions {
+  margin: 24px 0 0;
+}
+
+.tx-dlf-default-viewer-example {
+  margin-bottom: 0;
+  word-break: break-all;
+}
+
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-viewframe {
+  grid-template-columns: 1fr;
+}
+
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-control-bar {
+  display: none;
+}
+
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-document-functions {
+  padding: 12px;
+}
+
+@media (max-width: 980px) {
+  .tx-dlf-default-viewer-welcome {
+    width: min(100% - 32px, 1080px);
+    margin: 24px auto;
+    padding: 32px 28px 40px;
+  }
+
+  .tx-dlf-default-viewer-example-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1180px) {
+  .tx-dlf-default-viewer-viewframe {
+    grid-template-columns: 1fr;
+  }
+
+  .tx-dlf-default-viewer-main {
+    order: 1;
+  }
+
+  .tx-dlf-default-viewer-control-bar {
+    order: 2;
+    min-height: auto;
+    grid-template-rows: none;
+    grid-template-columns: 1fr;
+    border-top: 1px solid var(--default-border);
+    border-right: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .tx-dlf-default-viewer-welcome {
+    width: min(100% - 24px, 1080px);
+    margin: 12px auto;
+    padding: 24px 18px 28px;
+  }
+
+  .tx-dlf-default-viewer-welcome-lead {
+    font-size: 16px;
+  }
+
+  .tx-dlf-default-viewer-input-row {
+    grid-template-columns: 1fr;
+  }
+
+  .tx-dlf-default-viewer-input-row .tx-dlf-default-viewer-button {
+    width: 100%;
+  }
+
+  .tx-dlf-default-viewer-document-functions {
+    padding: 12px;
+  }
+
+  .tx-dlf-default-viewer-provider {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tx-dlf-default-viewer-submenu {
+    gap: 8px;
+  }
+
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages,
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form {
+    width: 100%;
+  }
+
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages select {
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  .tx-dlf-toolbox-fulltext-container {
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+  }
+}


### PR DESCRIPTION
This PR adds a first iteration of a minimal standalone "Basic Viewer". Its design is based on the DFG-Viewer.

<img width="1880" height="1122" alt="viewer" src="https://github.com/user-attachments/assets/ed6c5ab3-6a4a-486f-af40-87b040eec58a" />


It adds the viewer-facing TypoScript, templates, styling, and documentation needed to render a minimal standalone viewer (and a temporary (?) landing page independently).

## Changes

- adds a dedicated `BasicViewer` TypoScript set
- adds a (temporary?) landing page and viewer shell
  - The landing page is intentionally provisional and should be reviewed for direction. It found it helpful to have a landing page to test the viewer and to have a place to link to from the viewer when no manifest is loaded, but it may not be necessary or desirable in the long or even short term. Maybe thats more something for the DFG-Viewer as thats more of a use case for them? Open for discussion. Easy too remove if we decide we don't need it.
- adds the dedicated default viewer styling
- adds documentation for the manual viewer setup. 