### PR TITLE
[FEATURE] Improve single collection display and refactor collection retrieval

### DIFF
--- a/Classes/Controller/CollectionController.php
+++ b/Classes/Controller/CollectionController.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 /**
  * Controller class for the plugin 'Collection'.
@@ -88,18 +89,14 @@ class CollectionController extends AbstractController
         $this->collectionRepository->useStoragePid($this->settings['storagePid']);
         $this->metadataRepository->useStoragePid($this->settings['storagePid']);
 
-        // Sort collections according to order in plugin flexform configuration
-        if ($this->settings['collections']) {
-            $sortedCollections = [];
-            foreach (GeneralUtility::intExplode(',', $this->settings['collections']) as $uid) {
-                $sortedCollections[$uid] = $this->collectionRepository->findByUid($uid);
-            }
-            $collections = $sortedCollections;
-        } else {
-            $collections = $this->collectionRepository->findAll();
+        if ($this->settings['showSingle']) {
+            $uid = GeneralUtility::intExplode(',', $this->settings['collections']);
+            return $this->redirect('show', null, null, ['collection' => $this->collectionRepository->findByUid($uid[0])]);
         }
 
-        if (iterator_count($collections) == 1 && $this->settings['showSingle'] && is_array($collections)) {
+        $collections = $this->getCollections();
+
+        if (iterator_count($collections) == 1 && is_array($collections)) {
             return $this->redirect('show', null, null, ['collection' => array_pop($collections)]);
         }
 
@@ -196,6 +193,27 @@ class CollectionController extends AbstractController
                 'collection' => $collection
             ]
         );
+    }
+
+    /**
+     * Get collections.
+     *
+     * @access private
+     *
+     * @return array<int, Collection>|QueryResultInterface<int, Collection>
+     */
+    private function getCollections(): array|QueryResultInterface
+    {
+        // Sort collections according to order in plugin FlexForm configuration
+        if ($this->settings['collections']) {
+            $sortedCollections = [];
+            foreach (GeneralUtility::intExplode(',', $this->settings['collections']) as $uid) {
+                $sortedCollections[$uid] = $this->collectionRepository->findByUid($uid);
+            }
+            return $sortedCollections;
+        }
+
+        return $this->collectionRepository->findAll();
     }
 
     /**

--- a/Classes/Domain/Repository/CollectionRepository.php
+++ b/Classes/Domain/Repository/CollectionRepository.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  *
  * @access public
  *
+ * @method array<Collection>|QueryResultInterface<int,Collection> findAll() Returns all objects of this repository.
  * @method Collection|null findOneBy(array $criteria) Get a collection by criteria
  *
  * @extends AbstractRepository<Collection>

--- a/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/Tests/Functional/Controller/CollectionControllerTest.php
@@ -55,12 +55,12 @@ class CollectionControllerTest extends AbstractControllerTestCase
 
     #[Test]
     #[Group("listAction")]
-    public function canListActionForwardToShow()
+    public function canListActionForwardToShowEvenIfMoreCollectionsAreFound()
     {
         $settings = [
             'storagePid' => self::$storagePid,
             'solrcore' => self::$solrCoreId,
-            'collections' => '1',
+            'collections' => '1,2',
             'showSingle' => '1',
             'randomize' => ''
         ];
@@ -74,7 +74,7 @@ class CollectionControllerTest extends AbstractControllerTestCase
 
     #[Test]
     #[Group("listAction")]
-    public function canNotListActionForwardToShow()
+    public function canListActionForwardToShowIfOnlyOneCollectionIsFound()
     {
         $settings = [
             'storagePid' => self::$storagePid,
@@ -83,11 +83,12 @@ class CollectionControllerTest extends AbstractControllerTestCase
             'showSingle' => '0',
             'randomize' => ''
         ];
-        $templateHtml = '<html><f:for each="{collections}" as="item">{item.collection.indexName}</f:for></html>';
+        $controller = $this->setUpController(CollectionController::class, $settings);
+        $request = $this->setUpRequest('list', ['tx_dlf' => ['id' => 1] ]);
+        $request = $request->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
 
-        $actual = $this->getContentsList($settings, $templateHtml);
-        $expected = '<html>test-collection</html>';
-        $this->assertEquals($expected, $actual);
+        $response = $controller->processRequest($request);
+        $this->assertEquals(303, $response->getStatusCode());
     }
 
     #[Test]


### PR DESCRIPTION
The `showSingle` setting now ensures an immediate redirect to the first configured collection, bypassing the list view when a direct detail view is desired. This clarifies its intended behavior and prevents the list from displaying a single item unnecessarily.

The logic for fetching and sorting collections has been extracted into a new private method, `getCollections()`, enhancing the clarity and maintainability of the `listAction`.