### PR TITLE
[MAINTENANCE] Encapsulate document range finding in repository

### DIFF
--- a/Classes/Command/ReindexCommand.php
+++ b/Classes/Command/ReindexCommand.php
@@ -220,11 +220,7 @@ class ReindexCommand extends BaseCommand
         ) {
             $io->writeln($indexLimit . ' documents starting from ' . $indexBegin . ' will be indexed.');
             // Get all documents for given limit and start.
-            return $this->documentRepository->findAll() // @phpstan-ignore-line
-                ->getQuery()
-                ->setLimit((int) $indexLimit)
-                ->setOffset((int) $indexBegin)
-                ->execute();
+            return $this->documentRepository->findAllInRange((int) $indexLimit, (int) $indexBegin);
         } else {
             // Get all documents.
             return $this->documentRepository->findAll(); // @phpstan-ignore-line

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -228,6 +228,34 @@ class DocumentRepository extends AbstractRepository
     }
 
     /**
+     * Finds all documents for the given range.
+     *
+     * @access public
+     *
+     * @param int $limit
+     * @param int $offset
+     *
+     * @return array<Document>|QueryResultInterface<int, Document>
+     */
+    public function findAllInRange(int $limit = 50, int $offset = 0): array|QueryResultInterface
+    {
+        $query = $this->createQuery();
+
+        $query->setOrderings(
+            ['uid' => QueryInterface::ORDER_ASCENDING]
+        );
+
+        if ($limit > 0) {
+            $query->setLimit($limit);
+            $query->setOffset($offset);
+        }
+
+        $this->debugQuery($query);
+
+        return $query->execute();
+    }
+
+    /**
      * Count the titles and volumes for statistics
      *
      * Volumes are documents that are both


### PR DESCRIPTION
The logic for finding documents within a specific limit and offset has been moved from `ReindexCommand` into a new `findAllInRange` method in `DocumentRepository`.

This change improves encapsulation and makes the repository responsible for handling range-based queries, simplifying the command's logic.