### PR TITLE
[FEATURE] Add a tenant setup CLI command

### DIFF
--- a/Classes/Command/BootstrapSetupCommand.php
+++ b/Classes/Command/BootstrapSetupCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kitodo\Dlf\Command;
+
+use Kitodo\Dlf\Service\BootstrapRootSetupService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * CLI command for running the bootstrap root setup manually.
+ */
+final class BootstrapSetupCommand extends Command
+{
+    public function __construct(private readonly BootstrapRootSetupService $bootstrapRootSetupService)
+    {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        $this->setDescription('Create the root page tree and viewer setup manually.');
+        $this->addOption('identifier', null, InputOption::VALUE_REQUIRED, 'Custom site identifier.');
+        $this->addOption('base', null, InputOption::VALUE_REQUIRED, 'Custom site base path, for example /my-instance/.');
+        $this->addOption('root-title', null, InputOption::VALUE_REQUIRED, 'Custom root page title.');
+        $this->addOption('root-slug', null, InputOption::VALUE_REQUIRED, 'Custom root page slug.');
+        $this->addOption('viewer-slug', null, InputOption::VALUE_REQUIRED, 'Custom viewer page slug.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Page setup');
+
+        try {
+            $result = $this->bootstrapRootSetupService->runSetup(
+                [
+                    'identifier' => $input->getOption('identifier'),
+                    'base' => $input->getOption('base'),
+                    'rootTitle' => $input->getOption('root-title'),
+                    'rootSlug' => $input->getOption('root-slug'),
+                    'viewerSlug' => $input->getOption('viewer-slug'),
+                ]
+            );
+        } catch (Throwable $exception) {
+            $io->error($exception->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->definitionList(
+            ['Site identifier' => $result['siteIdentifier']],
+            ['Site base' => $result['siteBase']],
+            ['Root page' => (string) $result['rootPageId']],
+            ['Viewer page' => (string) $result['viewerPageId']],
+            ['Configuration page' => (string) $result['configurationPageId']],
+            ['Template record' => (string) $result['templateId']],
+            ['Solr core' => 'not implemented yet'],
+        );
+        $io->success('Default page setup completed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Command/TenantSetupCommand.php
+++ b/Classes/Command/TenantSetupCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kitodo\Dlf\Command;
+
+use Kitodo\Dlf\Service\TenantModuleSetupService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * CLI command for running the tenant module setup manually.
+ */
+final class TenantSetupCommand extends Command
+{
+    public function __construct(
+        private readonly TenantModuleSetupService $tenantModuleSetupService,
+    ) {
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        $this->setDescription('Run the tenant setup for an existing configuration folder.');
+        $this->addOption('config-page', null, InputOption::VALUE_REQUIRED, 'Existing configuration folder uid.');
+        $this->addOption('namespaces', null, InputOption::VALUE_NONE, 'Apply namespace defaults.');
+        $this->addOption('formats', null, InputOption::VALUE_NONE, 'Alias for --namespaces.');
+        $this->addOption('structures', null, InputOption::VALUE_NONE, 'Apply structure defaults.');
+        $this->addOption('metadata', null, InputOption::VALUE_NONE, 'Apply metadata defaults.');
+        $this->addOption('solr-core', null, InputOption::VALUE_NONE, 'Create a Solr core if missing.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Tenant setup');
+
+        $configurationPage = $input->getOption('config-page');
+        if (
+            !is_string($configurationPage)
+            || trim($configurationPage) === ''
+            || !ctype_digit(trim($configurationPage))
+        ) {
+            $io->error('The --config-page option is required and must be a numeric page uid.');
+            return Command::FAILURE;
+        }
+
+        $steps = [
+            'formats' => (bool) $input->getOption('namespaces') || (bool) $input->getOption('formats'),
+            'structures' => (bool) $input->getOption('structures'),
+            'metadata' => (bool) $input->getOption('metadata'),
+            'solrCore' => (bool) $input->getOption('solr-core'),
+        ];
+        if (!in_array(true, $steps, true)) {
+            $steps = [
+                'formats' => true,
+                'structures' => true,
+                'metadata' => true,
+                'solrCore' => true,
+            ];
+        }
+
+        try {
+            $result = $this->tenantModuleSetupService->runSetup((int) trim($configurationPage), $steps);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->definitionList(
+            ['Configuration page' => (string) $result['configurationPageId']],
+            ['Namespaces' => $result['steps']['formats'] ? (string) $result['results']['formats'] : 'skipped'],
+            ['Structures' => $result['steps']['structures'] ? (string) $result['results']['structures'] : 'skipped'],
+            ['Metadata' => $result['steps']['metadata'] ? (string) $result['results']['metadata'] : 'skipped'],
+            ['Solr core' => $result['steps']['solrCore'] ? (($result['results']['solrCore'] !== null) ? (string) $result['results']['solrCore'] : 'not created') : 'skipped']
+        );
+        $io->success('Tenant setup completed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Common/Helper.php
+++ b/Classes/Common/Helper.php
@@ -17,6 +17,8 @@ use Kitodo\Dlf\Domain\Model\Structure;
 use Kitodo\Dlf\Domain\Repository\StructureRepository;
 use TYPO3\CMS\Core\Configuration\ConfigurationManager;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\Uri;
@@ -548,11 +550,27 @@ class Helper
     public static function processDatabaseAsAdmin(array $data = [], array $cmd = [], bool $reverseOrder = false, bool $cmdFirst = false): array
     {
         $context = GeneralUtility::makeInstance(Context::class);
+        $isCli = Environment::isCli();
+        // phpcs:ignore Squiz.PHP.Superglobals.SuperGlobalUsage,WordPress.WP.GlobalVariablesOverride.Prohibited -- TYPO3 stores the current PSR-7 request in the global runtime state.
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        $isBackendRequest = $request !== null && ApplicationType::fromRequest($request)->isBackend();
 
-        if (
-            ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()
-            && $context->getPropertyFromAspect('backend.user', 'isAdmin')
-        ) {
+        if ($isCli) { // Initialize CLI user if not already done (e.g. by a CommandController)
+            // phpcs:ignore Squiz.PHP.Superglobals.SuperGlobalUsage,WordPress.WP.GlobalVariablesOverride.Prohibited -- TYPO3 exposes the backend user through global runtime state.
+            $backendUser = $GLOBALS['BE_USER'] ?? null;
+            if ($backendUser === null) {
+                Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
+                // phpcs:ignore Squiz.PHP.Superglobals.SuperGlobalUsage,WordPress.WP.GlobalVariablesOverride.Prohibited -- TYPO3 exposes the backend user through global runtime state.
+                $backendUser = $GLOBALS['BE_USER'] ?? null;
+            }
+            if (empty($backendUser->user['uid'] ?? null) || !$backendUser->isAdmin()) {
+                Bootstrap::initializeBackendAuthentication();
+                // phpcs:ignore Squiz.PHP.Superglobals.SuperGlobalUsage,WordPress.WP.GlobalVariablesOverride.Prohibited -- TYPO3 exposes the backend user through global runtime state.
+                $backendUser = $GLOBALS['BE_USER'] ?? null;
+            }
+        }
+
+        if (($isCli && isset($backendUser) && $backendUser->isAdmin()) || ($isBackendRequest && $context->getPropertyFromAspect('backend.user', 'isAdmin'))) {
             // Instantiate TYPO3 core engine.
             $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
             // We do not use workspaces and have to bypass restrictions in DataHandler.

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -12,26 +12,13 @@
 
 namespace Kitodo\Dlf\Controller\Backend;
 
-use Kitodo\Dlf\Common\Helper;
-use Kitodo\Dlf\Common\Solr\Solr;
 use Kitodo\Dlf\Controller\AbstractController;
-use Kitodo\Dlf\Domain\Model\Format;
-use Kitodo\Dlf\Domain\Model\Metadata;
-use Kitodo\Dlf\Domain\Model\SolrCore;
-use Kitodo\Dlf\Domain\Model\Structure;
-use Kitodo\Dlf\Domain\Repository\FormatRepository;
-use Kitodo\Dlf\Domain\Repository\MetadataRepository;
-use Kitodo\Dlf\Domain\Repository\SolrCoreRepository;
-use Kitodo\Dlf\Domain\Repository\StructureRepository;
 use Kitodo\Dlf\Service\BootstrapRootSetupService;
+use Kitodo\Dlf\Service\TenantDefaultsSetupService;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Exception\SiteNotFoundException;
-use TYPO3\CMS\Core\Localization\LocalizationFactory;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
-use TYPO3\CMS\Core\Site\Entity\NullSite;
-use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -58,86 +45,15 @@ class NewTenantController extends AbstractController
 
     /**
      * @access protected
-     * @var mixed[] All configured site languages
      */
-    protected array $siteLanguages;
-
-    /**
-     * @access protected
-     * @var LocalizationFactory Language factory to get language key/values by our own.
-     */
-    protected LocalizationFactory $languageFactory;
-
-    /**
-     * @access protected
-     * @var FormatRepository
-     */
-    protected FormatRepository $formatRepository;
+    protected TenantDefaultsSetupService $tenantDefaultsSetupService;
 
     /**
      * @access public
-     *
-     * @param FormatRepository $formatRepository
-     *
-     * @return void
      */
-    public function injectFormatRepository(FormatRepository $formatRepository): void
+    public function injectTenantDefaultsSetupService(TenantDefaultsSetupService $tenantDefaultsSetupService): void
     {
-        $this->formatRepository = $formatRepository;
-    }
-
-    /**
-     * @access protected
-     * @var MetadataRepository
-     */
-    protected MetadataRepository $metadataRepository;
-
-    /**
-     * @access public
-     *
-     * @param MetadataRepository $metadataRepository
-     *
-     * @return void
-     */
-    public function injectMetadataRepository(MetadataRepository $metadataRepository): void
-    {
-        $this->metadataRepository = $metadataRepository;
-    }
-
-    /**
-     * @access protected
-     * @var StructureRepository
-     */
-    protected StructureRepository $structureRepository;
-
-    /**
-     * @access public
-     *
-     * @param StructureRepository $structureRepository
-     *
-     * @return void
-     */
-    public function injectStructureRepository(StructureRepository $structureRepository): void
-    {
-        $this->structureRepository = $structureRepository;
-    }
-
-    /**
-     * @access protected
-     * @var SolrCoreRepository
-     */
-    protected SolrCoreRepository $solrCoreRepository;
-
-    /**
-     * @access public
-     *
-     * @param SolrCoreRepository $solrCoreRepository
-     *
-     * @return void
-     */
-    public function injectSolrCoreRepository(SolrCoreRepository $solrCoreRepository): void
-    {
-        $this->solrCoreRepository = $solrCoreRepository;
+        $this->tenantDefaultsSetupService = $tenantDefaultsSetupService;
     }
 
     /**
@@ -158,6 +74,7 @@ class NewTenantController extends AbstractController
      *
      * @access protected
      *
+     * @param string $template template name to render
      * @param mixed[] $extraData extra view data used to render the template (in addition to $viewData of AbstractController)
      *
      * @return ResponseInterface the response
@@ -186,23 +103,10 @@ class NewTenantController extends AbstractController
     {
         $this->pid = (int) ($this->request->getQueryParams()['id'] ?? null);
 
-        $this->formatRepository->useStoragePid($this->pid);
-        $this->metadataRepository->useStoragePid($this->pid);
-        $this->solrCoreRepository->useStoragePid($this->pid);
-        $this->structureRepository->useStoragePid($this->pid);
-
         $frameworkConfiguration = $this->configurationManager->getConfiguration($this->configurationManager::CONFIGURATION_TYPE_FRAMEWORK);
         $frameworkConfiguration['persistence']['storagePid'] = $this->pid;
         $this->configurationManager->setConfiguration($frameworkConfiguration);
 
-        $this->languageFactory = GeneralUtility::makeInstance(LocalizationFactory::class);
-
-        try {
-            $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($this->pid);
-        } catch (SiteNotFoundException $e) {
-            $site = new NullSite();
-        }
-        $this->siteLanguages = $site->getLanguages();
     }
 
 
@@ -222,7 +126,6 @@ class NewTenantController extends AbstractController
         return $this->redirect('index', null, null, ['refreshPageTree' => 1]);
     }
 
-
     /**
      * Action adding formats records
      *
@@ -232,29 +135,12 @@ class NewTenantController extends AbstractController
      */
     public function addFormatAction(): ResponseInterface
     {
-        // Include formats definition file.
-        $formatsDefaults = $this->getRecords('Format');
-
-        $doPersist = false;
-
-        foreach ($formatsDefaults as $type => $values) {
-            // if default format record is not found, add it to the repository
-            if ($this->formatRepository->findOneBy(['type' => $type]) === null) {
-                $newRecord = GeneralUtility::makeInstance(Format::class);
-                $newRecord->setType($type);
-                $newRecord->setRoot($values['root']);
-                $newRecord->setNamespace($values['namespace']);
-                $newRecord->setClass($values['class']);
-                $this->formatRepository->add($newRecord);
-
-                $doPersist = true;
-            }
-        }
-
-        // We must persist here, if we changed anything.
-        if ($doPersist === true) {
-            $this->formatRepository->persistAll();
-        }
+        $this->tenantDefaultsSetupService->run($this->pid, [
+            'formats' => true,
+            'structures' => false,
+            'metadata' => false,
+            'solrCore' => false,
+        ]);
 
         return $this->redirect('index');
     }
@@ -268,81 +154,12 @@ class NewTenantController extends AbstractController
      */
     public function addMetadataAction(): ResponseInterface
     {
-        // Include metadata definition file.
-        $metadataDefaults = $this->getRecords('Metadata');
-
-        // load language file in own array
-        $metadataLabels = $this->languageFactory->getParsedData('EXT:dlf/Resources/Private/Language/locallang_metadata.xlf', $this->siteLanguages[0]->getLocale()->getLanguageCode());
-
-        $insertedFormats = $this->formatRepository->findAll();
-
-        $availableFormats = [];
-        foreach ($insertedFormats as $insertedFormat) {
-            $availableFormats[$insertedFormat->getRoot()] = $insertedFormat->getUid();
-        }
-
-        $defaultWrap = BackendUtility::getTcaFieldConfiguration('tx_dlf_metadata', 'wrap')['default'];
-
-        $data = [];
-        foreach ($metadataDefaults as $indexName => $values) {
-            $formatIds = [];
-
-            foreach ($values['format'] as $format) {
-                $format['encoded'] = $availableFormats[$format['format_root']];
-                unset($format['format_root']);
-                $formatIds[] = uniqid('NEW');
-                $data['tx_dlf_metadataformat'][end($formatIds)] = $format;
-                $data['tx_dlf_metadataformat'][end($formatIds)]['pid'] = $this->pid;
-            }
-
-            $data['tx_dlf_metadata'][uniqid('NEW')] = [
-                'pid' => $this->pid,
-                'label' => $this->getLLL('metadata.' . $indexName, $this->siteLanguages[0]->getLocale()->getLanguageCode(), $metadataLabels),
-                'index_name' => $indexName,
-                'format' => implode(',', $formatIds),
-                'default_value' => $values['default_value'],
-                'wrap' => !empty($values['wrap']) ? $values['wrap'] : $defaultWrap,
-                'index_tokenized' => $values['index_tokenized'],
-                'index_stored' => $values['index_stored'],
-                'index_indexed' => $values['index_indexed'],
-                'index_boost' => $values['index_boost'],
-                'is_sortable' => $values['is_sortable'],
-                'is_facet' => $values['is_facet'],
-                'is_listed' => $values['is_listed'],
-                'index_autocomplete' => $values['index_autocomplete'],
-            ];
-        }
-
-        $metadataIds = Helper::processDatabaseAsAdmin($data, [], true);
-
-        $insertedMetadata = [];
-        foreach ($metadataIds as $id => $uid) {
-            /** @var Metadata $metadata */
-            $metadata = $this->metadataRepository->findByUid($uid);
-            // id array contains also ids of formats
-            if ($metadata != null) {
-                $insertedMetadata[$uid] = $metadata->getIndexName();
-            }
-        }
-
-        foreach ($this->siteLanguages as $siteLanguage) {
-            if ($siteLanguage->getLanguageId() === 0) {
-                // skip default language
-                continue;
-            }
-
-            $translateData = [];
-            foreach ($insertedMetadata as $id => $indexName) {
-                $translateData['tx_dlf_metadata'][uniqid('NEW')] = [
-                    'pid' => $this->pid,
-                    'sys_language_uid' => $siteLanguage->getLanguageId(),
-                    'l18n_parent' => $id,
-                    'label' => $this->getLLL('metadata.' . $indexName, $siteLanguage->getLocale()->getLanguageCode(), $metadataLabels),
-                ];
-            }
-
-            Helper::processDatabaseAsAdmin($translateData);
-        }
+        $this->tenantDefaultsSetupService->run($this->pid, [
+            'formats' => false,
+            'structures' => false,
+            'metadata' => true,
+            'solrCore' => false,
+        ]);
 
         return $this->redirect('index');
     }
@@ -356,29 +173,12 @@ class NewTenantController extends AbstractController
      */
     public function addSolrCoreAction(): ResponseInterface
     {
-        $doPersist = false;
-
-        // load language file in own array
-        $beLabels = $this->languageFactory->getParsedData('EXT:dlf/Resources/Private/Language/locallang_be.xlf', $this->siteLanguages[0]->getLocale()->getLanguageCode());
-
-        // @phpstan-ignore-next-line findAll() returns QueryResultInterface and there is function getFirst()
-        if ($this->solrCoreRepository->findAll()->getFirst() === null) {
-            $newRecord = GeneralUtility::makeInstance(SolrCore::class);
-            $newRecord->setLabel($this->getLLL('flexform.solrcore', $this->siteLanguages[0]->getLocale()->getLanguageCode(), $beLabels). ' (PID ' . $this->pid . ')');
-            $indexName = Solr::createCore('');
-            if (!empty($indexName)) {
-                $newRecord->setIndexName($indexName);
-
-                $this->solrCoreRepository->add($newRecord);
-
-                $doPersist = true;
-            }
-        }
-
-        // We must persist here, if we changed anything.
-        if ($doPersist === true) {
-            $this->solrCoreRepository->persistAll();
-        }
+        $this->tenantDefaultsSetupService->run($this->pid, [
+            'formats' => false,
+            'structures' => false,
+            'metadata' => false,
+            'solrCore' => true,
+        ]);
 
         return $this->redirect('index');
     }
@@ -392,50 +192,12 @@ class NewTenantController extends AbstractController
      */
     public function addStructureAction(): ResponseInterface
     {
-        // Include structure definition file.
-        $structureDefaults = $this->getRecords('Structure');
-
-        // load language file in own array
-        $structureLabels = $this->languageFactory->getParsedData('EXT:dlf/Resources/Private/Language/locallang_structure.xlf', $this->siteLanguages[0]->getLocale()->getLanguageCode());
-
-        $data = [];
-        foreach ($structureDefaults as $indexName => $values) {
-            $data['tx_dlf_structures'][uniqid('NEW')] = [
-                'pid' => $this->pid,
-                'toplevel' => $values['toplevel'],
-                'label' => $this->getLLL('structure.' . $indexName, $this->siteLanguages[0]->getLocale()->getLanguageCode(), $structureLabels),
-                'index_name' => $indexName,
-                'oai_name' => $values['oai_name'],
-                'thumbnail' => 0,
-            ];
-        }
-        $structureIds = Helper::processDatabaseAsAdmin($data, [], true);
-
-        $insertedStructures = [];
-        foreach ($structureIds as $id => $uid) {
-            /** @var Structure $structure */
-            $structure = $this->structureRepository->findByUid($uid);
-            $insertedStructures[$uid] = $structure->getIndexName();
-        }
-
-        foreach ($this->siteLanguages as $siteLanguage) {
-            if ($siteLanguage->getLanguageId() === 0) {
-                // skip default language
-                continue;
-            }
-
-            $translateData = [];
-            foreach ($insertedStructures as $id => $indexName) {
-                $translateData['tx_dlf_structures'][uniqid('NEW')] = [
-                    'pid' => $this->pid,
-                    'sys_language_uid' => $siteLanguage->getLanguageId(),
-                    'l18n_parent' => $id,
-                    'label' => $this->getLLL('structure.' . $indexName, $siteLanguage->getLocale()->getLanguageCode(), $structureLabels),
-                ];
-            }
-
-            Helper::processDatabaseAsAdmin($translateData);
-        }
+        $this->tenantDefaultsSetupService->run($this->pid, [
+            'formats' => false,
+            'structures' => true,
+            'metadata' => false,
+            'solrCore' => false,
+        ]);
 
         return $this->redirect('index');
     }
@@ -461,19 +223,16 @@ class NewTenantController extends AbstractController
             return $this->redirect('error');
         }
 
-        $formatsDefaults = $this->getRecords('Format');
-        $recordInfos['formats']['numCurrent'] = $this->formatRepository->countAll();
-        $recordInfos['formats']['numDefault'] = count($formatsDefaults);
+        $recordInfos['formats']['numCurrent'] = $this->countRecords('tx_dlf_formats');
+        $recordInfos['formats']['numDefault'] = count($this->getRecords('Format'));
 
-        $structuresDefaults = $this->getRecords('Structure');
-        $recordInfos['structures']['numCurrent'] = $this->structureRepository->countAll();
-        $recordInfos['structures']['numDefault'] = count($structuresDefaults);
+        $recordInfos['structures']['numCurrent'] = $this->countRecords('tx_dlf_structures');
+        $recordInfos['structures']['numDefault'] = count($this->getRecords('Structure'));
 
-        $metadataDefaults = $this->getRecords('Metadata');
-        $recordInfos['metadata']['numCurrent'] = $this->metadataRepository->countAll();
-        $recordInfos['metadata']['numDefault'] = count($metadataDefaults);
+        $recordInfos['metadata']['numCurrent'] = $this->countRecords('tx_dlf_metadata');
+        $recordInfos['metadata']['numDefault'] = count($this->getRecords('Metadata'));
 
-        $recordInfos['solrcore']['numCurrent'] = $this->solrCoreRepository->countAll();
+        $recordInfos['solrcore']['numCurrent'] = $this->countRecords('tx_dlf_solrcores');
 
         $viewData = ['recordInfos' => $recordInfos];
 
@@ -493,25 +252,22 @@ class NewTenantController extends AbstractController
     }
 
     /**
-     * Get language label for given key and language.
-     *
-     * @access private
-     *
-     * @param string $index
-     * @param string $lang
-     * @param mixed[] $langArray
-     *
-     * @return string
+     * Count non-deleted records on the current configuration folder.
      */
-    private function getLLL(string $index, string $lang, array $langArray): string
+    private function countRecords(string $table): int
     {
-        if (isset($langArray[$lang][$index][0]['target'])) {
-            return $langArray[$lang][$index][0]['target'];
-        } elseif (isset($langArray['default'][$index][0]['target'])) {
-            return $langArray['default'][$index][0]['target'];
-        } else {
-            return 'Missing translation for ' . $index;
-        }
+        $queryBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+            ->getQueryBuilderForTable($table);
+
+        return (int) $queryBuilder
+            ->count('uid')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($this->pid, \TYPO3\CMS\Core\Database\Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, \TYPO3\CMS\Core\Database\Connection::PARAM_INT))
+            )
+            ->executeQuery()
+            ->fetchOne();
     }
 
     /**
@@ -526,16 +282,13 @@ class NewTenantController extends AbstractController
     private function getRecords(string $recordType): array
     {
         $filePath = GeneralUtility::getFileAbsFileName('EXT:dlf/Resources/Private/Data/' . $recordType . 'Defaults.json');
-        if (file_exists($filePath)) {
-            $fileContents = file_get_contents($filePath);
-            if (is_string($fileContents)) {
-                $records = json_decode($fileContents, true);
-
-                if (json_last_error() === JSON_ERROR_NONE) {
-                    return $records;
-                }
-            }
+        $fileContents = GeneralUtility::getUrl($filePath);
+        if (!is_string($fileContents)) {
+            return [];
         }
-        return [];
+
+        $records = json_decode($fileContents, true);
+        return json_last_error() === JSON_ERROR_NONE && is_array($records) ? $records : [];
     }
+
 }

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -23,6 +23,7 @@ use Kitodo\Dlf\Domain\Repository\FormatRepository;
 use Kitodo\Dlf\Domain\Repository\MetadataRepository;
 use Kitodo\Dlf\Domain\Repository\SolrCoreRepository;
 use Kitodo\Dlf\Domain\Repository\StructureRepository;
+use Kitodo\Dlf\Service\BootstrapRootSetupService;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -140,17 +141,28 @@ class NewTenantController extends AbstractController
     }
 
     /**
+     * @access protected
+     */
+    protected BootstrapRootSetupService $bootstrapRootSetupService;
+
+    /**
+     * @access public
+     */
+    public function injectBootstrapRootSetupService(BootstrapRootSetupService $bootstrapRootSetupService): void
+    {
+        $this->bootstrapRootSetupService = $bootstrapRootSetupService;
+    }
+
+    /**
      * Returns a response object with either the given html string or the current rendered view as content.
      *
      * @access protected
-     *
-     * @param bool $isError whether to render the non-error or error template
      *
      * @param mixed[] $extraData extra view data used to render the template (in addition to $viewData of AbstractController)
      *
      * @return ResponseInterface the response
      */
-    protected function templateResponse(bool $isError, array $extraData): ResponseInterface
+    protected function templateResponse(string $template, array $extraData): ResponseInterface
     {
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
         $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
@@ -160,7 +172,6 @@ class NewTenantController extends AbstractController
         $moduleTemplate->assignMultiple($this->viewData);
         $moduleTemplate->assignMultiple($extraData);
         $moduleTemplate->setFlashMessageQueue($messageQueue);
-        $template = $isError ? 'Backend/NewTenant/Error' : 'Backend/NewTenant/Index';
         return $moduleTemplate->renderResponse($template);
     }
 
@@ -192,6 +203,23 @@ class NewTenantController extends AbstractController
             $site = new NullSite();
         }
         $this->siteLanguages = $site->getLanguages();
+    }
+
+
+    /**
+     * Action creating a default page tree from the virtual root page.
+     *
+     * @access public
+     */
+    public function createPagesAction(): ResponseInterface
+    {
+        if ($this->pid !== 0) {
+            return $this->redirect('error');
+        }
+
+        $this->bootstrapRootSetupService->runSetup();
+
+        return $this->redirect('index', null, null, ['refreshPageTree' => 1]);
     }
 
 
@@ -423,6 +451,10 @@ class NewTenantController extends AbstractController
     {
         $recordInfos = [];
 
+        if ($this->pid === 0) {
+            return $this->templateResponse('Backend/NewTenant/Root', ['refreshPageTree' => (bool) ($this->request->getQueryParams()['refreshPageTree'] ?? false)]);
+        }
+
         $this->pageInfo = BackendUtility::readPageAccess($this->pid, $GLOBALS['BE_USER']->getPagePermsClause(1)) ?: [];
 
         if (!isset($this->pageInfo['doktype']) || $this->pageInfo['doktype'] != 254) {
@@ -445,7 +477,7 @@ class NewTenantController extends AbstractController
 
         $viewData = ['recordInfos' => $recordInfos];
 
-        return $this->templateResponse(false, $viewData);
+        return $this->templateResponse('Backend/NewTenant/Index', $viewData);
     }
 
     /**
@@ -457,7 +489,7 @@ class NewTenantController extends AbstractController
      */
     public function errorAction(): ResponseInterface
     {
-        return $this->templateResponse(true, []);
+        return $this->templateResponse('Backend/NewTenant/Error', []);
     }
 
     /**

--- a/Classes/Service/BootstrapRootSetupService.php
+++ b/Classes/Service/BootstrapRootSetupService.php
@@ -48,7 +48,7 @@ final class BootstrapRootSetupService
         $this->writeSiteConfiguration($context, $rootPageId);
 
         $configurationPageId = $this->createPage($rootPageId, self::CONFIGURATION_PAGE_TITLE, ['doktype' => 254, 'sorting' => 256]);
-        $viewerPageId = $this->createPage($rootPageId, self::VIEWER_PAGE_TITLE, ['slug' => $context['viewerPageSlug'],'sorting' => 512]);
+        $viewerPageId = $this->createPage($rootPageId, self::VIEWER_PAGE_TITLE, ['slug' => $context['viewerPageSlug'], 'sorting' => 512]);
 
         $templateId = $this->ensureTemplate($rootPageId);
         $this->updateTemplate(
@@ -247,7 +247,7 @@ final class BootstrapRootSetupService
 
     /**
      * Asserts that the given site identifier is available (no existing site folder with the same name).
-     * 
+     *
      * @param string $siteIdentifier
      * @throws RuntimeException
      * @return void
@@ -261,7 +261,7 @@ final class BootstrapRootSetupService
 
     /**
      * Checks whether a site with the given identifier already exists.
-     * 
+     *
      * @param string $siteIdentifier
      * @return bool
      */
@@ -278,7 +278,7 @@ final class BootstrapRootSetupService
 
     /**
      * Checks if any existing site configuration uses the given site base.
-     * 
+     *
      * @param string $siteBase
      * @return bool
      */
@@ -295,7 +295,7 @@ final class BootstrapRootSetupService
 
     /**
      * Asserts that the given root page title is available (no existing root page with the same title).
-     * 
+     *
      * @param string $rootPageTitle
      * @throws RuntimeException
      * @return void
@@ -321,10 +321,11 @@ final class BootstrapRootSetupService
 
     /**
      * Asserts that custom root and viewer slugs are only used together with the root site base "/" to avoid conflicts with existing pages.
-     * 
+     *
      * @param string $siteBase
      * @param string $rootSlug
      * @param string $viewerSlug
+     * @throws RuntimeException
      * @return void
      */
     private function assertBaseCompatibleWithSlugs(string $siteBase, string $rootSlug, string $viewerSlug): void
@@ -339,7 +340,7 @@ final class BootstrapRootSetupService
 
     /**
      * Normalizes and validates the custom site identifier option. It must only contain lowercase letters, numbers and hyphens.
-     * 
+     *
      * @param mixed $value
      * @return string|null The normalized identifier or null if no valid value is provided.
      */
@@ -357,7 +358,7 @@ final class BootstrapRootSetupService
 
     /**
      * Normalizes and validates the custom site base option. It must start with a slash and end with a slash (unless it's just "/").
-     * 
+     *
      * @param mixed $value
      * @return string|null The normalized base or null if no valid value is provided.
      */
@@ -378,7 +379,7 @@ final class BootstrapRootSetupService
 
     /**
      * Normalizes and validates the custom slug options. They must start with a slash and must not end with a slash (unless it's just "/").
-     * 
+     *
      * @param mixed $value
      * @param string $optionName The name of the option for error messages.
      * @return string|null The normalized slug or null if no valid value is provided.
@@ -406,7 +407,7 @@ final class BootstrapRootSetupService
 
     /**
      * Creates or updates the root template and ensures the required static TypoScript includes are present.
-     * 
+     *
      * @param int $rootPageId The UID of the root page.
      * @return int The uid of the created or updated template record.
      */
@@ -462,7 +463,7 @@ final class BootstrapRootSetupService
 
     /**
      * Rewrites the bootstrap template constants to the imported page IDs.
-     * 
+     *
      * @param int $templateId The uid of the template record to update.
      * @param int $rootPageId The UID of the root page.
      * @param int $viewerPageId The UID of the viewer page.
@@ -474,8 +475,7 @@ final class BootstrapRootSetupService
         int $rootPageId,
         int $viewerPageId,
         int $configurationPageId
-    ): void
-    {
+    ): void {
         $constants = [
             'plugin.tx_dlf.persistence.storagePid = ' . $configurationPageId,
             'plugin.tx_dlf.basicViewer.rootPid = ' . $rootPageId,
@@ -494,7 +494,7 @@ final class BootstrapRootSetupService
 
     /**
      * Determines the next sorting value for a new page under the given parent page by finding the current maximum sorting value and adding 256.
-     * 
+     *
      * @param int $pid
      * @return int The next sorting value to use for a new page under the given parent page.
      */
@@ -516,7 +516,7 @@ final class BootstrapRootSetupService
 
     /**
      * Inserts a new row into the given table with the provided data and returns the uid of the newly created record.
-     * 
+     *
      * @param string $table The name of the table to insert into.
      * @param array<string, mixed> $data The data to insert.
      * @return int The uid of the newly created record.
@@ -530,7 +530,7 @@ final class BootstrapRootSetupService
 
     /**
      * Updates a row in the given table with the provided data.
-     * 
+     *
      * @param string $table The name of the table to update.
      * @param int $uid The uid of the row to update.
      * @param array<string, mixed> $data The data to update.
@@ -544,7 +544,7 @@ final class BootstrapRootSetupService
 
     /**
      * Merges the required static TypoScript files with any existing includes, ensuring there are no duplicates and that the required files are included.
-     * 
+     *
      * @param string $includeStaticFile The existing include_static_file value from the template record.
      * @return string The merged include_static_file value with required files included.
      */

--- a/Classes/Service/BootstrapRootSetupService.php
+++ b/Classes/Service/BootstrapRootSetupService.php
@@ -1,0 +1,558 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kitodo\Dlf\Service;
+
+use RuntimeException;
+use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteConfiguration;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Service class for creating a new bootstrap root page tree.
+ */
+final class BootstrapRootSetupService
+{
+    private const SITE_IDENTIFIER_PREFIX = 'kitodo-presentation';
+    private const ROOT_PAGE_TITLE_PREFIX = 'Kitodo Presentation';
+    private const VIEWER_PAGE_TITLE = 'Viewer';
+    private const CONFIGURATION_PAGE_TITLE = 'Kitodo Configuration';
+    private const TEMPLATE_TITLE = 'Kitodo Presentation Bootstrap';
+    private const BASIC_STATIC_FILE = 'EXT:dlf/Configuration/TypoScript/';
+    private const BASIC_VIEWER_STATIC_FILE = 'EXT:dlf/Configuration/TypoScript/BasicViewer/';
+    private const SITE_CONFIGURATION_TEMPLATE = 'EXT:dlf/Resources/Private/Data/BootstrapSiteConfig.yaml';
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly SiteConfiguration $siteConfiguration,
+        private readonly CacheManager $cacheManager,
+    ) {}
+
+    /**
+     * Runs the setup for a new bootstrap root page tree.
+     *
+     * @param array{identifier?:mixed,base?:mixed,rootTitle?:mixed,rootSlug?:mixed,viewerSlug?:mixed} $options
+     * @return array{siteIdentifier:string,siteBase:string,rootPageId:int,viewerPageId:int,configurationPageId:int,templateId:int}
+     */
+    public function runSetup(array $options = []): array
+    {
+        $context = $this->buildSetupContext($options);
+
+        $rootPageId = $this->createRootPage($context);
+        $this->writeSiteConfiguration($context, $rootPageId);
+
+        $configurationPageId = $this->createPage($rootPageId, self::CONFIGURATION_PAGE_TITLE, ['doktype' => 254, 'sorting' => 256]);
+        $viewerPageId = $this->createPage($rootPageId, self::VIEWER_PAGE_TITLE, ['slug' => $context['viewerPageSlug'],'sorting' => 512]);
+
+        $templateId = $this->ensureTemplate($rootPageId);
+        $this->updateTemplate(
+            $templateId,
+            $rootPageId,
+            $viewerPageId,
+            $configurationPageId,
+        );
+        $this->cacheManager->flushCaches();
+
+        return [
+            'siteIdentifier' => $context['siteIdentifier'],
+            'siteBase' => $context['siteBase'],
+            'rootPageId' => $rootPageId,
+            'viewerPageId' => $viewerPageId,
+            'configurationPageId' => $configurationPageId,
+            'templateId' => $templateId,
+        ];
+    }
+
+    /**
+     * Determines the next unique bootstrap site identifier, titles and slugs.
+     *
+     * @param array{identifier?:mixed,base?:mixed,rootTitle?:mixed,rootSlug?:mixed,viewerSlug?:mixed} $options
+     * @return array{siteIdentifier:string,siteBase:string,rootPageTitle:string,rootPageSlug:string,viewerPageSlug:string}
+     * @throws RuntimeException
+     */
+    private function buildSetupContext(array $options): array
+    {
+        $nextIndex = $this->determineNextGroupIndex();
+        $customIdentifier = $this->normalizeIdentifierOption($options['identifier'] ?? null);
+        $customBase = $this->normalizeBaseOption($options['base'] ?? null);
+        $customRootTitle = $this->normalizeTextOption($options['rootTitle'] ?? null);
+        $customRootSlug = $this->normalizeSlugOption($options['rootSlug'] ?? null, 'root-slug');
+        $customViewerSlug = $this->normalizeSlugOption($options['viewerSlug'] ?? null, 'viewer-slug');
+
+        $siteIdentifier = $customIdentifier ?? ($nextIndex === 1 ? self::SITE_IDENTIFIER_PREFIX : self::SITE_IDENTIFIER_PREFIX . '-' . $nextIndex);
+        $defaultBase = ($customIdentifier === null && $nextIndex === 1 && !$this->siteBaseExists('/')) ? '/' : '/' . $siteIdentifier . '/';
+        $siteBase = $customBase ?? $defaultBase;
+        $rootPageTitle = $customRootTitle ?? ($nextIndex === 1 ? self::ROOT_PAGE_TITLE_PREFIX : self::ROOT_PAGE_TITLE_PREFIX . ' ' . $nextIndex);
+        $rootPageSlug = $customRootSlug ?? '/';
+        $viewerPageSlug = $customViewerSlug ?? '/viewer';
+
+        $this->assertSiteIdentifierAvailable($siteIdentifier);
+        $this->assertRootTitleAvailable($rootPageTitle);
+        if ($this->siteBaseExists($siteBase)) {
+            throw new RuntimeException('The site base "' . $siteBase . '" is already in use.');
+        }
+        $this->assertBaseCompatibleWithSlugs($siteBase, $rootPageSlug, $viewerPageSlug);
+
+        return [
+            'siteIdentifier' => $siteIdentifier,
+            'siteBase' => $siteBase,
+            'rootPageTitle' => $rootPageTitle,
+            'rootPageSlug' => $rootPageSlug,
+            'viewerPageSlug' => $viewerPageSlug,
+        ];
+    }
+
+    /**
+     * Finds the next free numeric index for bootstrap groups by inspecting existing sites and root pages.
+     *
+     * @return int The next available index, starting from 1. If no existing groups are found, returns 1.
+     */
+    private function determineNextGroupIndex(): int
+    {
+        $maxIndex = 0;
+        foreach ($this->siteConfiguration->getAllExistingSites() as $site) {
+            if (!$site instanceof Site) {
+                continue;
+            }
+
+            $maxIndex = max($maxIndex, $this->extractBootstrapIndex($site->getIdentifier(), self::SITE_IDENTIFIER_PREFIX, '-'));
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        $rows = $queryBuilder
+            ->select('title')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))
+            )
+            ->executeQuery()
+            ->fetchFirstColumn();
+
+        foreach ($rows as $title) {
+            if (!is_string($title)) {
+                continue;
+            }
+
+            $maxIndex = max($maxIndex, $this->extractBootstrapIndex($title, self::ROOT_PAGE_TITLE_PREFIX, ' '));
+        }
+
+        return $maxIndex + 1;
+    }
+
+    /**
+     * Extracts the bootstrap group index from a generated site identifier or root page title.
+     *
+     * @param string $value
+     * @param string $prefix
+     * @param string $separator
+     * @return int
+     */
+    private function extractBootstrapIndex(string $value, string $prefix, string $separator): int
+    {
+        if ($value === $prefix) {
+            return 1;
+        }
+
+        $pattern = '/^' . preg_quote($prefix, '/') . preg_quote($separator, '/') . '(\d+)$/';
+        if (preg_match($pattern, $value, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return 0;
+    }
+
+    /**
+     * Creates a fresh bootstrap root page for the next group.
+     *
+     * @param array{rootPageTitle:string,rootPageSlug:string} $context
+     * @return int The uid of the created root page
+     */
+    private function createRootPage(array $context): int
+    {
+        return $this->insertRow(
+            'pages',
+            [
+                'pid' => 0,
+                'tstamp' => time(),
+                'crdate' => time(),
+                'deleted' => 0,
+                'hidden' => 0,
+                'doktype' => 1,
+                'title' => $context['rootPageTitle'],
+                'slug' => $context['rootPageSlug'],
+                'is_siteroot' => 1,
+                'sorting' => $this->nextSortingForPid(0),
+            ]
+        );
+    }
+
+    /**
+     * Creates a child page below a freshly created bootstrap root page.
+     *
+     * @param int $pid
+     * @param string $title
+     * @param array<string, mixed> $data
+     * @return int
+     */
+    private function createPage(int $pid, string $title, array $data): int
+    {
+        $pageData = array_merge(
+            [
+                'pid' => $pid,
+                'tstamp' => time(),
+                'crdate' => time(),
+                'deleted' => 0,
+                'hidden' => 0,
+                'doktype' => 1,
+                'title' => $title,
+            ],
+            $data
+        );
+
+        return $this->insertRow('pages', $pageData);
+    }
+
+    /**
+     * Writes a unique bootstrap site configuration for the freshly created root page.
+     *
+     * @param array{siteIdentifier:string,siteBase:string} $context
+     * @param int $rootPageId
+     * @return void
+     * @throws RuntimeException
+     */
+    private function writeSiteConfiguration(array $context, int $rootPageId): void
+    {
+        $templatePath = GeneralUtility::getFileAbsFileName(self::SITE_CONFIGURATION_TEMPLATE);
+        $configuration = Yaml::parseFile($templatePath);
+        if (!is_array($configuration)) {
+            throw new RuntimeException('Bootstrap site template is invalid.');
+        }
+
+        $configuration['base'] = $context['siteBase'];
+        $configuration['rootPageId'] = $rootPageId;
+
+        $siteDirectory = Environment::getConfigPath() . '/sites/' . $context['siteIdentifier'];
+        GeneralUtility::mkdir_deep($siteDirectory);
+        if (!GeneralUtility::writeFile($siteDirectory . '/config.yaml', Yaml::dump($configuration, 99, 2))) {
+            throw new RuntimeException('Bootstrap site configuration could not be written.');
+        }
+    }
+
+    /**
+     * Asserts that the given site identifier is available (no existing site folder with the same name).
+     * 
+     * @param string $siteIdentifier
+     * @throws RuntimeException
+     * @return void
+     */
+    private function assertSiteIdentifierAvailable(string $siteIdentifier): void
+    {
+        if ($this->siteIdentifierExists($siteIdentifier)) {
+            throw new RuntimeException('The site identifier "' . $siteIdentifier . '" already exists.');
+        }
+    }
+
+    /**
+     * Checks whether a site with the given identifier already exists.
+     * 
+     * @param string $siteIdentifier
+     * @return bool
+     */
+    private function siteIdentifierExists(string $siteIdentifier): bool
+    {
+        foreach ($this->siteConfiguration->getAllExistingSites() as $site) {
+            if ($site instanceof Site && $site->getIdentifier() === $siteIdentifier) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if any existing site configuration uses the given site base.
+     * 
+     * @param string $siteBase
+     * @return bool
+     */
+    private function siteBaseExists(string $siteBase): bool
+    {
+        foreach ($this->siteConfiguration->getAllExistingSites() as $site) {
+            if ($site instanceof Site && (string) $site->getBase() === $siteBase) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Asserts that the given root page title is available (no existing root page with the same title).
+     * 
+     * @param string $rootPageTitle
+     * @throws RuntimeException
+     * @return void
+     */
+    private function assertRootTitleAvailable(string $rootPageTitle): void
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        $count = $queryBuilder
+            ->count('uid')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('title', $queryBuilder->createNamedParameter($rootPageTitle)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        if ((int) $count > 0) {
+            throw new RuntimeException('The root page title "' . $rootPageTitle . '" is already in use.');
+        }
+    }
+
+    /**
+     * Asserts that custom root and viewer slugs are only used together with the root site base "/" to avoid conflicts with existing pages.
+     * 
+     * @param string $siteBase
+     * @param string $rootSlug
+     * @param string $viewerSlug
+     * @return void
+     */
+    private function assertBaseCompatibleWithSlugs(string $siteBase, string $rootSlug, string $viewerSlug): void
+    {
+        if ($siteBase !== '/' && $rootSlug !== '/') {
+            throw new RuntimeException('Custom root slugs are only supported together with the root site base "/".');
+        }
+        if ($viewerSlug === '/') {
+            throw new RuntimeException('The viewer slug must not be "/".');
+        }
+    }
+
+    /**
+     * Normalizes and validates the custom site identifier option. It must only contain lowercase letters, numbers and hyphens.
+     * 
+     * @param mixed $value
+     * @return string|null The normalized identifier or null if no valid value is provided.
+     */
+    private function normalizeIdentifierOption(mixed $value): ?string
+    {
+        $value = $this->normalizeTextOption($value);
+        if ($value === null) {
+            return null;
+        }
+        if (preg_match('/^[a-z0-9][a-z0-9-]*$/', $value) !== 1) {
+            throw new RuntimeException('The --identifier value may only contain lowercase letters, numbers and hyphens.');
+        }
+        return $value;
+    }
+
+    /**
+     * Normalizes and validates the custom site base option. It must start with a slash and end with a slash (unless it's just "/").
+     * 
+     * @param mixed $value
+     * @return string|null The normalized base or null if no valid value is provided.
+     */
+    private function normalizeBaseOption(mixed $value): ?string
+    {
+        $value = $this->normalizeTextOption($value);
+        if ($value === null) {
+            return null;
+        }
+        if (!str_starts_with($value, '/')) {
+            throw new RuntimeException('The --base value must start with "/".');
+        }
+        if (!str_ends_with($value, '/')) {
+            $value .= '/';
+        }
+        return $value;
+    }
+
+    /**
+     * Normalizes and validates the custom slug options. They must start with a slash and must not end with a slash (unless it's just "/").
+     * 
+     * @param mixed $value
+     * @param string $optionName The name of the option for error messages.
+     * @return string|null The normalized slug or null if no valid value is provided.
+     */
+    private function normalizeSlugOption(mixed $value, string $optionName): ?string
+    {
+        $value = $this->normalizeTextOption($value);
+        if ($value === null) {
+            return null;
+        }
+        if (!str_starts_with($value, '/')) {
+            throw new RuntimeException('The --' . $optionName . ' value must start with "/".');
+        }
+        return rtrim($value, '/') ?: '/';
+    }
+
+    private function normalizeTextOption(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        $value = trim($value);
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * Creates or updates the root template and ensures the required static TypoScript includes are present.
+     * 
+     * @param int $rootPageId The UID of the root page.
+     * @return int The uid of the created or updated template record.
+     */
+    private function ensureTemplate(int $rootPageId): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_template');
+        $row = $queryBuilder
+            ->select('uid', 'include_static_file')
+            ->from('sys_template')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($rootPageId, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))
+            )
+            ->orderBy('sorting')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if ($row !== false) {
+            $this->updateRow(
+                'sys_template',
+                (int) $row['uid'],
+                [
+                    'include_static_file' => $this->mergeStaticFiles((string) $row['include_static_file']),
+                    'title' => self::TEMPLATE_TITLE,
+                    'root' => 1,
+                    'clear' => 3,
+                    'tstamp' => time(),
+                ]
+            );
+
+            return (int) $row['uid'];
+        }
+
+        return $this->insertRow(
+            'sys_template',
+            [
+                'pid' => $rootPageId,
+                'tstamp' => time(),
+                'crdate' => time(),
+                'deleted' => 0,
+                'hidden' => 0,
+                'sorting' => 256,
+                'title' => self::TEMPLATE_TITLE,
+                'root' => 1,
+                'clear' => 3,
+                'include_static_file' => $this->mergeStaticFiles(''),
+                'constants' => '',
+                'config' => '',
+            ]
+        );
+    }
+
+    /**
+     * Rewrites the bootstrap template constants to the imported page IDs.
+     * 
+     * @param int $templateId The uid of the template record to update.
+     * @param int $rootPageId The UID of the root page.
+     * @param int $viewerPageId The UID of the viewer page.
+     * @param int $configurationPageId The UID of the configuration page.
+     * @return void
+     */
+    private function updateTemplate(
+        int $templateId,
+        int $rootPageId,
+        int $viewerPageId,
+        int $configurationPageId
+    ): void
+    {
+        $constants = [
+            'plugin.tx_dlf.persistence.storagePid = ' . $configurationPageId,
+            'plugin.tx_dlf.basicViewer.rootPid = ' . $rootPageId,
+            'plugin.tx_dlf.basicViewer.viewerPid = ' . $viewerPageId,
+        ];
+
+        $this->updateRow(
+            'sys_template',
+            $templateId,
+            [
+                'tstamp' => time(),
+                'constants' => implode(PHP_EOL, $constants),
+            ]
+        );
+    }
+
+    /**
+     * Determines the next sorting value for a new page under the given parent page by finding the current maximum sorting value and adding 256.
+     * 
+     * @param int $pid
+     * @return int The next sorting value to use for a new page under the given parent page.
+     */
+    private function nextSortingForPid(int $pid): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        $sorting = $queryBuilder
+            ->selectLiteral('MAX(sorting)')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return ((int) $sorting) + 256;
+    }
+
+    /**
+     * Inserts a new row into the given table with the provided data and returns the uid of the newly created record.
+     * 
+     * @param string $table The name of the table to insert into.
+     * @param array<string, mixed> $data The data to insert.
+     * @return int The uid of the newly created record.
+     */
+    private function insertRow(string $table, array $data): int
+    {
+        $connection = $this->connectionPool->getConnectionForTable($table);
+        $connection->insert($table, $data);
+        return (int) $connection->lastInsertId();
+    }
+
+    /**
+     * Updates a row in the given table with the provided data.
+     * 
+     * @param string $table The name of the table to update.
+     * @param int $uid The uid of the row to update.
+     * @param array<string, mixed> $data The data to update.
+     * @return void
+     */
+    private function updateRow(string $table, int $uid, array $data): void
+    {
+        $connection = $this->connectionPool->getConnectionForTable($table);
+        $connection->update($table, $data, ['uid' => $uid]);
+    }
+
+    /**
+     * Merges the required static TypoScript files with any existing includes, ensuring there are no duplicates and that the required files are included.
+     * 
+     * @param string $includeStaticFile The existing include_static_file value from the template record.
+     * @return string The merged include_static_file value with required files included.
+     */
+    private function mergeStaticFiles(string $includeStaticFile): string
+    {
+        $files = array_filter(array_map('trim', explode(',', $includeStaticFile)));
+        $files[] = self::BASIC_STATIC_FILE;
+        $files[] = self::BASIC_VIEWER_STATIC_FILE;
+        return implode(',', array_values(array_unique($files)));
+    }
+}

--- a/Classes/Service/TenantDefaultsSetupService.php
+++ b/Classes/Service/TenantDefaultsSetupService.php
@@ -1,0 +1,391 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kitodo\Dlf\Service;
+
+use Kitodo\Dlf\Common\Helper;
+use Kitodo\Dlf\Common\Solr\Solr;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Localization\LocalizationFactory;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Shared service for applying the same tenant defaults as the backend new-tenant module.
+ */
+final class TenantDefaultsSetupService
+{
+    public function __construct(
+        private readonly LocalizationFactory $languageFactory,
+        private readonly SiteFinder $siteFinder,
+        private readonly ConnectionPool $connectionPool,
+    ) {
+        // empty
+    }
+
+    /**
+     * Runs selected tenant setup steps for the given configuration folder.
+     *
+     * @param array{formats:bool,structures:bool,metadata:bool,solrCore:bool} $steps
+     * @return array{formats:int,structures:int,metadata:int,solrCore:?int}
+     */
+    public function run(int $configurationPageId, array $steps): array
+    {
+        $result = [
+            'formats' => 0,
+            'structures' => 0,
+            'metadata' => 0,
+            'solrCore' => null,
+        ];
+
+        if ($steps['formats']) {
+            $result['formats'] = $this->addFormats($configurationPageId);
+        }
+        if ($steps['structures']) {
+            $result['structures'] = $this->addStructures($configurationPageId);
+        }
+        if ($steps['metadata']) {
+            $result['metadata'] = $this->addMetadata($configurationPageId);
+        }
+        if ($steps['solrCore']) {
+            $result['solrCore'] = $this->addSolrCore($configurationPageId);
+        }
+
+        return $result;
+    }
+
+    private function addFormats(int $configurationPageId): int
+    {
+        $formatsDefaults = $this->getRecords('Format');
+        $data = [];
+        $formatTempIds = [];
+
+        foreach ($formatsDefaults as $type => $values) {
+            if ($this->recordExists(
+                'tx_dlf_formats',
+                [
+                    'pid' => $configurationPageId,
+                    'type' => $type,
+                ]
+            )) {
+                continue;
+            }
+
+            $formatId = uniqid('NEW', true);
+            $formatTempIds[] = $formatId;
+            $data['tx_dlf_formats'][$formatId] = [
+                'pid' => $configurationPageId,
+                'type' => $type,
+                'root' => $values['root'],
+                'namespace' => $values['namespace'],
+                'class' => $values['class'],
+            ];
+        }
+
+        if ($formatTempIds === []) {
+            return 0;
+        }
+
+        $insertedIds = Helper::processDatabaseAsAdmin($data, [], true);
+        return count(array_intersect_key(array_flip($formatTempIds), $insertedIds));
+    }
+
+    private function addMetadata(int $configurationPageId): int
+    {
+        $metadataDefaults = $this->getRecords('Metadata');
+        $siteLanguages = $this->getSiteLanguages($configurationPageId);
+        $defaultLanguage = $siteLanguages[0];
+        $metadataLabels = $this->languageFactory->getParsedData(
+            'EXT:dlf/Resources/Private/Language/locallang_metadata.xlf',
+            $defaultLanguage->getLocale()->getLanguageCode()
+        );
+
+        $availableFormats = [];
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_dlf_formats');
+        $queryBuilder->getRestrictions()->removeAll();
+        foreach ($queryBuilder
+            ->select('uid', 'root')
+            ->from('tx_dlf_formats')
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($configurationPageId, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))
+            )
+            ->executeQuery()
+            ->fetchAllAssociative() as $row) {
+            $availableFormats[$row['root']] = (int) $row['uid'];
+        }
+
+        $defaultWrap = BackendUtility::getTcaFieldConfiguration('tx_dlf_metadata', 'wrap')['default'];
+        $data = [];
+        $metadataTempIds = [];
+
+        foreach ($metadataDefaults as $indexName => $values) {
+            if ($this->recordExists(
+                'tx_dlf_metadata',
+                [
+                    'pid' => $configurationPageId,
+                    'index_name' => $indexName,
+                    'sys_language_uid' => 0,
+                ]
+            )) {
+                continue;
+            }
+
+            $formatIds = [];
+            foreach ($values['format'] as $format) {
+                $format['encoded'] = $availableFormats[$format['format_root']] ?? null;
+                unset($format['format_root']);
+                $formatId = uniqid('NEW', true);
+                $formatIds[] = $formatId;
+                $data['tx_dlf_metadataformat'][$formatId] = $format + ['pid' => $configurationPageId];
+            }
+
+            $metadataId = uniqid('NEW', true);
+            $metadataTempIds[$metadataId] = $indexName;
+            $data['tx_dlf_metadata'][$metadataId] = [
+                'pid' => $configurationPageId,
+                'label' => $this->getLocalizedLabel(
+                    'metadata.' . $indexName,
+                    $defaultLanguage->getLocale()->getLanguageCode(),
+                    $metadataLabels
+                ),
+                'index_name' => $indexName,
+                'format' => implode(',', $formatIds),
+                'default_value' => $values['default_value'],
+                'wrap' => !empty($values['wrap']) ? $values['wrap'] : $defaultWrap,
+                'index_tokenized' => $values['index_tokenized'],
+                'index_stored' => $values['index_stored'],
+                'index_indexed' => $values['index_indexed'],
+                'index_boost' => $values['index_boost'],
+                'is_sortable' => $values['is_sortable'],
+                'is_facet' => $values['is_facet'],
+                'is_listed' => $values['is_listed'],
+                'index_autocomplete' => $values['index_autocomplete'],
+            ];
+        }
+
+        if ($metadataTempIds === []) {
+            return 0;
+        }
+
+        $insertedIds = Helper::processDatabaseAsAdmin($data, [], true);
+        $insertedMetadata = [];
+        foreach ($metadataTempIds as $tempId => $indexName) {
+            if (isset($insertedIds[$tempId])) {
+                $insertedMetadata[(int) $insertedIds[$tempId]] = $indexName;
+            }
+        }
+
+        foreach ($siteLanguages as $siteLanguage) {
+            if ($siteLanguage->getLanguageId() === 0) {
+                continue;
+            }
+
+            $translateData = [];
+            foreach ($insertedMetadata as $uid => $indexName) {
+                $translateData['tx_dlf_metadata'][uniqid('NEW', true)] = [
+                    'pid' => $configurationPageId,
+                    'sys_language_uid' => $siteLanguage->getLanguageId(),
+                    'l18n_parent' => $uid,
+                    'label' => $this->getLocalizedLabel(
+                        'metadata.' . $indexName,
+                        $siteLanguage->getLocale()->getLanguageCode(),
+                        $metadataLabels
+                    ),
+                ];
+            }
+
+            if ($translateData !== []) {
+                Helper::processDatabaseAsAdmin($translateData);
+            }
+        }
+
+        return count($insertedMetadata);
+    }
+
+    private function addSolrCore(int $configurationPageId): ?int
+    {
+        $existingUid = $this->findUidByFields('tx_dlf_solrcores', ['pid' => $configurationPageId]);
+        if ($existingUid !== null) {
+            return $existingUid;
+        }
+
+        $siteLanguages = $this->getSiteLanguages($configurationPageId);
+        $beLabels = $this->languageFactory->getParsedData(
+            'EXT:dlf/Resources/Private/Language/locallang_be.xlf',
+            $siteLanguages[0]->getLocale()->getLanguageCode()
+        );
+        $indexName = Solr::createCore('');
+        if ($indexName === '') {
+            return null;
+        }
+
+        $connection = $this->connectionPool->getConnectionForTable('tx_dlf_solrcores');
+        $connection->insert(
+            'tx_dlf_solrcores',
+            [
+                'pid' => $configurationPageId,
+                'tstamp' => time(),
+                'crdate' => time(),
+                'cruser_id' => 0,
+                'deleted' => 0,
+                'label' => $this->getLocalizedLabel(
+                    'flexform.solrcore',
+                    $siteLanguages[0]->getLocale()->getLanguageCode(),
+                    $beLabels
+                ) . ' (PID ' . $configurationPageId . ')',
+                'index_name' => $indexName,
+            ]
+        );
+
+        return (int) $connection->lastInsertId();
+    }
+
+    private function addStructures(int $configurationPageId): int
+    {
+        $structureDefaults = $this->getRecords('Structure');
+        $siteLanguages = $this->getSiteLanguages($configurationPageId);
+        $defaultLanguage = $siteLanguages[0];
+        $structureLabels = $this->languageFactory->getParsedData(
+            'EXT:dlf/Resources/Private/Language/locallang_structure.xlf',
+            $defaultLanguage->getLocale()->getLanguageCode()
+        );
+
+        $data = [];
+        $structureTempIds = [];
+        foreach ($structureDefaults as $indexName => $values) {
+            if ($this->recordExists(
+                'tx_dlf_structures',
+                [
+                    'pid' => $configurationPageId,
+                    'index_name' => $indexName,
+                    'sys_language_uid' => 0,
+                ]
+            )) {
+                continue;
+            }
+
+            $structureId = uniqid('NEW', true);
+            $structureTempIds[$structureId] = $indexName;
+            $data['tx_dlf_structures'][$structureId] = [
+                'pid' => $configurationPageId,
+                'toplevel' => $values['toplevel'],
+                'label' => $this->getLocalizedLabel(
+                    'structure.' . $indexName,
+                    $defaultLanguage->getLocale()->getLanguageCode(),
+                    $structureLabels
+                ),
+                'index_name' => $indexName,
+                'oai_name' => $values['oai_name'],
+                'thumbnail' => 0,
+            ];
+        }
+
+        if ($structureTempIds === []) {
+            return 0;
+        }
+
+        $insertedIds = Helper::processDatabaseAsAdmin($data, [], true);
+        $insertedStructures = [];
+        foreach ($structureTempIds as $tempId => $indexName) {
+            if (isset($insertedIds[$tempId])) {
+                $insertedStructures[(int) $insertedIds[$tempId]] = $indexName;
+            }
+        }
+
+        foreach ($siteLanguages as $siteLanguage) {
+            if ($siteLanguage->getLanguageId() === 0) {
+                continue;
+            }
+
+            $translateData = [];
+            foreach ($insertedStructures as $uid => $indexName) {
+                $translateData['tx_dlf_structures'][uniqid('NEW', true)] = [
+                    'pid' => $configurationPageId,
+                    'sys_language_uid' => $siteLanguage->getLanguageId(),
+                    'l18n_parent' => $uid,
+                    'label' => $this->getLocalizedLabel(
+                        'structure.' . $indexName,
+                        $siteLanguage->getLocale()->getLanguageCode(),
+                        $structureLabels
+                    ),
+                ];
+            }
+
+            if ($translateData !== []) {
+                Helper::processDatabaseAsAdmin($translateData);
+            }
+        }
+
+        return count($insertedStructures);
+    }
+
+    /**
+     * @return SiteLanguage[]
+     */
+    private function getSiteLanguages(int $pageId): array
+    {
+        try {
+            return $this->siteFinder->getSiteByPageId($pageId)->getLanguages();
+        } catch (SiteNotFoundException) {
+            return (new NullSite())->getLanguages();
+        }
+    }
+
+    /**
+     * @param array<string, array<string, array<int, array<string, string>>>> $langArray
+     */
+    private function getLocalizedLabel(string $index, string $lang, array $langArray): string
+    {
+        if (isset($langArray[$lang][$index][0]['target'])) {
+            return $langArray[$lang][$index][0]['target'];
+        }
+        if (isset($langArray['default'][$index][0]['target'])) {
+            return $langArray['default'][$index][0]['target'];
+        }
+        return 'Missing translation for ' . $index;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function getRecords(string $recordType): array
+    {
+        $filePath = GeneralUtility::getFileAbsFileName('EXT:dlf/Resources/Private/Data/' . $recordType . 'Defaults.json');
+        $fileContents = GeneralUtility::getUrl($filePath);
+        if (!is_string($fileContents)) {
+            return [];
+        }
+        $records = json_decode($fileContents, true);
+        return json_last_error() === JSON_ERROR_NONE && is_array($records) ? $records : [];
+    }
+
+    /**
+     * @param array<string, int|string> $fields
+     */
+    private function recordExists(string $table, array $fields): bool
+    {
+        return $this->findUidByFields($table, $fields) !== null;
+    }
+
+    /**
+     * @param array<string, int|string> $fields
+     */
+    private function findUidByFields(string $table, array $fields): ?int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $constraints = [$queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))];
+        foreach ($fields as $field => $value) {
+            $type = is_int($value) ? Connection::PARAM_INT : Connection::PARAM_STR;
+            $constraints[] = $queryBuilder->expr()->eq($field, $queryBuilder->createNamedParameter($value, $type));
+        }
+        $row = $queryBuilder->select('uid')->from($table)->where(...$constraints)->setMaxResults(1)->executeQuery()->fetchAssociative();
+        return $row !== false ? (int) $row['uid'] : null;
+    }
+}

--- a/Classes/Service/TenantModuleSetupService.php
+++ b/Classes/Service/TenantModuleSetupService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kitodo\Dlf\Service;
+
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Service class for running the tenant module setup on an existing configuration folder.
+ */
+final class TenantModuleSetupService
+{
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly CacheManager $cacheManager,
+        private readonly TenantDefaultsSetupService $tenantDefaultsSetupService,
+    ) {}
+
+    /**
+     * Runs selected tenant setup steps for an existing configuration folder.
+     *
+     * @param array{formats:bool,structures:bool,metadata:bool,solrCore:bool} $steps
+     * @return array{configurationPageId:int,steps:array{formats:bool,structures:bool,metadata:bool,solrCore:bool},results:array{formats:int,structures:int,metadata:int,solrCore:?int}}
+     */
+    public function runSetup(int $configurationPageId, array $steps): array
+    {
+        $configurationPage = $this->findByUid('pages', $configurationPageId);
+        if ($configurationPage === null) {
+            throw new \RuntimeException(sprintf('The configuration page %d could not be found.', $configurationPageId));
+        }
+        if ((int) ($configurationPage['doktype'] ?? 0) !== 254) {
+            throw new \RuntimeException(sprintf('Page %d is not a configuration folder.', $configurationPageId));
+        }
+
+        $rootPageId = (int) ($configurationPage['pid'] ?? 0);
+        if ($rootPageId <= 0) {
+            throw new \RuntimeException(sprintf('Configuration page %d has no valid root page parent.', $configurationPageId));
+        }
+
+        $results = $this->tenantDefaultsSetupService->run($configurationPageId, $steps);
+        $this->cacheManager->flushCaches();
+
+        return [
+            'configurationPageId' => $configurationPageId,
+            'steps' => $steps,
+            'results' => $results,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findByUid(string $table, int $uid): ?array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+        $row = $queryBuilder
+            ->select('*')
+            ->from($table)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return $row !== false ? $row : null;
+    }
+}

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -26,7 +26,7 @@ return [
         'navigationComponentId' => '@typo3/backend/page-tree/page-tree-element',
         'controllerActions'     => [
             \Kitodo\Dlf\Controller\Backend\NewTenantController::class => [
-                'index','error','addFormat','addMetadata','addSolrCore','addStructure'
+                'index','error','createPages','addFormat','addMetadata','addSolrCore','addStructure'
             ],
         ],
     ],

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,6 +13,12 @@ services:
         command: 'kitodo:dbdocs'
         description: 'Generate database rst file.'
 
+  Kitodo\Dlf\Command\BootstrapSetupCommand:
+    tags:
+      - name: console.command
+        command: 'kitodo:setup'
+        description: 'Create a default root page tree and viewer setup.'
+
   Kitodo\Dlf\Command\DeleteCommand:
     tags:
       - name: console.command

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -19,6 +19,12 @@ services:
         command: 'kitodo:setup'
         description: 'Create a default root page tree and viewer setup.'
 
+  Kitodo\Dlf\Command\TenantSetupCommand:
+    tags:
+      - name: console.command
+        command: 'kitodo:tenantSetup'
+        description: 'Run the tenant setup for an existing configuration folder.'
+
   Kitodo\Dlf\Command\DeleteCommand:
     tags:
       - name: console.command

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -22,6 +22,12 @@ if (!defined('TYPO3')) {
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'dlf',
+    'Configuration/TypoScript/BasicViewer/',
+    'Install Basic Viewer'
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'dlf',
     'Configuration/TypoScript/Plugins/Feeds/',
     'RSS Feed Plugin Configuration'
 );

--- a/Configuration/TypoScript/BasicViewer/constants.typoscript
+++ b/Configuration/TypoScript/BasicViewer/constants.typoscript
@@ -1,0 +1,6 @@
+plugin.tx_dlf {
+    basicViewer {
+        rootPid =
+        viewerPid =
+    }
+}

--- a/Configuration/TypoScript/BasicViewer/setup.typoscript
+++ b/Configuration/TypoScript/BasicViewer/setup.typoscript
@@ -1,0 +1,85 @@
+page = PAGE
+page {
+    typeNum = 0
+    meta.viewport = width=device-width, initial-scale=1
+    includeCSS.dlfBasicViewer = EXT:dlf/Resources/Public/Stylesheets/default-viewer.css
+
+    10 = FLUIDTEMPLATE
+    10 {
+        templateRootPaths.10 = EXT:dlf/Resources/Private/Templates/Bootstrap/
+        file = EXT:dlf/Resources/Private/Templates/Bootstrap/Landing.html
+
+        variables {
+            rootPid = TEXT
+            rootPid.value = {$plugin.tx_dlf.basicViewer.rootPid}
+
+            viewerPid = TEXT
+            viewerPid.value = {$plugin.tx_dlf.basicViewer.viewerPid}
+
+            documentId = TEXT
+            documentId.data = GP:tx_dlf|id
+        }
+    }
+}
+
+plugin.tx_dlf_navigation = EXTBASEPLUGIN
+plugin.tx_dlf_navigation {
+    extensionName = Dlf
+    pluginName = Navigation
+    settings {
+        pageStep = 10
+        features = pagesBackward,pageSelect,pagesForward
+    }
+}
+
+plugin.tx_dlf_metadata = EXTBASEPLUGIN
+plugin.tx_dlf_metadata {
+    extensionName = Dlf
+    pluginName = Metadata
+    settings {
+        linkTitle = 0
+        getTitle = 0
+        showFull = 1
+        rootline = 1
+        separator = #
+    }
+}
+
+plugin.tx_dlf_pageview = EXTBASEPLUGIN
+plugin.tx_dlf_pageview {
+    extensionName = Dlf
+    pluginName = PageView
+    settings {
+        features =
+        elementId = tx-dlf-map
+        useInternalProxy = 1
+    }
+}
+
+plugin.tx_dlf_tableofcontents = EXTBASEPLUGIN
+plugin.tx_dlf_tableofcontents {
+    extensionName = Dlf
+    pluginName = TableOfContents
+    settings {
+        targetPid = {$plugin.tx_dlf.basicViewer.viewerPid}
+    }
+}
+
+plugin.tx_dlf_toolbox = EXTBASEPLUGIN
+plugin.tx_dlf_toolbox {
+    extensionName = Dlf
+    pluginName = Toolbox
+    settings {
+        tools = rotationTool,zoomTool,imageDownloadTool,pdfDownloadTool,fulltextTool,fulltextDownloadTool
+        showAsList = 0
+        activateFullTextInitially = 0
+        fullTextScrollElement = #tx-dlf-toolbox-fulltext-selection
+    }
+}
+
+[getTSFE() && getTSFE().id == {$plugin.tx_dlf.basicViewer.viewerPid}]
+page {
+    bodyTag = <body class="tx-dlf-default-viewer tx-dlf-default-viewer-page">
+    10.file = EXT:dlf/Resources/Private/Templates/Bootstrap/Viewer.html
+}
+[END]

--- a/Documentation/User/BootstrapViewerSetup.rst
+++ b/Documentation/User/BootstrapViewerSetup.rst
@@ -1,0 +1,84 @@
+######################
+Bootstrap Viewer Setup
+######################
+
+This document describes the manual bootstrap setup for a new Kitodo.Presentation root page tree and its standalone viewer.
+
+Bootstrap Root Setup
+====================
+
+The bootstrap root setup is implemented by:
+
+* ``Classes/Command/BootstrapSetupCommand.php``
+* ``Classes/Service/BootstrapRootSetupService.php``
+* ``Resources/Private/Data/BootstrapSiteConfig.yaml``
+
+Run the command with generated defaults:
+
+::
+
+   php /var/www/typo3/vendor/bin/typo3 kitodo:setup
+
+You can also override the generated values:
+
+::
+
+   php /var/www/typo3/vendor/bin/typo3 kitodo:setup \
+     --identifier=my-instance \
+     --base=/my-instance/ \
+     --root-title="My Instance" \
+     --root-slug=/ \
+     --viewer-slug=/viewer
+
+The command creates:
+
+* a new root page
+* a ``Viewer`` page below the root page
+* a ``Kitodo Configuration`` sysfolder below the root page
+* a site configuration in ``config/sites/<identifier>/config.yaml``
+* a root ``sys_template`` record with the required static TypoScript includes
+
+The root page stays the bootstrap landing page. The child ``Viewer`` page is the standalone viewer shell.
+
+The command also rewrites the template constants so the basic viewer TypoScript receives the generated page IDs:
+
+* ``plugin.tx_dlf.persistence.storagePid``
+* ``plugin.tx_dlf.basicViewer.rootPid``
+* ``plugin.tx_dlf.basicViewer.viewerPid``
+
+Generated Defaults
+------------------
+
+If no options are provided, the service generates unique values for:
+
+* the site identifier
+* the site base
+* the root page title
+* the viewer page slug
+
+For the first bootstrap site, the service prefers ``/`` as the site base if it is still unused. Later setups use ``/<identifier>/``.
+The generated site configuration also ships with two enabled languages by default: German on the site base and English below ``/en/``.
+
+Validation Rules
+----------------
+
+The bootstrap command validates the custom options as follows:
+
+* ``--identifier`` may only contain lowercase letters, digits and hyphens.
+* ``--base`` must start with ``/`` and is normalized to end with ``/``.
+* ``--root-slug`` and ``--viewer-slug`` must start with ``/``.
+* ``--viewer-slug`` must not be ``/``.
+* Custom root slugs are only supported when the site base is ``/``.
+* The site identifier must not exist already.
+* The site base must not exist already.
+* The root page title must not exist already among root pages.
+
+Viewer Wiring
+=============
+
+The standalone viewer is configured through:
+
+* ``Configuration/TypoScript/BasicViewer/setup.typoscript``
+* ``Resources/Private/Templates/Bootstrap/Landing.html``
+* ``Resources/Private/Templates/Bootstrap/Viewer.html``
+* ``Resources/Public/Stylesheets/default-viewer.css``

--- a/Documentation/User/Index.rst
+++ b/Documentation/User/Index.rst
@@ -20,6 +20,7 @@ User Manual
    :hidden:
 
    ManualViewerSetup
+   BootstrapViewerSetup
 
 .. _indexing_documents:
 

--- a/Documentation/User/Index.rst
+++ b/Documentation/User/Index.rst
@@ -21,6 +21,7 @@ User Manual
 
    ManualViewerSetup
    BootstrapViewerSetup
+   TenantSetup
 
 .. _indexing_documents:
 

--- a/Documentation/User/Index.rst
+++ b/Documentation/User/Index.rst
@@ -16,6 +16,11 @@ User Manual
     :local:
     :depth: 2
 
+.. toctree::
+   :hidden:
+
+   ManualViewerSetup
+
 .. _indexing_documents:
 
 Indexing Documents

--- a/Documentation/User/ManualViewerSetup.rst
+++ b/Documentation/User/ManualViewerSetup.rst
@@ -1,0 +1,43 @@
+###################
+Manual Viewer Setup
+###################
+
+This document describes the verified manual backend setup for a standalone viewer page and configuration folder without using the root setup CLI command.
+
+Working Sequence
+================
+
+1. Create a root page (``Create a regular page > Edit page properties > Behavior > Use as root page``)
+2. Create or edit the TYPO3 site configuration for that root page in ``Site Management > Sites``.
+3. Create these children below the root page (the naming may differ):
+
+   * ``Viewer`` with page type ``Standard``
+   * ``Kitodo Configuration`` with page type ``Folder``
+
+4. Create a TypoScript template record (``sys_template``) on the root page:
+
+   * ``Site Management > TypoScript > Edit TypoScript Record (Top Dropdownmenu) > [select the root page] > Create a root TypoScript record``
+
+5. Edit the whole TypoScript record.
+
+   Under the tab ``General``:
+
+   * set the title
+   * clear any prefilled content in the ``Setup`` field
+   * set the ``Constants`` field to the required values:
+
+     .. code-block:: typoscript
+
+        plugin.tx_dlf.persistence.storagePid = <uid of Kitodo Configuration>
+        plugin.tx_dlf.basicViewer.rootPid = <uid of root page>
+        plugin.tx_dlf.basicViewer.viewerPid = <uid of Viewer page>
+
+   Under the tab ``Advanced Options``:
+
+   * enable ``Rootlevel``
+   * include these TypoScript sets:
+
+     * ``Basic Configuration``
+     * ``Install Basic Viewer``
+
+6. Apply tenant defaults to the configuration folder through the backend new-tenant module.

--- a/Documentation/User/TenantSetup.rst
+++ b/Documentation/User/TenantSetup.rst
@@ -1,0 +1,79 @@
+############
+Tenant Setup
+############
+
+This document describes the manual tenant setup via the CLI for an existing Kitodo.Presentation configuration folder.
+The setup applies tenant defaults to the configuration folder, such as formats, structures, metadata and optional Solr wiring.
+
+Tenant Setup Command
+====================
+
+The tenant setup flow is implemented by:
+
+* ``Classes/Command/TenantSetupCommand.php``
+* ``Classes/Service/TenantModuleSetupService.php``
+* ``Classes/Service/TenantDefaultsSetupService.php``
+
+Run the command against an existing configuration folder:
+
+::
+
+   php /var/www/typo3/vendor/bin/typo3 kitodo:tenantSetup --config-page=<uid>
+
+The ``--config-page`` option is required and must point to a page of type sysfolder.
+
+If no step flags are provided, the command runs the complete tenant setup:
+
+* namespaces/formats
+* structures
+* metadata
+* Solr core creation
+
+You can also run individual steps only:
+
+::
+
+   php /var/www/typo3/vendor/bin/typo3 kitodo:tenantSetup \
+     --config-page=<uid> \
+     --namespaces \
+     --metadata
+
+When you run individual steps, apply ``--namespaces`` (or ``--formats``) before ``--metadata`` so the metadata step can attach its metadata-format relations to existing format records.
+
+Available Options
+-----------------
+
+The command supports these options:
+
+* ``--config-page`` for the target configuration folder UID
+* ``--namespaces`` to apply format defaults
+* ``--formats`` as an alias for ``--namespaces``
+* ``--structures`` to apply structure defaults
+* ``--metadata`` to apply metadata defaults
+* ``--solr-core`` to create a Solr core record when missing
+
+Validation Rules
+----------------
+
+The tenant setup validates the target before any defaults are applied:
+
+* ``--config-page`` must be present and numeric.
+* The referenced page must exist.
+* The referenced page must be a configuration folder with ``doktype = 254``.
+* The configuration folder must have a valid parent root page.
+
+Applied Defaults
+================
+
+The tenant defaults service applies the same defaults as the backend new-tenant module.
+
+Depending on the selected flags, it can create:
+
+* namespace/formats records in ``tx_dlf_formats``
+* structure records in ``tx_dlf_structures``
+* metadata records and metadata-format relations
+* translated metadata and structure labels for the configured site languages
+* a Solr core record in ``tx_dlf_solrcores``
+
+The setup is additive. Existing matching records are reused instead of duplicated, so repeated runs only fill missing defaults.
+Translations are only created for newly inserted default structures and metadata records.

--- a/Resources/Private/Data/BootstrapSiteConfig.yaml
+++ b/Resources/Private/Data/BootstrapSiteConfig.yaml
@@ -1,0 +1,26 @@
+base: '/'
+baseVariants: {  }
+errorHandling: {  }
+languages:
+    -   title: Deutsch
+        enabled: true
+        locale: de_DE.UTF-8
+        hreflang: de-DE
+        base: /
+        websiteTitle: ''
+        navigationTitle: German
+        flag: de
+        languageId: 0
+    -   title: English
+        enabled: true
+        locale: en_US.UTF-8
+        hreflang: en-US
+        base: /en/
+        websiteTitle: ''
+        navigationTitle: English
+        fallbackType: strict
+        fallbacks: ''
+        flag: us
+        languageId: 1
+rootPageId: 1
+routes: {  }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -269,6 +269,26 @@
                 <source><![CDATA[New Tenant Module]]></source>
                 <target><![CDATA[Modul Neuer Mandant]]></target>
             </trans-unit>
+            <trans-unit id="newTenant.createPages" approved="yes">
+                <source><![CDATA[Create default pages]]></source>
+                <target><![CDATA[Standardseiten anlegen]]></target>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupOkay" approved="yes">
+                <source><![CDATA[Default pages found!]]></source>
+                <target><![CDATA[Standardseiten gefunden!]]></target>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupOkayMsg" approved="yes">
+                <source><![CDATA[The root page already contains the default Viewer page and the Kitodo Configuration folder.]]></source>
+                <target><![CDATA[Die Root-Seite enthält bereits die Standardseite Viewer und den Ordner Kitodo Configuration.]]></target>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupMissing" approved="yes">
+                <source><![CDATA[Create new default page tree]]></source>
+                <target><![CDATA[Neue Standard-Seitenstruktur anlegen]]></target>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupMissingMsg" approved="yes">
+                <source><![CDATA[Create a new default page tree with the standard Viewer page and the Kitodo Configuration folder.]]></source>
+                <target><![CDATA[Es wird eine neue Standard-Seitenstruktur mit der Seite Viewer und dem Ordner Kitodo Configuration angelegt.]]></target>
+            </trans-unit>
             <trans-unit id="newTenant.createFormat" approved="yes">
                 <source><![CDATA[Create default namespaces]]></source>
                 <target><![CDATA[Standard-Namensräume anlegen]]></target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -200,6 +200,21 @@
             <trans-unit id="newTenant.module">
                 <source><![CDATA[New Tenant Module]]></source>
             </trans-unit>
+            <trans-unit id="newTenant.createPages">
+                <source><![CDATA[Create default pages]]></source>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupOkay">
+                <source><![CDATA[Default pages found!]]></source>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupOkayMsg">
+                <source><![CDATA[The root page already contains the default Viewer page and the Kitodo Configuration folder.]]></source>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupMissing">
+                <source><![CDATA[Create new default page tree]]></source>
+            </trans-unit>
+            <trans-unit id="newTenant.rootSetupMissingMsg">
+                <source><![CDATA[Create a new default page tree with the standard Viewer page and the Kitodo Configuration folder.]]></source>
+            </trans-unit>
             <trans-unit id="newTenant.createSolrCore">
                 <source><![CDATA[Create solr core]]></source>
             </trans-unit>

--- a/Resources/Private/Partials/Navigation/PageSelect.html
+++ b/Resources/Private/Partials/Navigation/PageSelect.html
@@ -12,28 +12,30 @@
 </f:comment>
 
 <li class="tx-dlf-navigation-pages">
-    <f:form method="post" action="pageSelect" controller="Navigation" name="pageSelectForm" object="{pageSelectForm}" addQueryString="untrusted">
+    <form method="get" action="{f:uri.page(pageUid: viewData.pageUid)}">
         <f:if condition="{viewData.requestData.id}">
-            <f:form.hidden property="id" value="{viewData.requestData.id}"/>
+            <input type="hidden" name="tx_dlf[id]" value="{viewData.requestData.id}" />
         </f:if>
         <f:if condition="{viewData.requestData.recordId}">
-            <f:form.hidden property="recordId" value="{viewData.requestData.recordId}"/>
+            <input type="hidden" name="tx_dlf[recordId]" value="{viewData.requestData.recordId}" />
         </f:if>
         <f:if condition="{viewData.requestData.double}">
-            <f:form.hidden property="double" value="{viewData.requestData.double}"/>
+            <input type="hidden" name="tx_dlf[double]" value="{viewData.requestData.double}" />
         </f:if>
         <f:if condition="{viewData.requestData.multiviewembedded} == 1">
-            <f:form.hidden name="tx_dlf[multiviewembedded]" value="{viewData.requestData.multiviewembedded}"/>
+            <input type="hidden" name="tx_dlf[multiviewembedded]" value="1" />
         </f:if>
         <label for="tx-dlf-page-{viewData.uniqueId}">
             <f:translate key="navigation.page.selectPage"/>
         </label>
-        <f:form.select id="tx-dlf-page-{viewData.uniqueId}" property="page"
-                       options="{pageOptions}"
-                       value="{viewData.requestData.page}"
-                       additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
-        </f:form.select>
-    </f:form>
+        <select id="tx-dlf-page-{viewData.uniqueId}"
+                name="tx_dlf[page]"
+                onchange="this.form.submit();">
+            <f:for each="{pageOptions}" as="pageLabel" key="pageNumber">
+                <option value="{pageNumber}" <f:if condition="{pageNumber} == {viewData.requestData.page}">selected="selected"</f:if>>{pageLabel}</option>
+            </f:for>
+        </select>
+    </form>
 </li>
 
 </html>

--- a/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/ImageDownloadTool.html
@@ -15,17 +15,17 @@
     <span class="tx-dlf-tools-imagedownload">
         <f:if condition="{double} === 0">
             <f:then>
-                <f:link.external uri="{imageDownload.0.url}">
+                <f:link.external uri="{imageDownload.0.url}" target="_blank">
                     <f:translate key="toolbox.general.downloadSinglePage" /> {imageDownload.0.mimetypeLabel}
                 </f:link.external>
             </f:then>
             <f:else>
-                <f:link.external uri="{imageDownload.0.url}">
+                <f:link.external uri="{imageDownload.0.url}" target="_blank">
                     <f:translate key="toolbox.general.downloadLeftPage" /> {imageDownload.0.mimetypeLabel}
                 </f:link.external>
                 <f:if condition="{imageDownload.1}">
                     <span class="tx-dlf-tools-imagedownload">
-                        <f:link.external uri="{imageDownload.1.url}">
+                        <f:link.external uri="{imageDownload.1.url}" target="_blank">
                             <f:translate key="toolbox.general.downloadRightPage" /> {imageDownload.1.mimetypeLabel}
                         </f:link.external>
                     </span>

--- a/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
+++ b/Resources/Private/Partials/Toolbox/PdfDownloadTool.html
@@ -16,22 +16,22 @@
         <f:if condition="{double} === 0">
             <f:then>
                 <f:if condition="{pageLinks.0}">
-                    <f:link.external uri="{pageLinks.0}"><f:translate key="toolbox.general.downloadSinglePage" /> (PDF)</f:link.external>
+                    <f:link.external uri="{pageLinks.0}" target="_blank"><f:translate key="toolbox.general.downloadSinglePage" /> (PDF)</f:link.external>
                 </f:if>
             </f:then>
             <f:else>
                 <f:if condition="{pageLinks.0}">
-                    <f:link.external uri="{pageLinks.0}"><f:translate key="toolbox.general.downloadLeftPage" /> (PDF)</f:link.external>
+                    <f:link.external uri="{pageLinks.0}" target="_blank"><f:translate key="toolbox.general.downloadLeftPage" /> (PDF)</f:link.external>
                 </f:if>
                 <f:if condition="{pageLinks.1}">
-                    <f:link.external uri="{pageLinks.1}"><f:translate key="toolbox.general.downloadRightPage" /> (PDF)</f:link.external>
+                    <f:link.external uri="{pageLinks.1}" target="_blank"><f:translate key="toolbox.general.downloadRightPage" /> (PDF)</f:link.external>
                 </f:if>
             </f:else>
         </f:if>
     </span>
     <span class="tx-dlf-tools-pdf-work">
         <f:if condition="{workLink}">
-            <f:link.external uri="{workLink}"><f:translate key="toolbox.pdfDownload.downloadWork"/> (PDF)</f:link.external>
+            <f:link.external uri="{workLink}" target="_blank"><f:translate key="toolbox.pdfDownload.downloadWork"/> (PDF)</f:link.external>
         </f:if>
     </span>
     <span class="tx-dlf-tools-score">

--- a/Resources/Private/Templates/Backend/NewTenant/Root.html
+++ b/Resources/Private/Templates/Backend/NewTenant/Root.html
@@ -1,0 +1,33 @@
+<f:comment>
+    <!--
+     * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+     *
+     * This file is part of the Kitodo and TYPO3 projects.
+     *
+     * @license GNU General Public License version 3 or later.
+     * For the full copyright and license information, please read the
+     * LICENSE.txt file that was distributed with this source code.
+    -->
+</f:comment>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:be="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers/Be"
+      data-namespace-typo3-fluid="true">
+
+<f:variable name="rootSetupTitle" value="{f:translate(key: 'newTenant.rootSetupMissing')}" />
+<f:variable name="rootSetupMessage" value="{f:translate(key: 'newTenant.rootSetupMissingMsg')}" />
+<f:if condition="{refreshPageTree}">
+    <be:pageRenderer includeJsFiles="{0: 'EXT:dlf/Resources/Public/JavaScript/Backend/new-tenant-root.js'}" />
+</f:if>
+
+<div class="module-body t3js-module-body" data-refresh-page-tree="{f:if(condition: refreshPageTree, then: '1', else: '0')}">
+    <h1><f:translate key="newTenant.module" /></h1>
+
+    <div class="p-2">
+        <f:render partial="Backend/InfoBox" arguments="{title: rootSetupTitle, message: rootSetupMessage, alert: 'warning'}" />
+        <f:form action="createPages" name="pages">
+            <f:form.submit name="submit" value="{f:translate(key: 'newTenant.createPages')}" class="btn btn-primary" />
+        </f:form>
+    </div>
+</div>
+
+</html>

--- a/Resources/Private/Templates/Bootstrap/Landing.html
+++ b/Resources/Private/Templates/Bootstrap/Landing.html
@@ -1,0 +1,89 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<div class="tx-dlf-default-viewer-shell tx-dlf-default-viewer-landing">
+    <div class="tx-dlf-default-viewer-welcome">
+        <section class="tx-dlf-default-viewer-welcome-hero">
+            <p class="tx-dlf-default-viewer-kicker">Kitodo Presentation</p>
+            <h1>New viewer instance</h1>
+            <p class="tx-dlf-default-viewer-welcome-lead">
+                This installation already includes a working viewer page and a prepared configuration folder.
+            </p>
+
+            <form class="tx-dlf-default-viewer-input-form" action="{f:uri.page(pageUid: viewerPid)}" method="get" onsubmit="var input=this.querySelector('input[name='tx_dlf[id]']'); if(input){ input.value=input.value.trim(); }">
+                <label class="tx-dlf-default-viewer-input-label" for="tx-dlf-default-viewer-document-url">
+                    Enter a METS, OAI-PMH or other supported document URL
+                </label>
+                <div class="tx-dlf-default-viewer-input-row">
+                    <input id="tx-dlf-default-viewer-document-url"
+                           class="tx-dlf-default-viewer-input"
+                           type="url"
+                           name="tx_dlf[id]"
+                           placeholder="https://example.org/record.xml"
+                           inputmode="url"
+                           autocomplete="off" />
+                    <button type="submit" class="tx-dlf-default-viewer-button">Open</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="tx-dlf-default-viewer-welcome-section">
+            <div class="tx-dlf-default-viewer-welcome-header">
+                <p class="tx-dlf-default-viewer-kicker">Examples</p>
+                <h2>Examples of supported content types</h2>
+            </div>
+
+            <div class="tx-dlf-default-viewer-example-grid">
+                <article class="tx-dlf-default-viewer-example-card">
+                    <p class="tx-dlf-default-viewer-kicker">Classic documents</p>
+                    <h3>Prints, letters, newspapers</h3>
+                    <p>Representative METS/OAI-PMH document for traditional digitized materials such as prints, letters, newspapers and other classic sources.</p>
+                    <p>Examples:</p>
+                    <f:link.page pageUid="{viewerPid}" class="tx-dlf-default-viewer-link"
+                        additionalParams="{tx_dlf: {id: 'http://digital.slub-dresden.de/oai/?verb=GetRecord&metadataPrefix=mets&identifier=oai:de:slub-dresden:db:id-263566811'}}">
+                        "Der furnembsten, notwendigsten, der gantzen Architectur ..."
+                    </f:link.page>
+                    <f:link.page pageUid="{viewerPid}" class="tx-dlf-default-viewer-link"
+                        additionalParams="{tx_dlf: {id: 'http://daten.digitale-sammlungen.de/~db/mets/bsb00020619_mets.xml'}}">
+                        "Prima [- Undecima] pars librorum divi Aurelii Augustini ..."
+                    </f:link.page>
+                    <f:link.page pageUid="{viewerPid}" class="tx-dlf-default-viewer-link"
+                        additionalParams="{tx_dlf: {id: 'https://digi.bib.uni-mannheim.de/fileadmin/digi/428458289/428458289.xml'}}">
+                        "Historia Baetica"
+                    </f:link.page>
+                </article>
+
+                <article class="tx-dlf-default-viewer-example-card">
+                    <p class="tx-dlf-default-viewer-kicker">Musical sources</p>
+                    <h3>Scores and bar-by-bar navigation</h3>
+                    <p>Support for digitized musical sources in MEI format is stable. Musical scores are rendered with Verovio and can be navigated bar by bar.</p>
+                    <span class="tx-dlf-default-viewer-link tx-dlf-default-viewer-link-muted">Examples coming soon</span>
+                </article>
+
+                <article class="tx-dlf-default-viewer-example-card">
+                    <p class="tx-dlf-default-viewer-kicker">3D objects</p>
+                    <h3>Embedded model viewers</h3>
+                    <p>Support for 3D objects is now an official feature. Kitodo.Presentation integrates Google&apos;s open source model-viewer and also allows other viewers to be used instead.</p>
+                    <span class="tx-dlf-default-viewer-link tx-dlf-default-viewer-link-muted">Examples coming soon</span>
+                </article>
+            </div>
+        </section>
+
+        <section class="tx-dlf-default-viewer-welcome-section tx-dlf-default-viewer-welcome-section-compact">
+            <div class="tx-dlf-default-viewer-welcome-header">
+                <p class="tx-dlf-default-viewer-kicker">Formats</p>
+                <h2>Supported input formats</h2>
+            </div>
+            <ul class="tx-dlf-default-viewer-format-list">
+                <li>OAI-PMH endpoints delivering compatible records</li>
+                <li>METS documents</li>
+                                <li>OCR and full text via ALTO and TEI</li>
+                <li>MEI-based musical sources</li>
+                <li>3D object workflows through configured embedded viewers</li>
+            </ul>
+            <p>
+                Open documents on the viewer page by passing the source URL in <code>tx_dlf[id]</code>.
+            </p>
+        </section>
+    </div>
+</div>
+</html>

--- a/Resources/Private/Templates/Bootstrap/Viewer.html
+++ b/Resources/Private/Templates/Bootstrap/Viewer.html
@@ -1,0 +1,107 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<div class="tx-dlf-default-viewer-shell">
+            <div class="tx-dlf-default-viewer-viewframe">
+                <aside class="tx-dlf-default-viewer-control-bar">
+                    <section class="tx-dlf-default-viewer-control-panel tx-dlf-default-viewer-control-panel-metadata">
+                        <div class="tx-dlf-default-viewer-control-header">
+                            <p class="tx-dlf-default-viewer-panel-kicker">Document</p>
+                            <h2>Metadata</h2>
+                        </div>
+                        <f:cObject typoscriptObjectPath="plugin.tx_dlf_metadata" />
+                    </section>
+
+                    <section class="tx-dlf-default-viewer-control-panel tx-dlf-default-viewer-control-panel-toc">
+                        <div class="tx-dlf-default-viewer-control-header">
+                            <p class="tx-dlf-default-viewer-panel-kicker">Structure</p>
+                            <h2>Contents</h2>
+                        </div>
+                        <f:cObject typoscriptObjectPath="plugin.tx_dlf_tableofcontents" />
+                    </section>
+                </aside>
+
+                <main class="tx-dlf-default-viewer-main">
+                    <div class="document-view tx-dlf-default-viewer-document-view">
+                        <div class="document-functions tx-dlf-default-viewer-document-functions">
+                            <div class="tx-dlf-default-viewer-provider">
+                                <div>
+                                    <p class="tx-dlf-default-viewer-kicker">Kitodo Presentation</p>
+                                    <h1>Viewer</h1>
+                                </div>
+                                <div class="tx-dlf-default-viewer-provider-actions">
+                                    <f:link.page pageUid="{rootPid}" class="tx-dlf-default-viewer-button tx-dlf-default-viewer-button-secondary">Back</f:link.page>
+                                </div>
+                            </div>
+
+                            <div class="tx-dlf-default-viewer-submenu">
+                                <f:cObject typoscriptObjectPath="plugin.tx_dlf_navigation" />
+                                <f:cObject typoscriptObjectPath="plugin.tx_dlf_toolbox" />
+                            </div>
+                        </div>
+
+                        <f:if condition="{documentId}">
+                            <f:then>
+                                <f:cObject typoscriptObjectPath="plugin.tx_dlf_pageview" />
+                            </f:then>
+                            <f:else>
+                                <div class="tx-dlf-default-viewer-empty-state">
+                                    <div class="tx-dlf-default-viewer-empty-notice">
+                                        <p class="tx-dlf-default-viewer-kicker">No Document</p>
+                                        <h2>No document selected</h2>
+                                        <p>Pass a document URL in <code>tx_dlf[id]</code> to open a METS or IIIF document.</p>
+                                    </div>
+                                </div>
+                            </f:else>
+                        </f:if>
+                    </div>
+                </main>
+            </div>
+
+            <script>
+                (function () {
+                    function updateViewerSize() {
+                        if (window.tx_dlf_viewer && typeof window.tx_dlf_viewer.updateLayerSize === 'function') {
+                            window.setTimeout(function () { window.tx_dlf_viewer.updateLayerSize(); }, 0);
+                            window.setTimeout(function () { window.tx_dlf_viewer.updateLayerSize(); }, 250);
+                        }
+                    }
+
+                    function enterFullscreen() {
+                        document.body.classList.add('fullscreen');
+                        var button = document.querySelector('li.tx-dlf-tools-fullscreen a');
+                        if (button) {
+                            button.classList.add('active');
+                        }
+                        updateViewerSize();
+                    }
+
+                    function exitFullscreen() {
+                        document.body.classList.remove('fullscreen');
+                        var button = document.querySelector('li.tx-dlf-tools-fullscreen a');
+                        if (button) {
+                            button.classList.remove('active');
+                        }
+                        updateViewerSize();
+                    }
+
+                    function toggleFullscreen(event) {
+                        event.preventDefault();
+                        if (document.body.classList.contains('fullscreen')) {
+                            exitFullscreen();
+                        } else {
+                            enterFullscreen();
+                        }
+                    }
+
+                    window.addEventListener('load', function () {
+                        updateViewerSize();
+                        var fullscreenButton = document.querySelector('li.tx-dlf-tools-fullscreen a');
+                        if (fullscreenButton) {
+                            fullscreenButton.addEventListener('click', toggleFullscreen);
+                            fullscreenButton.addEventListener('touchstart', toggleFullscreen, { passive: false });
+                        }
+                    });
+                })();
+            </script>
+</div>
+</html>

--- a/Resources/Public/JavaScript/Backend/new-tenant-root.js
+++ b/Resources/Public/JavaScript/Backend/new-tenant-root.js
@@ -1,0 +1,21 @@
+(function () {
+  function refreshPageTree() {
+    const moduleBody = document.querySelector('.t3js-module-body[data-refresh-page-tree="1"]');
+    if (!moduleBody || !window.top || !window.top.document) {
+      return;
+    }
+
+    window.top.document.dispatchEvent(new CustomEvent('typo3:pagetree:refresh'));
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete('refreshPageTree');
+    window.history.replaceState(window.history.state, document.title, url.toString());
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', refreshPageTree, { once: true });
+    return;
+  }
+
+  refreshPageTree();
+})();

--- a/Resources/Public/Stylesheets/default-viewer.css
+++ b/Resources/Public/Stylesheets/default-viewer.css
@@ -1,0 +1,596 @@
+body.tx-dlf-default-viewer-page {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.tx-dlf-default-viewer-shell {
+  --default-ink: #18212c;
+  --default-link: #1a4d8f;
+  --default-link-hover: #0f539f;
+  --default-accent: #213345;
+  --default-surface: rgba(255, 255, 255, 0.94);
+  --default-border: rgba(24, 33, 44, 0.1);
+  --default-shadow: 0 10px 24px rgba(7, 14, 21, 0.14);
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+  color: var(--default-ink);
+  background: whitesmoke;
+}
+
+.tx-dlf-default-viewer-viewframe {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+
+.tx-dlf-default-viewer-landing {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.94)),
+    linear-gradient(120deg, rgba(26, 77, 143, 0.08), transparent 35%),
+    whitesmoke;
+}
+
+.tx-dlf-default-viewer-welcome {
+  width: min(1080px, calc(100% - 48px));
+  margin: 48px auto;
+  padding: 40px 44px 56px;
+  border: 1px solid var(--default-border);
+  border-radius: 20px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+}
+
+.tx-dlf-default-viewer-welcome-hero,
+.tx-dlf-default-viewer-welcome-section {
+  margin-bottom: 40px;
+  padding: 0;
+}
+
+.tx-dlf-default-viewer-welcome-hero h1,
+.tx-dlf-default-viewer-welcome-header h2,
+.tx-dlf-default-viewer-example-card h3 {
+  margin: 0;
+}
+
+.tx-dlf-default-viewer-welcome-lead {
+  max-width: 760px;
+  margin: 18px 0 0;
+  font-size: 18px;
+  line-height: 1.65;
+}
+
+.tx-dlf-default-viewer-welcome-header {
+  margin-bottom: 18px;
+}
+
+.tx-dlf-default-viewer-welcome-hero {
+  padding-bottom: 34px;
+  border-bottom: 1px solid var(--default-border);
+}
+
+
+.tx-dlf-default-viewer-example-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.tx-dlf-default-viewer-example-card {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 20px 18px;
+  border: 1px solid var(--default-border);
+  border-radius: 16px;
+  background: white;
+}
+
+.tx-dlf-default-viewer-example-card p,
+.tx-dlf-default-viewer-welcome-section p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.tx-dlf-default-viewer-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--default-link);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-link:hover {
+  color: var(--default-link-hover);
+}
+
+.tx-dlf-default-viewer-link-muted {
+  color: slategray;
+}
+
+.tx-dlf-default-viewer-link-muted:hover {
+  color: slategray;
+}
+
+.tx-dlf-default-viewer-format-list {
+  margin: 0 0 18px;
+  padding-left: 20px;
+}
+
+.tx-dlf-default-viewer-format-list li {
+  margin-bottom: 10px;
+  line-height: 1.6;
+}
+
+
+.tx-dlf-default-viewer-input-form {
+  display: grid;
+  gap: 14px;
+}
+
+.tx-dlf-default-viewer-input-label {
+  font-weight: 700;
+}
+
+.tx-dlf-default-viewer-input-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.tx-dlf-default-viewer-input {
+  min-width: 0;
+  min-height: 46px;
+  padding: 0 14px;
+  border: 1px solid var(--default-border);
+  border-radius: 12px;
+  background: white;
+  color: var(--default-ink);
+  font: inherit;
+}
+
+.tx-dlf-default-viewer-input:focus {
+  outline: 2px solid rgba(26, 77, 143, 0.22);
+  outline-offset: 1px;
+}
+
+.tx-dlf-default-viewer-welcome-section-compact {
+  max-width: 760px;
+  margin-bottom: 0;
+  padding-top: 10px;
+  border-top: 1px solid var(--default-border);
+}
+
+.tx-dlf-default-viewer-control-bar {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1px;
+  min-height: 100vh;
+  border-right: 1px solid var(--default-border);
+  background: rgba(24, 33, 44, 0.14);
+}
+
+.tx-dlf-default-viewer-control-panel,
+.tx-dlf-default-viewer-card {
+  border: 1px solid var(--default-border);
+  background: var(--default-surface);
+}
+
+.tx-dlf-default-viewer-control-panel {
+  min-width: 0;
+  padding: 22px 20px;
+  overflow: auto;
+}
+
+.tx-dlf-default-viewer-control-header {
+  margin-bottom: 16px;
+}
+
+.tx-dlf-default-viewer-main {
+  min-width: 0;
+}
+
+.tx-dlf-default-viewer-document-view {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.tx-dlf-default-viewer-empty-state {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.tx-dlf-default-viewer-empty-notice {
+  width: min(460px, 100%);
+  padding: 24px 28px;
+  border: 1px solid var(--default-border);
+  border-radius: 18px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+  text-align: center;
+}
+
+.tx-dlf-default-viewer-empty-notice h2,
+.tx-dlf-default-viewer-empty-notice p {
+  margin-top: 0;
+}
+
+.tx-dlf-default-viewer-empty-notice p:last-child {
+  margin-bottom: 0;
+}
+
+.tx-dlf-default-viewer-document-functions {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 20;
+  display: grid;
+  gap: 10px;
+  padding: 14px 18px;
+  pointer-events: none;
+}
+
+.tx-dlf-default-viewer-provider,
+.tx-dlf-default-viewer-submenu {
+  pointer-events: auto;
+  border: 1px solid var(--default-border);
+  border-radius: 10px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+}
+
+.tx-dlf-default-viewer-provider {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+}
+
+.tx-dlf-default-viewer-provider h1,
+.tx-dlf-default-viewer-control-header h2,
+.tx-dlf-default-viewer-card h2 {
+  margin: 0;
+}
+
+.tx-dlf-default-viewer-provider h1 {
+  font-size: 26px;
+  line-height: 1;
+}
+
+.tx-dlf-default-viewer-provider-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tx-dlf-default-viewer-kicker,
+.tx-dlf-default-viewer-panel-kicker {
+  margin: 0 0 4px;
+  color: slategray;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tx-dlf-default-viewer-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--default-accent);
+  border-radius: 999px;
+  background: var(--default-accent);
+  color: white;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-button-secondary {
+  background: white;
+  color: var(--default-accent);
+  border-color: rgba(33, 51, 69, 0.2);
+}
+
+.tx-dlf-default-viewer-submenu {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  padding: 10px 12px;
+  color: var(--default-accent);
+}
+
+.tx-dlf-default-viewer-submenu ul,
+.tx-dlf-default-viewer-submenu li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-dlf-default-viewer-submenu a,
+.tx-dlf-default-viewer-submenu span,
+.tx-dlf-default-viewer-submenu label,
+.tx-dlf-default-viewer-submenu select {
+  color: inherit;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward > div,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward > div,
+.tx-dlf-default-viewer-submenu li {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--default-border);
+  border-radius: 7px;
+  background: var(--default-surface);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.tx-dlf-default-viewer-submenu a:hover,
+.tx-dlf-default-viewer-submenu li.tx-dlf-tools-fullscreen a.active {
+  color: var(--default-link-hover);
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward span,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward span {
+  opacity: 0.46;
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages {
+  gap: 10px;
+  padding: 6px 10px;
+  background: var(--default-surface);
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages label {
+  font-weight: 700;
+}
+
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages select {
+  min-width: 110px;
+  min-height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--default-border);
+  border-radius: 6px;
+  background: white;
+}
+
+.tx-dlf-default-viewer-submenu li[class^="tx-dlf-tools-"] span,
+.tx-dlf-default-viewer-submenu li[class^="tx-dlf-tools-"] a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tx-dlf-default-viewer-document-view .tx-dlf-map {
+  position: absolute;
+  inset: 0;
+}
+
+#tx-dlf-annotationselection,
+#tx-dlf-toolbox-fulltext-selection {
+  border-radius: 10px;
+  background: var(--default-surface);
+  box-shadow: var(--default-shadow);
+}
+
+#tx-dlf-annotationselection {
+  position: absolute;
+  top: 110px;
+  right: 24px;
+  z-index: 21;
+  max-width: 320px;
+  padding: 12px 14px;
+}
+
+#tx-dlf-annotationselection:empty,
+#tx-dlf-toolbox-fulltext-selection:empty {
+  display: none;
+}
+
+.tx-dlf-toolbox-fulltext-container {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  left: 24px;
+  z-index: 16;
+  pointer-events: none;
+}
+
+#tx-dlf-toolbox-fulltext-selection {
+  max-width: min(640px, 100%);
+  max-height: 28vh;
+  overflow: auto;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.55;
+  pointer-events: auto;
+}
+
+#tx-dlf-toolbox-fulltext-selection .textline,
+#tx-dlf-toolbox-fulltext-selection .sp {
+  display: inline;
+}
+
+#tx-dlf-toolbox-fulltext-selection .sp {
+  white-space: pre;
+}
+
+#tx-dlf-toolbox-fulltext-selection .highlight {
+  background: khaki;
+}
+
+#tx-dlf-toolbox-fulltext-selection .string,
+#tx-dlf-toolbox-fulltext-selection .hyp {
+  color: inherit;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents,
+.tx-dlf-default-viewer-control-panel .tx-dlf-metadata-titledata {
+  font-size: 14px;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents li {
+  margin-bottom: 8px;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a {
+  color: var(--default-link);
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a:hover {
+  text-decoration: underline;
+}
+
+.tx-dlf-metadata-titledata {
+  margin: 0;
+}
+
+.tx-dlf-metadata-titledata dt {
+  margin: 0 0 4px;
+  color: #425264;
+  font-weight: 700;
+}
+
+.tx-dlf-metadata-titledata dd {
+  margin: 0 0 14px;
+}
+
+.tx-dlf-default-viewer-card {
+  max-width: 760px;
+  margin: 12vh auto 0;
+  padding: 28px;
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(9, 16, 24, 0.14);
+}
+
+.tx-dlf-default-viewer-actions {
+  margin: 24px 0 0;
+}
+
+.tx-dlf-default-viewer-example {
+  margin-bottom: 0;
+  word-break: break-all;
+}
+
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-viewframe {
+  grid-template-columns: 1fr;
+}
+
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-control-bar {
+  display: none;
+}
+
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-document-functions {
+  padding: 12px;
+}
+
+@media (max-width: 980px) {
+  .tx-dlf-default-viewer-welcome {
+    width: min(100% - 32px, 1080px);
+    margin: 24px auto;
+    padding: 32px 28px 40px;
+  }
+
+  .tx-dlf-default-viewer-example-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1180px) {
+  .tx-dlf-default-viewer-viewframe {
+    grid-template-columns: 1fr;
+  }
+
+  .tx-dlf-default-viewer-main {
+    order: 1;
+  }
+
+  .tx-dlf-default-viewer-control-bar {
+    order: 2;
+    min-height: auto;
+    grid-template-rows: none;
+    grid-template-columns: 1fr;
+    border-top: 1px solid var(--default-border);
+    border-right: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .tx-dlf-default-viewer-welcome {
+    width: min(100% - 24px, 1080px);
+    margin: 12px auto;
+    padding: 24px 18px 28px;
+  }
+
+  .tx-dlf-default-viewer-welcome-lead {
+    font-size: 16px;
+  }
+
+  .tx-dlf-default-viewer-input-row {
+    grid-template-columns: 1fr;
+  }
+
+  .tx-dlf-default-viewer-input-row .tx-dlf-default-viewer-button {
+    width: 100%;
+  }
+
+  .tx-dlf-default-viewer-document-functions {
+    padding: 12px;
+  }
+
+  .tx-dlf-default-viewer-provider {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tx-dlf-default-viewer-submenu {
+    gap: 8px;
+  }
+
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages,
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form {
+    width: 100%;
+  }
+
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages select {
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  .tx-dlf-toolbox-fulltext-container {
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+  }
+}

--- a/Resources/Public/Stylesheets/default-viewer.css
+++ b/Resources/Public/Stylesheets/default-viewer.css
@@ -1,6 +1,7 @@
 body.tx-dlf-default-viewer-page {
   margin: 0;
   min-height: 100vh;
+  background: #f5f5f5;
 }
 
 .tx-dlf-default-viewer-shell {
@@ -8,68 +9,95 @@ body.tx-dlf-default-viewer-page {
   --default-link: #1a4d8f;
   --default-link-hover: #0f539f;
   --default-accent: #213345;
+  --default-muted: #708090;
   --default-surface: rgba(255, 255, 255, 0.94);
-  --default-border: rgba(24, 33, 44, 0.1);
+  --default-border: rgba(24, 33, 44, 0.12);
   --default-shadow: 0 10px 24px rgba(7, 14, 21, 0.14);
   min-height: 100vh;
-  font-family: Arial, sans-serif;
   color: var(--default-ink);
-  background: whitesmoke;
+  font-family: "Arial", sans-serif;
 }
 
-.tx-dlf-default-viewer-viewframe {
-  display: grid;
-  grid-template-columns: 360px minmax(0, 1fr);
-  min-height: 100vh;
+.tx-dlf-default-viewer-shell :is(h1, h2, h3, p) { margin-top: 0; }
+
+.tx-dlf-default-viewer-kicker,
+.tx-dlf-default-viewer-panel-kicker {
+  margin: 0 0 4px;
+  color: var(--default-muted);
+  font-size: 11px;
+  font-weight: bold;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
+.tx-dlf-default-viewer-link,
+.tx-dlf-default-viewer-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.tx-dlf-default-viewer-link { color: var(--default-link); }
+
+.tx-dlf-default-viewer-link:hover,
+.tx-dlf-default-viewer-submenu a:hover,
+.tx-dlf-default-viewer-submenu li.tx-dlf-tools-fullscreen a.active {
+  color: var(--default-link-hover);
+}
+
+.tx-dlf-default-viewer-button {
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--default-accent);
+  border-radius: 999px;
+  background: var(--default-accent);
+  color: #fff;
+  font-size: 13px;
+}
+
+.tx-dlf-default-viewer-button-secondary {
+  border-color: rgba(33, 51, 69, 0.2);
+  background: #fff;
+  color: var(--default-accent);
+}
 
 .tx-dlf-default-viewer-landing {
-  min-height: 100vh;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.94)),
-    linear-gradient(120deg, rgba(26, 77, 143, 0.08), transparent 35%),
-    whitesmoke;
+  box-sizing: border-box;
+  padding: 48px 24px;
 }
 
 .tx-dlf-default-viewer-welcome {
-  width: min(1080px, calc(100% - 48px));
-  margin: 48px auto;
+  max-width: 1080px;
+  margin: 0 auto;
   padding: 40px 44px 56px;
   border: 1px solid var(--default-border);
-  border-radius: 20px;
+  border-radius: 18px;
   background: var(--default-surface);
   box-shadow: var(--default-shadow);
 }
 
 .tx-dlf-default-viewer-welcome-hero,
-.tx-dlf-default-viewer-welcome-section {
-  margin-bottom: 40px;
-  padding: 0;
-}
-
-.tx-dlf-default-viewer-welcome-hero h1,
-.tx-dlf-default-viewer-welcome-header h2,
-.tx-dlf-default-viewer-example-card h3 {
-  margin: 0;
-}
-
-.tx-dlf-default-viewer-welcome-lead {
-  max-width: 760px;
-  margin: 18px 0 0;
-  font-size: 18px;
-  line-height: 1.65;
-}
-
-.tx-dlf-default-viewer-welcome-header {
-  margin-bottom: 18px;
-}
+.tx-dlf-default-viewer-welcome-section { margin-bottom: 40px; }
 
 .tx-dlf-default-viewer-welcome-hero {
   padding-bottom: 34px;
   border-bottom: 1px solid var(--default-border);
 }
 
+.tx-dlf-default-viewer-welcome-lead,
+.tx-dlf-default-viewer-welcome-section p,
+.tx-dlf-default-viewer-format-list { line-height: 1.6; }
+
+.tx-dlf-default-viewer-welcome-lead {
+  max-width: 760px;
+  margin: 18px 0 0;
+  font-size: 18px;
+}
+
+.tx-dlf-default-viewer-welcome-header { margin-bottom: 18px; }
 
 .tx-dlf-default-viewer-example-grid {
   display: grid;
@@ -79,60 +107,35 @@ body.tx-dlf-default-viewer-page {
 
 .tx-dlf-default-viewer-example-card {
   display: grid;
-  gap: 12px;
   align-content: start;
+  gap: 12px;
   padding: 20px 18px;
   border: 1px solid var(--default-border);
-  border-radius: 16px;
-  background: white;
+  border-radius: 12px;
+  background: #fff;
 }
 
 .tx-dlf-default-viewer-example-card p,
-.tx-dlf-default-viewer-welcome-section p {
-  margin: 0;
-  line-height: 1.6;
-}
+.tx-dlf-default-viewer-welcome-section p { margin-bottom: 0; }
 
-.tx-dlf-default-viewer-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--default-link);
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.tx-dlf-default-viewer-link:hover {
-  color: var(--default-link-hover);
-}
-
-.tx-dlf-default-viewer-link-muted {
-  color: slategray;
-}
-
-.tx-dlf-default-viewer-link-muted:hover {
-  color: slategray;
-}
+.tx-dlf-default-viewer-link-muted,
+.tx-dlf-default-viewer-link-muted:hover { color: var(--default-muted); }
 
 .tx-dlf-default-viewer-format-list {
   margin: 0 0 18px;
   padding-left: 20px;
 }
 
-.tx-dlf-default-viewer-format-list li {
-  margin-bottom: 10px;
-  line-height: 1.6;
-}
-
+.tx-dlf-default-viewer-format-list li { margin-bottom: 10px; }
 
 .tx-dlf-default-viewer-input-form {
   display: grid;
   gap: 14px;
 }
 
-.tx-dlf-default-viewer-input-label {
-  font-weight: 700;
-}
+.tx-dlf-default-viewer-input-label,
+.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages label,
+.tx-dlf-metadata-titledata dt { font-weight: bold; }
 
 .tx-dlf-default-viewer-input-row {
   display: grid;
@@ -146,8 +149,8 @@ body.tx-dlf-default-viewer-page {
   min-height: 46px;
   padding: 0 14px;
   border: 1px solid var(--default-border);
-  border-radius: 12px;
-  background: white;
+  border-radius: 10px;
+  background: #fff;
   color: var(--default-ink);
   font: inherit;
 }
@@ -164,34 +167,34 @@ body.tx-dlf-default-viewer-page {
   border-top: 1px solid var(--default-border);
 }
 
+.tx-dlf-default-viewer-viewframe {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
 .tx-dlf-default-viewer-control-bar {
   display: grid;
-  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 1px;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
   min-height: 100vh;
   border-right: 1px solid var(--default-border);
   background: rgba(24, 33, 44, 0.14);
-}
-
-.tx-dlf-default-viewer-control-panel,
-.tx-dlf-default-viewer-card {
-  border: 1px solid var(--default-border);
-  background: var(--default-surface);
 }
 
 .tx-dlf-default-viewer-control-panel {
   min-width: 0;
   padding: 22px 20px;
   overflow: auto;
+  border: 1px solid var(--default-border);
+  background: var(--default-surface);
 }
 
-.tx-dlf-default-viewer-control-header {
-  margin-bottom: 16px;
-}
+.tx-dlf-default-viewer-control-header { margin-bottom: 16px; }
 
-.tx-dlf-default-viewer-main {
-  min-width: 0;
-}
+.tx-dlf-default-viewer-control-header h2,
+.tx-dlf-default-viewer-provider h1 { margin: 0; }
+
+.tx-dlf-default-viewer-main { min-width: 0; }
 
 .tx-dlf-default-viewer-document-view {
   position: relative;
@@ -199,32 +202,10 @@ body.tx-dlf-default-viewer-page {
   overflow: hidden;
 }
 
+.tx-dlf-default-viewer-document-view .tx-dlf-map,
 .tx-dlf-default-viewer-empty-state {
   position: absolute;
   inset: 0;
-  z-index: 5;
-  display: grid;
-  place-items: center;
-  padding: 24px;
-}
-
-.tx-dlf-default-viewer-empty-notice {
-  width: min(460px, 100%);
-  padding: 24px 28px;
-  border: 1px solid var(--default-border);
-  border-radius: 18px;
-  background: var(--default-surface);
-  box-shadow: var(--default-shadow);
-  text-align: center;
-}
-
-.tx-dlf-default-viewer-empty-notice h2,
-.tx-dlf-default-viewer-empty-notice p {
-  margin-top: 0;
-}
-
-.tx-dlf-default-viewer-empty-notice p:last-child {
-  margin-bottom: 0;
 }
 
 .tx-dlf-default-viewer-document-functions {
@@ -238,13 +219,18 @@ body.tx-dlf-default-viewer-page {
 }
 
 .tx-dlf-default-viewer-provider,
-.tx-dlf-default-viewer-submenu {
-  pointer-events: auto;
+.tx-dlf-default-viewer-submenu,
+.tx-dlf-default-viewer-empty-notice,
+#tx-dlf-annotationselection,
+#tx-dlf-toolbox-fulltext-selection {
   border: 1px solid var(--default-border);
   border-radius: 10px;
   background: var(--default-surface);
   box-shadow: var(--default-shadow);
 }
+
+.tx-dlf-default-viewer-provider,
+.tx-dlf-default-viewer-submenu { pointer-events: auto; }
 
 .tx-dlf-default-viewer-provider {
   display: flex;
@@ -254,12 +240,6 @@ body.tx-dlf-default-viewer-page {
   padding: 12px 16px;
 }
 
-.tx-dlf-default-viewer-provider h1,
-.tx-dlf-default-viewer-control-header h2,
-.tx-dlf-default-viewer-card h2 {
-  margin: 0;
-}
-
 .tx-dlf-default-viewer-provider h1 {
   font-size: 26px;
   line-height: 1;
@@ -267,39 +247,7 @@ body.tx-dlf-default-viewer-page {
 
 .tx-dlf-default-viewer-provider-actions {
   display: flex;
-  align-items: center;
   gap: 10px;
-}
-
-.tx-dlf-default-viewer-kicker,
-.tx-dlf-default-viewer-panel-kicker {
-  margin: 0 0 4px;
-  color: slategray;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.tx-dlf-default-viewer-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 38px;
-  padding: 0 14px;
-  border: 1px solid var(--default-accent);
-  border-radius: 999px;
-  background: var(--default-accent);
-  color: white;
-  font-size: 13px;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.tx-dlf-default-viewer-button-secondary {
-  background: white;
-  color: var(--default-accent);
-  border-color: rgba(33, 51, 69, 0.2);
 }
 
 .tx-dlf-default-viewer-submenu {
@@ -311,64 +259,36 @@ body.tx-dlf-default-viewer-page {
   color: var(--default-accent);
 }
 
-.tx-dlf-default-viewer-submenu ul,
-.tx-dlf-default-viewer-submenu li {
+.tx-dlf-default-viewer-submenu :is(ul, li) {
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward,
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward,
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages,
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.tx-dlf-default-viewer-submenu a,
-.tx-dlf-default-viewer-submenu span,
-.tx-dlf-default-viewer-submenu label,
-.tx-dlf-default-viewer-submenu select {
+.tx-dlf-default-viewer-submenu :is(a, span, label, select) {
   color: inherit;
   font-size: 13px;
   text-decoration: none;
 }
 
-
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward > div,
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward > div,
-.tx-dlf-default-viewer-submenu li {
+.tx-dlf-default-viewer-submenu :is(.tx-dlf-navigation-backward, .tx-dlf-navigation-forward,
+.tx-dlf-navigation-pages, .tx-dlf-navigation-pages form, li,
+li[class^="tx-dlf-tools-"] a, li[class^="tx-dlf-tools-"] span) {
   display: inline-flex;
   align-items: center;
+  gap: 8px;
+}
+
+.tx-dlf-default-viewer-submenu :is(li, .tx-dlf-navigation-backward > div,
+.tx-dlf-navigation-forward > div, .tx-dlf-navigation-pages) {
   min-height: 36px;
   padding: 0 12px;
   border: 1px solid var(--default-border);
   border-radius: 7px;
   background: var(--default-surface);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
-.tx-dlf-default-viewer-submenu a:hover,
-.tx-dlf-default-viewer-submenu li.tx-dlf-tools-fullscreen a.active {
-  color: var(--default-link-hover);
-}
-
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-backward span,
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-forward span {
-  opacity: 0.46;
-}
-
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages {
-  gap: 10px;
-  padding: 6px 10px;
-  background: var(--default-surface);
-}
-
-.tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages label {
-  font-weight: 700;
-}
+.tx-dlf-default-viewer-submenu :is(.tx-dlf-navigation-backward span, .tx-dlf-navigation-forward span) { opacity: 0.46; }
 
 .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages select {
   min-width: 110px;
@@ -376,26 +296,20 @@ body.tx-dlf-default-viewer-page {
   padding: 0 8px;
   border: 1px solid var(--default-border);
   border-radius: 6px;
-  background: white;
+  background: #fff;
 }
 
-.tx-dlf-default-viewer-submenu li[class^="tx-dlf-tools-"] span,
-.tx-dlf-default-viewer-submenu li[class^="tx-dlf-tools-"] a {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+.tx-dlf-default-viewer-empty-state {
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  padding: 24px;
 }
 
-.tx-dlf-default-viewer-document-view .tx-dlf-map {
-  position: absolute;
-  inset: 0;
-}
-
-#tx-dlf-annotationselection,
-#tx-dlf-toolbox-fulltext-selection {
-  border-radius: 10px;
-  background: var(--default-surface);
-  box-shadow: var(--default-shadow);
+.tx-dlf-default-viewer-empty-notice {
+  width: min(460px, 100%);
+  padding: 24px 28px;
+  text-align: center;
 }
 
 #tx-dlf-annotationselection {
@@ -408,9 +322,7 @@ body.tx-dlf-default-viewer-page {
 }
 
 #tx-dlf-annotationselection:empty,
-#tx-dlf-toolbox-fulltext-selection:empty {
-  display: none;
-}
+#tx-dlf-toolbox-fulltext-selection:empty { display: none; }
 
 .tx-dlf-toolbox-fulltext-container {
   position: absolute;
@@ -431,157 +343,77 @@ body.tx-dlf-default-viewer-page {
   pointer-events: auto;
 }
 
-#tx-dlf-toolbox-fulltext-selection .textline,
-#tx-dlf-toolbox-fulltext-selection .sp {
-  display: inline;
-}
+#tx-dlf-toolbox-fulltext-selection :is(.textline, .sp) { display: inline; }
 
-#tx-dlf-toolbox-fulltext-selection .sp {
-  white-space: pre;
-}
+#tx-dlf-toolbox-fulltext-selection .sp { white-space: pre; }
 
-#tx-dlf-toolbox-fulltext-selection .highlight {
-  background: khaki;
-}
+#tx-dlf-toolbox-fulltext-selection .highlight { background: #f0e68c; }
 
-#tx-dlf-toolbox-fulltext-selection .string,
-#tx-dlf-toolbox-fulltext-selection .hyp {
-  color: inherit;
-}
-
-.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents,
-.tx-dlf-default-viewer-control-panel .tx-dlf-metadata-titledata {
-  font-size: 14px;
-}
+.tx-dlf-default-viewer-control-panel :is(.tx-dlf-tableofcontents, .tx-dlf-metadata-titledata) { font-size: 14px; }
 
 .tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents ul {
   margin: 0;
   padding-left: 18px;
 }
 
-.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents li {
-  margin-bottom: 8px;
-}
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents li { margin-bottom: 8px; }
 
 .tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a {
   color: var(--default-link);
   text-decoration: none;
 }
 
-.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a:hover {
-  text-decoration: underline;
-}
+.tx-dlf-default-viewer-control-panel .tx-dlf-tableofcontents a:hover { text-decoration: underline; }
 
-.tx-dlf-metadata-titledata {
-  margin: 0;
-}
+.tx-dlf-metadata-titledata { margin: 0; }
 
 .tx-dlf-metadata-titledata dt {
   margin: 0 0 4px;
   color: #425264;
-  font-weight: 700;
 }
 
-.tx-dlf-metadata-titledata dd {
-  margin: 0 0 14px;
-}
+.tx-dlf-metadata-titledata dd { margin: 0 0 14px; }
 
-.tx-dlf-default-viewer-card {
-  max-width: 760px;
-  margin: 12vh auto 0;
-  padding: 28px;
-  border-radius: 18px;
-  box-shadow: 0 24px 60px rgba(9, 16, 24, 0.14);
-}
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-viewframe { grid-template-columns: 1fr; }
 
-.tx-dlf-default-viewer-actions {
-  margin: 24px 0 0;
-}
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-control-bar { display: none; }
 
-.tx-dlf-default-viewer-example {
-  margin-bottom: 0;
-  word-break: break-all;
-}
-
-body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-viewframe {
-  grid-template-columns: 1fr;
-}
-
-body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-control-bar {
-  display: none;
-}
-
-body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-document-functions {
-  padding: 12px;
-}
-
-@media (max-width: 980px) {
-  .tx-dlf-default-viewer-welcome {
-    width: min(100% - 32px, 1080px);
-    margin: 24px auto;
-    padding: 32px 28px 40px;
-  }
-
-  .tx-dlf-default-viewer-example-grid {
-    grid-template-columns: 1fr;
-  }
-}
+body.tx-dlf-default-viewer-page.fullscreen .tx-dlf-default-viewer-document-functions { padding: 12px; }
 
 @media (max-width: 1180px) {
-  .tx-dlf-default-viewer-viewframe {
-    grid-template-columns: 1fr;
-  }
+  .tx-dlf-default-viewer-viewframe { grid-template-columns: 1fr; }
 
-  .tx-dlf-default-viewer-main {
-    order: 1;
-  }
+  .tx-dlf-default-viewer-main { order: 1; }
 
   .tx-dlf-default-viewer-control-bar {
     order: 2;
     min-height: auto;
     grid-template-rows: none;
-    grid-template-columns: 1fr;
     border-top: 1px solid var(--default-border);
     border-right: 0;
   }
 }
 
+@media (max-width: 980px) {
+  .tx-dlf-default-viewer-landing { padding: 24px 16px; }
+  .tx-dlf-default-viewer-welcome { padding: 32px 28px 40px; }
+  .tx-dlf-default-viewer-example-grid { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 720px) {
-  .tx-dlf-default-viewer-welcome {
-    width: min(100% - 24px, 1080px);
-    margin: 12px auto;
-    padding: 24px 18px 28px;
-  }
-
-  .tx-dlf-default-viewer-welcome-lead {
-    font-size: 16px;
-  }
-
-  .tx-dlf-default-viewer-input-row {
-    grid-template-columns: 1fr;
-  }
-
-  .tx-dlf-default-viewer-input-row .tx-dlf-default-viewer-button {
-    width: 100%;
-  }
-
-  .tx-dlf-default-viewer-document-functions {
-    padding: 12px;
-  }
-
+  .tx-dlf-default-viewer-landing { padding: 12px; }
+  .tx-dlf-default-viewer-welcome { padding: 24px 18px 28px; }
+  .tx-dlf-default-viewer-welcome-lead { font-size: 16px; }
+  .tx-dlf-default-viewer-input-row { grid-template-columns: 1fr; }
+  .tx-dlf-default-viewer-input-row .tx-dlf-default-viewer-button { width: 100%; }
+  .tx-dlf-default-viewer-document-functions { padding: 12px; }
   .tx-dlf-default-viewer-provider {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .tx-dlf-default-viewer-submenu {
-    gap: 8px;
-  }
-
   .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages,
-  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form {
-    width: 100%;
-  }
+  .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages form { width: 100%; }
 
   .tx-dlf-default-viewer-submenu .tx-dlf-navigation-pages select {
     min-width: 0;


### PR DESCRIPTION
This PR adds a new tenant setup flow, which does exaclty the same as the original new tenant backend module but is accessible through a new CLI command.

It introduces a dedicated CLI command for applying tenant defaults to an existing configuration folder and refactors the backend new-tenant module so that both use the same shared setup logic and future changes affect both.

This PR builds on top of:
1. [the Basic Viewer PR](https://github.com/kitodo/kitodo-presentation/pull/1978)
2. [the root page tree setup](https://github.com/kitodo/kitodo-presentation/pull/1979)

## Changes

- add the CLI command:
  - `kitodo:tenantSetup --config-page=<uid>` for all
  - or one or multiple for individual setup:
    - `--namespaces`
    - `--structures`
    - `--metadata`
- make the CLI and backend module share one implementation for tenant defaults
  - add `TenantModuleSetupService`
  - add `TenantDefaultsSetupService`
- support full tenant setup or selected setup steps:
  - `--namespaces`
  - `--formats` as alias for `--namespaces`
  - `--structures`
  - `--metadata`
  - `--solr-core`

## New Tenant module refactor

This PR moves significant parts out of the original `NewTenantController`. I did not find a nice other way.

Because the tenant setup logic is now shared between the backend module and the CLI command, it makes sense to extract that logic into shared services. The `NewTenantController` now acts as a coordinator that delegates to those services.

- `NewTenantController` acts as a coordinator
- setup actions delegate to `TenantDefaultsSetupService`
- the same service is used by the CLI command

This hopefully keeps the backend and CLI behavior aligned and avoids maintaining two separate implementations of the same setup steps.