### PR TITLE
[MAINTENANCE] Fix git ownership (needed for php-actions/composer@v6)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Fix git ownership (needed for php-actions/composer@v6)
+        run: git config --global --add safe.directory /app
+
       - name: Install dependencies
         uses: php-actions/composer@v6
         with:


### PR DESCRIPTION
This CI issue is fixed by the pull request:

```
2026-06-18T05:40:38.0956763Z The repository at "/app" does not have the correct ownership and git refuses to use it:
2026-06-18T05:40:38.0957497Z 
2026-06-18T05:40:38.0957804Z fatal: detected dubious ownership in repository at '/app'
2026-06-18T05:40:38.0958463Z To add an exception for this directory, call:
2026-06-18T05:40:38.0958876Z 
2026-06-18T05:40:38.0959118Z git config --global --add safe.directory /app
```