### PR TITLE
[MAINTENANCE] Enhance PHPStan type inference and compliance for repositories

### DIFF
--- a/.github/phpstan_12.4.neon
+++ b/.github/phpstan_12.4.neon
@@ -18,6 +18,9 @@ parameters:
     -
       message: '#Access to constant EDIT on an unknown class TYPO3\\CMS\\Scheduler\\SchedulerManagementAction\.#'
       path: ../Classes/Task/BaseAdditionalFieldProvider.php
+    -
+      message: '#Cannot call method getFirst\(\) on iterable<Kitodo\\Dlf\\Domain\\Model\\SolrCore>|TYPO3\\CMS\\Extbase\\Persistence\\QueryResultInterface\.#'
+      path: ../Classes/Controller/Backend/NewTenantController.php
   level: 7
   paths:
     - ../Classes/

--- a/Classes/Command/ReindexCommand.php
+++ b/Classes/Command/ReindexCommand.php
@@ -227,7 +227,7 @@ class ReindexCommand extends BaseCommand
                 ->execute();
         } else {
             // Get all documents.
-            return $this->documentRepository->findAll(); // @phpstan-ignore-line
+            return $this->documentRepository->findAll();
         }
     }
 

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -339,7 +339,6 @@ class NewTenantController extends AbstractController
         // load language file in own array
         $beLabels = $this->languageFactory->getParsedData('EXT:dlf/Resources/Private/Language/locallang_be.xlf', $this->siteLanguages[0]->getLocale()->getLanguageCode());
 
-        // @phpstan-ignore-next-line findAll() returns QueryResultInterface and there is function getFirst()
         if ($this->solrCoreRepository->findAll()->getFirst() === null) {
             $newRecord = GeneralUtility::makeInstance(SolrCore::class);
             $newRecord->setLabel($this->getLLL('flexform.solrcore', $this->siteLanguages[0]->getLocale()->getLanguageCode(), $beLabels). ' (PID ' . $this->pid . ')');

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -35,6 +35,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  *
  * @access public
  *
+ * @method array<Document>|QueryResultInterface<int, Document> findAll() Get all documents
  * @method Document|null findByUid(int|null $uid) Get a document by its UID
  * @method Document|null findOneBy(array $criteria) Get a document by criteria
  *


### PR DESCRIPTION
The `DocumentRepository` now includes a more precise `@method` PHPDoc type hint for `findAll()`, allowing PHPStan to correctly infer its return type as `array|QueryResultInterface`. This enables the removal of an `@phpstan-ignore-line` annotation in `ReindexCommand`.

For `NewTenantController`, a PHPStan error regarding the `getFirst()` method on `QueryResultInterface` has been moved from an inline ignore to a configuration-based ignore in `phpstan_12.4.neon`. This centralizes the ignore for a specific type inference limitation.