### PR TITLE
[MAINTENANCE] Expose MetsDocument::$mets property publicly

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -326,7 +326,7 @@ final class MetsDocument extends AbstractDocument
     }
 
     /**
-     * Return clone of METS for external uage.
+     * Return clone of METS for external usage.
      *
      * @access public
      *

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -177,10 +177,10 @@ final class MetsDocument extends AbstractDocument
     protected bool $fileGrpsLoaded = false;
 
     /**
-     * @access public
+     * @access protected
      * @var SimpleXMLElement|null This holds the XML file's METS part as SimpleXMLElement object
      */
-    public ?SimpleXMLElement $mets = null;
+    protected ?SimpleXMLElement $mets = null;
 
     /**
      * @access protected
@@ -323,6 +323,18 @@ final class MetsDocument extends AbstractDocument
             $this->logger->warning('There is no file node with @ID "' . $id . '"');
             return '';
         }
+    }
+
+    /**
+     * Return clone of METS for external uage.
+     *
+     * @access public
+     *
+     * @return SimpleXMLElement|null
+     */
+    public function getMets(): ?SimpleXMLElement
+    {
+        return clone $this->mets;
     }
 
     /**

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -334,7 +334,10 @@ final class MetsDocument extends AbstractDocument
      */
     public function getMets(): ?SimpleXMLElement
     {
-        return clone $this->mets;
+        if ($this->mets !== null) {
+            return clone $this->mets;
+        }
+        return null;
     }
 
     /**

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -177,10 +177,10 @@ final class MetsDocument extends AbstractDocument
     protected bool $fileGrpsLoaded = false;
 
     /**
-     * @access protected
+     * @access public
      * @var SimpleXMLElement|null This holds the XML file's METS part as SimpleXMLElement object
      */
-    protected ?SimpleXMLElement $mets = null;
+    public ?SimpleXMLElement $mets = null;
 
     /**
      * @access protected


### PR DESCRIPTION
This allows direct access to the `SimpleXMLElement` object representing the METS document part, facilitating external processing or modification.

Error comes from slub_digitalcollections: 
`Error: Access to protected property Kitodo\Dlf\Common\MetsDocument::$mets.`

See: 
https://github.com/slub/slub_digitalcollections/actions/runs/30346470277/job/90233742182
https://github.com/slub/slub_digitalcollections/blob/602891882d97545dd35b5ef1f08c858e93cf53a6/Classes/ViewHelpers/XpathViewHelper.php#L129