### PR TITLE
[MAINTENANCE] Refine handling of optional document fields

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -217,7 +217,7 @@ class BaseCommand extends Command
             $document->setPlace(implode('; ', $metadata['place'] ?? []));
             $document->setYear(implode('; ', $metadata['year'] ?? []));
             $document->setAuthor($this->getAuthors($metadata['author'] ?? []));
-            $document->setThumbnail($doc->thumbnail ?? '');
+            $document->setThumbnail($doc->thumbnail);
             $document->setMetsLabel($metadata['mets_label'][0] ?? '');
             $document->setMetsOrderlabel($metadata['mets_orderlabel'][0] ?? '');
 

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -217,7 +217,7 @@ class IndexCommand extends BaseCommand
     {
         $document = null;
 
-        if ($doc->recordId ?? false) {
+        if (!empty($doc->recordId)) {
             $document = $this->documentRepository->findOneBy(['recordId' => $doc->recordId]);
         } else {
             $document = $this->documentRepository->findOneBy(['location' => $url]);


### PR DESCRIPTION
Missing thumbnail is already an empty string, use a `!empty()` check for record IDs, because it is as default empty string instead of null.