### PR TITLE
[BUGFIX] Fix statistics retrieval

### DIFF
--- a/Classes/Controller/StatisticsController.php
+++ b/Classes/Controller/StatisticsController.php
@@ -34,7 +34,7 @@ class StatisticsController extends AbstractController
      */
     public function mainAction(): ResponseInterface
     {
-        $foundNumbers = $this->documentRepository->getStatisticsForSelectedCollection($this->settings);
+        $foundNumbers = $this->documentRepository->getStatistics($this->settings);
 
         // Set replacements.
         $args['###TITLES###'] = $foundNumbers['titles'] . ' ' . htmlspecialchars(

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -241,9 +241,9 @@ class DocumentRepository extends AbstractRepository
      *
      * @return array<string, int>
      */
-    public function getStatisticsForSelectedCollection(array $settings): array
+    public function getStatistics(array $settings): array
     {
-        if (array_key_exists('collections', $settings)) {
+        if (array_key_exists('collections', $settings) && !empty($settings['collections'])) {
             return $this->getStatisticsForSelectedCollections($settings);
         } else {
             return $this->getStatisticsForAllCollections($settings);

--- a/Tests/Functional/Repository/DocumentRepositoryTest.php
+++ b/Tests/Functional/Repository/DocumentRepositoryTest.php
@@ -160,22 +160,22 @@ class DocumentRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function canGetStatisticsForSelectedCollection(): void
+    public function canGetStatistics(): void
     {
         // TODO: check why it returns 3 if statistics for both collections return 4
-        $result = $this->documentRepository->getStatisticsForSelectedCollection(['storagePid' => 20000]);
+        $result = $this->documentRepository->getStatistics(['storagePid' => 20000]);
         self::assertEquals(3, $result['titles']);
         self::assertEquals(3, $result['volumes']);
 
-        $result = $this->documentRepository->getStatisticsForSelectedCollection(['collections' => '1101', 'storagePid' => 20000]);
+        $result = $this->documentRepository->getStatistics(['collections' => '1101', 'storagePid' => 20000]);
         self::assertEquals(3, $result['titles']);
         self::assertEquals(3, $result['volumes']);
 
-        $result = $this->documentRepository->getStatisticsForSelectedCollection(['collections' => '1102', 'storagePid' => 20000]);
+        $result = $this->documentRepository->getStatistics(['collections' => '1102', 'storagePid' => 20000]);
         self::assertEquals(1, $result['titles']);
         self::assertEquals(1, $result['volumes']);
 
-        $result = $this->documentRepository->getStatisticsForSelectedCollection(['collections' => '1101, 1102', 'storagePid' => 20000]);
+        $result = $this->documentRepository->getStatistics(['collections' => '1101, 1102', 'storagePid' => 20000]);
         self::assertEquals(4, $result['titles']);
         self::assertEquals(4, $result['volumes']);
     }


### PR DESCRIPTION
The method's internal logic is corrected to properly distinguish between fetching statistics for all collections or for explicitly selected ones. If the 'collections' setting is present but empty, it will now default to fetching statistics for all collections, preventing unintended empty selections.

Rename `getStatisticsForSelectedCollection()` to `getStatistics()` to make it more clear.