### PR TITLE
[BUGFIX] Fix incomplete metadata search

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -765,7 +765,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
 
             $edismax = $selectQuery->getEDisMax();
 
-            $queryFields = '';
+            $queryFields = 'default ';
 
             if ($this->indexedMetadata) {
                 foreach ($this->indexedMetadata as $metadata) {


### PR DESCRIPTION
This bugfix resolves an issue, where the results in the listview dont add up to the total results in the facets (or more precisely the actual amount of documents that should have been found in the index).

This was likely introduced with the "query time field boost", where the configured field boost for a metadata of the metadata repository was applied during querytime on that specific field: https://github.com/kitodo/kitodo-presentation/blob/4dd3b4d8e6313095b3b2bfc2bfe183e528a430f8/Classes/Common/Solr/SolrSearch.php#L774

The reason behind this misbehaviour is, that the query time field boost is comparable to an extended search, where we search for our query through as list of fields (those, that are indexed) with custom weights (field boost), but we dont take into consideration anymore, that some metadata fields are untokenized. Thus the search is only showing results, where our search string matches an untokenized string in one of our documents metadata.

BUT In our solr schema.xml we have the catch-all field "default", that has a tokenizer in its analyzer chain. It is being used and filled with every metadata that is being indexed. It does so via the copyfield directive. It also was the classic metadata search, that falls back onto "default", when no field is specified to be searched within. This was at least since Kitodo.Presentation version 4.x.

This means, that prior to query time field boosting, we searched only the default field and have relied on index time field boosting. But with the change to query time field boosting, we dont lookup the generaly tokenized "default" field with not weight anymore, but only all indexed metadata field and their weights, which requires "exact matching" for fields that are untokenized. Thus the difference between the seemingly small hitcount in the listview compared to the proper hitcount in the facets.