### PR TITLE
[MAINTENANCE] Correct behavior of 'showSingle' setting in CollectionController

### DIFF
--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -97,7 +97,7 @@ class CollectionController extends AbstractController
             $collections = $this->collectionRepository->findAll();
         }
 
-        if (iterator_count($collections) == 1 && empty($this->settings['showSingle']) && is_array($collections)) {
+        if (iterator_count($collections) == 1 && $this->settings['showSingle'] && is_array($collections)) {
             return $this->redirect('show', null, null, ['collection' => array_pop($collections)]);
         }
 

--- a/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/Tests/Functional/Controller/CollectionControllerTest.php
@@ -41,7 +41,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
             'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
-            'showSingle' => '1',
+            'showSingle' => '0',
             'randomize' => ''
         ];
         $templateHtml = '<html><f:for each="{collections}" as="item">{item.collection.indexName}</f:for></html>';
@@ -62,6 +62,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
             'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
             'collections' => '1',
+            'showSingle' => '1',
             'randomize' => ''
         ];
         $controller = $this->setUpController(CollectionController::class, $settings);


### PR DESCRIPTION
The `showSingle` setting previously caused a redirect to a single collection view when it was disabled (empty or false). This change corrects the condition so that the redirect only occurs when `showSingle` is explicitly enabled (`true`), aligning with its intended purpose to directly display a single collection.