### PR TITLE
[MAINTENANCE] Replace generic `viewData` array with explicit assignments

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -95,15 +95,15 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
     /**
      * @access protected
-     * @var mixed[] This holds some common data for the fluid view
+     * @var string This holds unique id for the fluid view
      */
-    protected array $viewData;
+    protected string $uniqueId;
 
     /**
      * @access protected
      * @var int This holds the current page UID (only in frontend context)
      */
-    protected int $pageUid;
+    protected int $pageUid = 0;
 
     /**
      * Holds the configured useGroups as array.
@@ -141,18 +141,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
 
-        $this->viewData = [
-            'pageUid' => $this->pageUid ?? 0,
-            'uniqueId' => uniqid(),
-            'requestData' => $this->requestData
-        ];
-
-        try {
-            $this->viewData['publicResourcePath'] = PathUtility::getPublicResourceWebPath('EXT:dlf/Resources/Public');
-        } catch (InvalidFileException) {
-            $this->logger->warning('Public resource path of the dlf extension could not be determined');
-        }
-
+        $this->uniqueId = uniqid();
     }
 
     /**
@@ -655,9 +644,6 @@ abstract class AbstractController extends ActionController implements LoggerAwar
         }
 
         $this->requestData['page'] = MathUtility::forceIntegerInRange($this->requestData['page'], 1, $this->document->getCurrentDocument()->numPages, 1);
-
-        // reassign viewData to get correct page
-        $this->viewData['requestData'] = $this->requestData;
     }
 
     /**

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -95,7 +95,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
 
     /**
      * @access protected
-     * @var string This holds unique id for the fluid view
+     * @var string This holds the unique id for the fluid view
      */
     protected string $uniqueId;
 

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -157,7 +157,12 @@ class NewTenantController extends AbstractController
 
         $moduleTemplateFactory = GeneralUtility::makeInstance(ModuleTemplateFactory::class);
         $moduleTemplate = $moduleTemplateFactory->create($this->request);
-        $moduleTemplate->assignMultiple($this->viewData);
+        $this->view->assignMultiple(
+            [
+                'requestData' => $this->requestData,
+                'uniqueId' => $this->uniqueId
+            ]
+        );
         $moduleTemplate->assignMultiple($extraData);
         $moduleTemplate->setFlashMessageQueue($messageQueue);
         $template = $isError ? 'Backend/NewTenant/Error' : 'Backend/NewTenant/Index';

--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -173,13 +173,14 @@ class CollectionController extends AbstractController
         $pagination = $this->buildSimplePagination($simplePagination, $solrPaginator);
         $this->view->assignMultiple([ 'pagination' => $pagination, 'paginator' => $solrPaginator ]);
 
-        $this->view->assign('viewData', $this->viewData);
         $this->view->assign('documents', $solrResults);
         $this->view->assign('collection', $collection);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $search);
         $this->view->assign('sortableMetadata', $sortableMetadata);
         $this->view->assign('listedMetadata', $listedMetadata);
+        $this->view->assign('requestData', $this->requestData);
+        $this->view->assign('uniqueId', $this->uniqueId);
 
         return $this->htmlResponse();
     }

--- a/Classes/Controller/ListViewController.php
+++ b/Classes/Controller/ListViewController.php
@@ -118,13 +118,14 @@ class ListViewController extends AbstractController
             $this->view->assignMultiple([ 'pagination' => $pagination, 'paginator' => $solrPaginator ]);
         }
 
-        $this->view->assign('viewData', $this->viewData);
         $this->view->assign('documents', $solrResults);
         $this->view->assign('numResults', $numResults);
         $this->view->assign('page', $currentPage);
         $this->view->assign('lastSearch', $this->search);
         $this->view->assign('sortableMetadata', $sortableMetadata);
         $this->view->assign('listedMetadata', $listedMetadata);
+        $this->view->assign('requestData', $this->requestData);
+        $this->view->assign('uniqueId', $this->uniqueId);
 
         return $this->htmlResponse();
     }

--- a/Classes/Controller/MultiViewController.php
+++ b/Classes/Controller/MultiViewController.php
@@ -48,13 +48,14 @@ class MultiViewController extends AbstractController
 
         $page = $this->requestData['page'] ?? 0;
 
-        $this->view->assign('viewData', $this->viewData);
         $this->view->assign('forceAbsoluteUrl', $this->extConf['general']['forceAbsoluteUrl'] ?? 0);
         $this->view->assign('docId', $this->requestData['id']);
         $this->view->assign('page', $page);
 
         $this->view->assign('multiview', 1);
         $this->view->assign('multiViewDocuments', $this->multiViewDocuments);
+
+        $this->view->assign('requestData', $this->requestData);
 
         return $this->htmlResponse();
     }

--- a/Classes/Controller/NavigationController.php
+++ b/Classes/Controller/NavigationController.php
@@ -78,8 +78,6 @@ class NavigationController extends AbstractController
         } else {
             $this->requestData['page'] = 0;
             $this->requestData['double'] = 0;
-            // reassign requestData to viewData after assigning default values
-            $this->viewData['requestData'] = $this->requestData;
         }
 
         if ($this->document->getUid() !== null) {
@@ -103,7 +101,8 @@ class NavigationController extends AbstractController
         $this->view->assign('pageStepForwardActive', $this->isPageStepForwardActive());
         $this->view->assign('pageSteps', $this->getPageSteps());
         $this->view->assign('numPages', $this->document->getCurrentDocument()->numPages);
-        $this->view->assign('viewData', $this->viewData);
+        $this->view->assign('requestData', $this->requestData);
+        $this->view->assign('uniqueId', $this->uniqueId);
 
         $searchSessionParameters = $this->request->getAttribute('frontend.user')->getKey('ses', 'search');
         if ($searchSessionParameters) {

--- a/Classes/Controller/PageViewController.php
+++ b/Classes/Controller/PageViewController.php
@@ -105,7 +105,6 @@ class PageViewController extends AbstractController
 
         $page = $this->requestData['page'] ?? 0;
 
-        $this->view->assign('viewData', $this->viewData);
         $this->view->assign('forceAbsoluteUrl', $this->extConf['general']['forceAbsoluteUrl'] ?? 0);
         $this->view->assign('docId', $this->requestData['id']);
         $this->view->assign('page', $page);

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -217,7 +217,8 @@ class SearchController extends AbstractController
             $this->view->assign('currentDocument', $currentDocument);
         }
 
-        $this->view->assign('viewData', $this->viewData);
+        $this->view->assign('requestData', $this->requestData);
+        $this->view->assign('uniqueId', $this->uniqueId);
 
         return $this->htmlResponse();
     }

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -56,7 +56,8 @@ class TableOfContentsController extends AbstractController
             $this->view->assign('toc', $this->makeMenuArray());
         }
 
-        $this->view->assign('viewData', $this->viewData);
+        $this->view->assign('requestData', $this->requestData);
+
         return $this->htmlResponse();
     }
 

--- a/Classes/Controller/ToolboxController.php
+++ b/Classes/Controller/ToolboxController.php
@@ -57,7 +57,13 @@ class ToolboxController extends AbstractController
         }
 
         $this->renderTools();
-        $this->view->assign('viewData', $this->viewData);
+        $this->view->assignMultiple(
+            [
+                'pageUid' => $this->pageUid,
+                'requestData' => $this->requestData,
+                'uniqueId' => $this->uniqueId,
+            ]
+        );
 
         return $this->htmlResponse();
     }

--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -46,7 +46,7 @@ final class LinkViewHelper extends AbstractTagBasedViewHelper
         $renderingContext = $this->renderingContext;
         $request = $renderingContext->getRequest();
 
-        $requestData= $this->arguments['requestData'];
+        $requestData = $this->arguments['requestData'];
 
         $dlfArguments = [];
         foreach ($requestData as $key => $data) {

--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -33,7 +33,7 @@ final class LinkViewHelper extends AbstractTagBasedViewHelper
     public function initializeArguments(): void
     {
         parent::initializeArguments();
-        $this->registerArgument('viewData', 'array', 'View data of the current controller.');
+        $this->registerArgument('requestData', 'array', 'Request data of the current controller.');
         $this->registerArgument('pageUid', 'int', 'Target page. See TypoLink destination');
         $this->registerArgument('section', 'string', 'The anchor to be added to the URI', false, '');
         $this->registerArgument('additionalParams', 'array', 'Additional dlf parameters', false, []);
@@ -46,10 +46,10 @@ final class LinkViewHelper extends AbstractTagBasedViewHelper
         $renderingContext = $this->renderingContext;
         $request = $renderingContext->getRequest();
 
-        $viewData = $this->arguments['viewData'];
+        $requestData= $this->arguments['requestData'];
 
         $dlfArguments = [];
-        foreach ($viewData['requestData'] as $key => $data) {
+        foreach ($requestData as $key => $data) {
             if (is_array($data)) {
                 $tempData = [];
                 foreach ($data as $dataKey => $dataValue) {

--- a/Resources/Private/Partials/ListView/SortingForm.html
+++ b/Resources/Private/Partials/ListView/SortingForm.html
@@ -26,8 +26,8 @@
 
     <f:form section="showResults" action="search" controller="Search" name="search" method="post" class="tx-dlf-search-form">
         <div>
-            <label for="form-orderBy-{viewData.uniqueId}"><f:translate key="listView.form.orderBy"/></label>
-            <f:form.select id="form-orderBy-{viewData.uniqueId}" property="orderBy" value="{lastSearch.orderBy}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
+            <label for="form-orderBy-{uniqueId}"><f:translate key="listView.form.orderBy"/></label>
+            <f:form.select id="form-orderBy-{uniqueId}" property="orderBy" value="{lastSearch.orderBy}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
                 <f:form.select.option value="score"><f:translate key="listView.form.relevance" /></f:form.select.option>
                 <f:for each="{sortableMetadata}" as="meta">
                     <f:form.select.option value="{meta.indexName}_sorting">
@@ -35,8 +35,8 @@
                     </f:form.select.option>
                 </f:for>
             </f:form.select>
-            <label for="form-order-{viewData.uniqueId}"><f:translate key="listView.form.order"/></label>
-            <f:form.select id="form-order-{viewData.uniqueId}" property="order" value="{lastSearch.order}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
+            <label for="form-order-{uniqueId}"><f:translate key="listView.form.order"/></label>
+            <f:form.select id="form-order-{uniqueId}" property="order" value="{lastSearch.order}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
                 <f:form.select.option value="asc"><f:translate key='listView.form.order.asc' extensionName='dlf' /></f:form.select.option>
                 <f:form.select.option value="desc"><f:translate key='listView.form.order.desc' extensionName='dlf' />
                 </f:form.select.option>

--- a/Resources/Private/Partials/Navigation/DoublePage.html
+++ b/Resources/Private/Partials/Navigation/DoublePage.html
@@ -14,15 +14,15 @@
 
 <f:if condition="{numPages} > 0">
     <f:then>
-        <f:if condition="{viewData.requestData.double}">
+        <f:if condition="{requestData.double}">
             <f:then>
                 <div class="tx-dlf-navigation-single">
-                    <kitodo:link viewData="{viewData}" additionalParams="{'double':'0'}" excludedParams="{0: 'measure'}"><f:translate key="navigation.doublePage.singlePageView"/></kitodo:link>
+                    <kitodo:link requestData="{requestData}" additionalParams="{'double':'0'}" excludedParams="{0: 'measure'}"><f:translate key="navigation.doublePage.singlePageView"/></kitodo:link>
                 </div>
                 <div class="tx-dlf-navigation-double+">
-                    <f:if condition="{viewData.requestData.double} && ({viewData.requestData.page} < {numPages})">
+                    <f:if condition="{requestData.double} && ({requestData.page} < {numPages})">
                         <f:then>
-                            <kitodo:link viewData="{viewData}" additionalParams="{'page':'{viewData.requestData.page + 1}'}" excludedParams="{0: 'measure'}"><f:translate key="navigation.doublePage.rectoVerso"/></kitodo:link>
+                            <kitodo:link requestData="{requestData}" additionalParams="{'page':'{requestData.page + 1}'}" excludedParams="{0: 'measure'}"><f:translate key="navigation.doublePage.rectoVerso"/></kitodo:link>
                         </f:then>
                         <f:else>
                             <span title="{f:translate(key: 'navigation.doublePage.rectoVerso')}"><f:translate key="navigation.doublePage.rectoVerso"/></span>
@@ -32,7 +32,7 @@
             </f:then>
             <f:else>
                 <div class="tx-dlf-navigation-double">
-                    <kitodo:link viewData="{viewData}" additionalParams="{'double':'1'}" excludedParams="{0: 'measure'}"><f:translate key="navigation.doublePage.doublePageView"/></kitodo:link>>
+                    <kitodo:link requestData="{requestData}" additionalParams="{'double':'1'}" excludedParams="{0: 'measure'}"><f:translate key="navigation.doublePage.doublePageView"/></kitodo:link>
                 </div>
             </f:else>
         </f:if>

--- a/Resources/Private/Partials/Navigation/MeasureBack.html
+++ b/Resources/Private/Partials/Navigation/MeasureBack.html
@@ -18,7 +18,7 @@
             <f:if condition="{currentMeasure} > 1">
                 <f:then>
                     <f:variable name="prevMeasure" value="{currentMeasure - 1}" />
-                    <kitodo:link viewData="{viewData}" additionalParams="{'measure':'{currentMeasure - 1}', 'page':'{measurePages.{prevMeasure}}'}"><f:translate key="general.prevMeasure"/></kitodo:link>
+                    <kitodo:link requestData="{requestData}" additionalParams="{'measure':'{currentMeasure - 1}', 'page':'{measurePages.{prevMeasure}}'}"><f:translate key="general.prevMeasure"/></kitodo:link>
                 </f:then>
                 <f:else>
                     <span title="{f:translate(key: 'prevPage')}"><f:translate key="general.prevMeasure"/></span>

--- a/Resources/Private/Partials/Navigation/MeasureForward.html
+++ b/Resources/Private/Partials/Navigation/MeasureForward.html
@@ -20,10 +20,10 @@
                     <f:if condition="{currentMeasure} > 0">
                         <f:then>
                             <f:variable name="nextMeasure" value="{currentMeasure + 1}" />
-                            <kitodo:link viewData="{viewData}" additionalParams="{'measure':'{nextMeasure}', 'page':'{measurePages.{nextMeasure}}'}"><f:translate key="nextMeasure"/></kitodo:link>
+                            <kitodo:link requestData="{requestData}" additionalParams="{'measure':'{nextMeasure}', 'page':'{measurePages.{nextMeasure}}'}"><f:translate key="nextMeasure"/></kitodo:link>
                         </f:then>
                         <f:else>
-                            <kitodo:link viewData="{viewData}" additionalParams="{'measure':'1', 'page':'{measurePages.1}'}"><f:translate key="nextMeasure"/></kitodo:link>
+                            <kitodo:link requestData="{requestData}" additionalParams="{'measure':'1', 'page':'{measurePages.1}'}"><f:translate key="nextMeasure"/></kitodo:link>
                         </f:else>
                     </f:if>
                 </f:then>

--- a/Resources/Private/Partials/Navigation/Page.html
+++ b/Resources/Private/Partials/Navigation/Page.html
@@ -15,7 +15,7 @@
 <div class="{class}">
     <f:if condition="{condition}">
         <f:then>
-            <kitodo:link viewData="{viewData}" additionalParams="{'page':'{navigationPage}'}" excludedParams="{0: 'measure'}"><f:translate key="{value}"/></kitodo:link>
+            <kitodo:link requestData="{requestData}" additionalParams="{'page':'{navigationPage}'}" excludedParams="{0: 'measure'}"><f:translate key="{value}"/></kitodo:link>
         </f:then>
         <f:else>
             <span title="{f:translate(key: '{value}')}"><f:translate key="{value}"/></span>

--- a/Resources/Private/Partials/Navigation/PageBack.html
+++ b/Resources/Private/Partials/Navigation/PageBack.html
@@ -11,8 +11,8 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:variable name="navigationPage" value="{viewData.requestData.page - 1 - viewData.requestData.double}" />
+<f:variable name="navigationPage" value="{requestData.page - 1 - requestData.double}" />
 
-<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-prev', condition: pageBackActive, navigationPage: navigationPage, value: 'navigation.page.prevPage', viewData: viewData}" />
+<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-prev', condition: pageBackActive, navigationPage: navigationPage, value: 'navigation.page.prevPage', requestData: requestData}" />
 
 </html>

--- a/Resources/Private/Partials/Navigation/PageFirst.html
+++ b/Resources/Private/Partials/Navigation/PageFirst.html
@@ -11,6 +11,6 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-first', condition: pageFirstActive, navigationPage: '1', value: 'navigation.page.firstPage', viewData: viewData}" />
+<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-first', condition: pageFirstActive, navigationPage: '1', value: 'navigation.page.firstPage', requestData: requestData}" />
 
 </html>

--- a/Resources/Private/Partials/Navigation/PageForward.html
+++ b/Resources/Private/Partials/Navigation/PageForward.html
@@ -11,9 +11,9 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:variable name="navigationPage" value="{viewData.requestData.page + 1 + viewData.requestData.double}" />
+<f:variable name="navigationPage" value="{requestData.page + 1 + requestData.double}" />
 
-<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-next', condition: pageForwardActive, navigationPage: navigationPage, value: 'navigation.page.nextPage', viewData: viewData}" />
+<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-next', condition: pageForwardActive, navigationPage: navigationPage, value: 'navigation.page.nextPage', requestData: requestData}" />
 
 </html>
 

--- a/Resources/Private/Partials/Navigation/PageLast.html
+++ b/Resources/Private/Partials/Navigation/PageLast.html
@@ -11,8 +11,8 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:variable name="navigationPage" value="{numPages - viewData.requestData.double}" />
+<f:variable name="navigationPage" value="{numPages - requestData.double}" />
 
-<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-last', condition: pageLastActive, navigationPage: navigationPage, value: 'navigation.page.lastPage', viewData: viewData}" />
+<f:render partial="Navigation/Page" arguments="{class: 'tx-dlf-navigation-last', condition: pageLastActive, navigationPage: navigationPage, value: 'navigation.page.lastPage', requestData: requestData}" />
 
 </html>

--- a/Resources/Private/Partials/Navigation/PageSelect.html
+++ b/Resources/Private/Partials/Navigation/PageSelect.html
@@ -13,24 +13,24 @@
 
 <li class="tx-dlf-navigation-pages">
     <f:form method="post" action="pageSelect" controller="Navigation" name="pageSelectForm" object="{pageSelectForm}" addQueryString="untrusted">
-        <f:if condition="{viewData.requestData.id}">
-            <f:form.hidden property="id" value="{viewData.requestData.id}"/>
+        <f:if condition="{requestData.id}">
+            <f:form.hidden property="id" value="{requestData.id}"/>
         </f:if>
-        <f:if condition="{viewData.requestData.recordId}">
-            <f:form.hidden property="recordId" value="{viewData.requestData.recordId}"/>
+        <f:if condition="{requestData.recordId}">
+            <f:form.hidden property="recordId" value="{requestData.recordId}"/>
         </f:if>
-        <f:if condition="{viewData.requestData.double}">
-            <f:form.hidden property="double" value="{viewData.requestData.double}"/>
+        <f:if condition="{requestData.double}">
+            <f:form.hidden property="double" value="{requestData.double}"/>
         </f:if>
-        <f:if condition="{viewData.requestData.multiviewembedded} == 1">
-            <f:form.hidden name="tx_dlf[multiviewembedded]" value="{viewData.requestData.multiviewembedded}"/>
+        <f:if condition="{requestData.multiviewembedded} == 1">
+            <f:form.hidden name="tx_dlf[multiviewembedded]" value="{requestData.multiviewembedded}"/>
         </f:if>
-        <label for="tx-dlf-page-{viewData.uniqueId}">
+        <label for="tx-dlf-page-{uniqueId}">
             <f:translate key="navigation.page.selectPage"/>
         </label>
-        <f:form.select id="tx-dlf-page-{viewData.uniqueId}" property="page"
+        <f:form.select id="tx-dlf-page-{uniqueId}" property="page"
                        options="{pageOptions}"
-                       value="{viewData.requestData.page}"
+                       value="{requestData.page}"
                        additionalAttributes="{'onchange': 'javascript:this.form.submit();'}">
         </f:form.select>
     </f:form>

--- a/Resources/Private/Partials/Navigation/PageStep.html
+++ b/Resources/Private/Partials/Navigation/PageStep.html
@@ -15,7 +15,7 @@
 <div class="{class}">
     <f:if condition="{condition}">
         <f:then>
-            <kitodo:link viewData="{viewData}" additionalParams="{'page':'{navigationPage}'}" excludedParams="{0: 'measure'}"><f:translate key="{value}" arguments="{0: '{pageSteps}'}"/></kitodo:link>
+            <kitodo:link requestData="{requestData}" additionalParams="{'page':'{navigationPage}'}" excludedParams="{0: 'measure'}"><f:translate key="{value}" arguments="{0: '{pageSteps}'}"/></kitodo:link>
         </f:then>
         <f:else>
             <span title="{f:translate(key: '{value}', arguments: '{0: pageSteps}')}"><f:translate key="{value}" arguments="{0: '{pageSteps}'}"/></span>

--- a/Resources/Private/Partials/Navigation/PageStepBack.html
+++ b/Resources/Private/Partials/Navigation/PageStepBack.html
@@ -11,11 +11,11 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:variable name="navigationPage" value="{viewData.requestData.page - pageSteps}" />
+<f:variable name="navigationPage" value="{requestData.page - pageSteps}" />
 <f:if condition="{navigationPage} < 1">
     <f:variable name="navigationPage" value="1" />
 </f:if>
 
-<f:render partial="Navigation/PageStep" arguments="{class: 'tx-dlf-navigation-back', condition: pageStepBackActive, navigationPage: navigationPage, pageSteps: pageSteps, value: 'navigation.page.backXPages', viewData: viewData}" />
+<f:render partial="Navigation/PageStep" arguments="{class: 'tx-dlf-navigation-back', condition: pageStepBackActive, navigationPage: navigationPage, pageSteps: pageSteps, value: 'navigation.page.backXPages', requestData: requestData}" />
 
 </html>

--- a/Resources/Private/Partials/Navigation/PageStepForward.html
+++ b/Resources/Private/Partials/Navigation/PageStepForward.html
@@ -11,9 +11,9 @@
     LICENSE.txt file that was distributed with this source code.
 </f:comment>
 
-<f:variable name="navigationPage" value="{viewData.requestData.page + pageSteps}" />
+<f:variable name="navigationPage" value="{requestData.page + pageSteps}" />
 
-<f:render partial="Navigation/PageStep" arguments="{class: 'tx-dlf-navigation-fwd', condition: pageStepForwardActive, navigationPage: navigationPage, pageSteps: pageSteps, value: 'navigation.page.forwardXPages', viewData: viewData}" />
+<f:render partial="Navigation/PageStep" arguments="{class: 'tx-dlf-navigation-fwd', condition: pageStepForwardActive, navigationPage: navigationPage, pageSteps: pageSteps, value: 'navigation.page.forwardXPages', requestData: requestData}" />
 
 </html>
 

--- a/Resources/Private/Partials/Search/Form.html
+++ b/Resources/Private/Partials/Search/Form.html
@@ -38,17 +38,17 @@
         <f:comment><!-- needs to be written like this, to check if fulltext searchparam == NULL --></f:comment>
         <f:if condition="{lastSearch.fulltext} ==">
             <f:then>
-                <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{viewData.uniqueId}" class="tx-dlf-search-fulltext" checked="{settings.fulltextPreselect} == 0" />
-                <label for="tx-dlf-search-fulltext-no-{viewData.uniqueId}"><f:translate key="search.inMetadata"/></label>
-                <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{viewData.uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{settings.fulltextPreselect} == 1" />
-                <label for="tx-dlf-search-fulltext-yes-{viewData.uniqueId}"><f:translate key="search.inFulltext"/></label>
+                <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{uniqueId}" class="tx-dlf-search-fulltext" checked="{settings.fulltextPreselect} == 0" />
+                <label for="tx-dlf-search-fulltext-no-{uniqueId}"><f:translate key="search.inMetadata"/></label>
+                <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{settings.fulltextPreselect} == 1" />
+                <label for="tx-dlf-search-fulltext-yes-{uniqueId}"><f:translate key="search.inFulltext"/></label>
             </f:then>
             <f:comment><!-- as soon we have a user preference, we use it instead --></f:comment>
             <f:else>
-                <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{viewData.uniqueId}" class="tx-dlf-search-fulltext" checked="{lastSearch.fulltext} == 0" />
-                <label for="tx-dlf-search-fulltext-no-{viewData.uniqueId}"><f:translate key="search.inMetadata"/></label>
-                <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{viewData.uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{lastSearch.fulltext} == 1" />
-                <label for="tx-dlf-search-fulltext-yes-{viewData.uniqueId}"><f:translate key="search.inFulltext"/></label>
+                <f:form.radio property="fulltext" value="0" id="tx-dlf-search-fulltext-no-{uniqueId}" class="tx-dlf-search-fulltext" checked="{lastSearch.fulltext} == 0" />
+                <label for="tx-dlf-search-fulltext-no-{uniqueId}"><f:translate key="search.inMetadata"/></label>
+                <f:form.radio property="fulltext" value="1" id="tx-dlf-search-fulltext-yes-{uniqueId}" class="tx-dlf-search-fulltext-yes" checked="{lastSearch.fulltext} == 1" />
+                <label for="tx-dlf-search-fulltext-yes-{uniqueId}"><f:translate key="search.inFulltext"/></label>
             </f:else>
         </f:if>
     </f:if>

--- a/Resources/Private/Partials/TableOfContents/Children.html
+++ b/Resources/Private/Partials/TableOfContents/Children.html
@@ -42,7 +42,7 @@
         </f:then>
         <f:else>
             <kitodo:link
-                viewData="{viewData}"
+                requestData="{requestData}"
                 pageUid="{settings.targetPid}"
                 additionalParams="{f:if(condition:'{child.id}', then:'{\'id\':child.id, \'page\':child.page}', else: '{\'page\':child.page}')}"
                 excludedParams="{0: 'measure', 1: 'multiview'}"
@@ -68,7 +68,7 @@
 
     <f:if condition="{child._SUB_MENU} && ({child.ITEM_STATE} == 'IFSUB' || {child.ITEM_STATE} == 'ACTIFSUB' || {child.ITEM_STATE} == 'CURIFSUB')">
         <ul>
-            <f:render partial="TableOfContents/Children" arguments="{children: child._SUB_MENU, viewData: viewData}"/>
+            <f:render partial="TableOfContents/Children" arguments="{children: child._SUB_MENU, requestData: requestData}"/>
         </ul>
     </f:if>
 

--- a/Resources/Private/Partials/Toolbox/SearchInDocumentTool.html
+++ b/Resources/Private/Partials/Toolbox/SearchInDocumentTool.html
@@ -19,7 +19,7 @@
             <f:variable name="actionUrl" value="{settings.searchUrl}" />
         </f:then>
         <f:else>
-            <f:variable name="actionUrl" value="{f:uri.page(pageUid='{viewData.pageUid}')}" />
+            <f:variable name="actionUrl" value="{f:uri.page(pageUid='{pageUid}')}" />
         </f:else>
     </f:if>
     <form class="tx-dlf-search-form" id="{id}-form" action="{actionUrl}" method="get" enctype="multipart/form-data">
@@ -32,7 +32,7 @@
             <input type="submit" id="{id}-input-button" value="{f:translate(key: 'search.submit')}" onclick="resetStart();" />
             <input type="hidden" id="{id}-input-start" name="{searchInDocument.labelStart}" value="0" />
             <input type="hidden" id="{id}-input-id" name="{searchInDocument.labelId}" value="{searchInDocument.documentId}" />
-            <input type="hidden" id="{id}-input-pid" name="{searchInDocument.labelPid}" value="{viewData.pageUid}" />
+            <input type="hidden" id="{id}-input-pid" name="{searchInDocument.labelPid}" value="{pageUid}" />
             <input type="hidden" id="{id}-input-page" name="{searchInDocument.labelPageUrl}" />
             <input type="hidden" id="{id}-input-highlight-word" name="{searchInDocument.labelHighlightWord}" />
             <input type="hidden" id="{id}-input-encrypted" name="{searchInDocument.labelEncrypted}" value="{searchInDocument.solrEncrypted}" />

--- a/Resources/Private/Partials/Toolbox/ViewerSelectionTool.html
+++ b/Resources/Private/Partials/Toolbox/ViewerSelectionTool.html
@@ -12,17 +12,17 @@
 </f:comment>
 
 <li class="tx-dlf-tools-viewerselection">
-    <form method="get" action="{f:uri.page(pageUid='{viewData.pageUid}')}">
-        <f:if condition="{viewData.requestData.id}">
-            <f:form.hidden name="tx_dlf[id]" value="{viewData.requestData.id}"/>
+    <form method="get" action="{f:uri.page(pageUid='{pageUid}')}">
+        <f:if condition="{requestData.id}">
+            <f:form.hidden name="tx_dlf[id]" value="{requestData.id}"/>
         </f:if>
-        <f:if condition="{viewData.requestData.model}">
-            <f:form.hidden name="tx_dlf[model]" value="{viewData.requestData.model}"/>
+        <f:if condition="{requestData.model}">
+            <f:form.hidden name="tx_dlf[model]" value="{requestData.model}"/>
         </f:if>
-        <f:if condition="{viewData.requestData.modelFormat}">
-            <f:form.hidden name="tx_dlf[modelFormat]" value="{viewData.requestData.modelFormat}"/>
+        <f:if condition="{requestData.modelFormat}">
+            <f:form.hidden name="tx_dlf[modelFormat]" value="{requestData.modelFormat}"/>
         </f:if>
-        <f:form.select id="tx-dlf-tools-viewer-{viewData.uniqueId}" name="tx_dlf[viewer]" options="{viewers}" optionValueField="id" optionLabelField="name" value="{viewData.requestData.viewer}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}" prependOptionLabel="{f:translate(key: 'toolbox.viewerSelection.default', extensionName: 'dlf')}"/>
+        <f:form.select id="tx-dlf-tools-viewer-{uniqueId}" name="tx_dlf[viewer]" options="{viewers}" optionValueField="id" optionLabelField="name" value="{requestData.viewer}" additionalAttributes="{'onchange': 'javascript:this.form.submit();'}" prependOptionLabel="{f:translate(key: 'toolbox.viewerSelection.default', extensionName: 'dlf')}"/>
     </form>
 </li>
 

--- a/Resources/Private/Templates/MultiView/Main.html
+++ b/Resources/Private/Templates/MultiView/Main.html
@@ -49,7 +49,7 @@
                 <div class="gridstack-dragging-handle" title="{f:translate(key: 'multiview.dragging_label', extensionName: 'dfgviewer')}"></div>
                 <f:if condition="{document.sourceKey} >= 0">
                     <div class="removeDocument">
-                        <kitodo:link viewData="{viewData}" excludedParams="{0: 'multiViewSource[{document.sourceKey}]', 1: 'multiview'}">
+                        <kitodo:link requestData="{requestData}" excludedParams="{0: 'multiViewSource[{document.sourceKey}]', 1: 'multiview'}">
                             <f:translate key="multiview.remove_document" extensionName="dfgviewer" />
                         </kitodo:link>
                     </div>

--- a/Resources/Private/Templates/TableOfContents/Main.html
+++ b/Resources/Private/Templates/TableOfContents/Main.html
@@ -17,7 +17,7 @@
 
 <div class="tx-dlf-tableofcontents">
     <ul class="tx-dlf-tableofcontents-list">
-        <f:render partial="TableOfContents/Children" arguments="{children: toc, viewData: viewData}"/>
+        <f:render partial="TableOfContents/Children" arguments="{children: toc, requestData: requestData}"/>
     </ul>
 </div>
 

--- a/Tests/Functional/Controller/ListViewControllerTest.php
+++ b/Tests/Functional/Controller/ListViewControllerTest.php
@@ -51,9 +51,9 @@ class ListViewControllerTest extends AbstractControllerTestCase
         ];
         $templateHtml = '<html xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers">
                 <f:spaceless>
-                uniqueId-length: <v:count.bytes>{viewData.uniqueId}</v:count.bytes>
+                uniqueId-length: <v:count.bytes>{uniqueId}</v:count.bytes>
                 page: {page}
-                double: {viewData.requestData.double}
+                double: {requestData.double}
                 lastSearch.query: {lastSearch.query}
                 numResults: {numResults}
                 </f:spaceless>


### PR DESCRIPTION
This refactoring removes the `$viewData` array from controllers and directly assigns its former constituents, such as `requestData`, `uniqueId`, and `pageUid`, to Fluid views.

This improves clarity and simplifies access to these variables within Fluid templates and ViewHelpers by removing an unnecessary layer of indirection.