### PR TITLE
[MAINTENANCE] Enhance Solr core ID retrieval in BaseCommand

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -136,11 +136,11 @@ class BaseCommand extends Command
     protected function getSolrCoreUid(array $solrCores, bool|string|null $inputSolrId): ?int
     {
         if (MathUtility::canBeInterpretedAsInteger($inputSolrId)) {
-            $solrCoreUid = MathUtility::forceIntegerInRange((int) $inputSolrId, 0);
-        } else {
-            $solrCoreUid = $solrCores[$inputSolrId];
+            return MathUtility::forceIntegerInRange((int) $inputSolrId, 0);
+        } else if (is_string($inputSolrId) && array_key_exists($inputSolrId, $solrCores)) {
+            return $solrCores[$inputSolrId];
         }
-        return $solrCoreUid;
+        return null;
     }
 
     /**

--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -137,7 +137,7 @@ class BaseCommand extends Command
     {
         if (MathUtility::canBeInterpretedAsInteger($inputSolrId)) {
             return MathUtility::forceIntegerInRange((int) $inputSolrId, 0);
-        } else if (is_string($inputSolrId) && array_key_exists($inputSolrId, $solrCores)) {
+        } elseif (is_string($inputSolrId) && array_key_exists($inputSolrId, $solrCores)) {
             return $solrCores[$inputSolrId];
         }
         return null;


### PR DESCRIPTION
The `getSolrCoreUid` method is made more robust by explicitly checking for string keys within the `$solrCores` array. This prevents potential `Undefined index` errors if `$inputSolrId` is a string that does not correspond to an existing core.

Additionally, the method now clarifies its return behavior by explicitly returning `null` if a valid Solr core UID cannot be determined from the provided input.