### PR TITLE
[MAINTENANCE] Refine type handling in `DataHandler` for Solr core creation

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -44,7 +44,7 @@ class DataHandler implements LoggerAwareInterface
      * @param string $status 'new' or 'update'
      * @param string $table The destination table
      * @param int|string $id The uid of the record
-     * @param array<string, string> &$fieldArray Array of field values
+     * @param array<string, int|string> &$fieldArray Array of field values
      *
      * @return void
      */
@@ -100,7 +100,7 @@ class DataHandler implements LoggerAwareInterface
                     // Field post-processing for table "tx_dlf_solrcores".
                 case 'tx_dlf_solrcores':
                     // Create new Solr core.
-                    $fieldArray['index_name'] = Solr::createCore($fieldArray['index_name']);
+                    $fieldArray['index_name'] = Solr::createCore((string) $fieldArray['index_name']);
                     if (empty($fieldArray['index_name'])) {
                         $this->logger->error('Could not create new Apache Solr core');
                         // Unset all fields to prevent new database record if Solr core creation failed.


### PR DESCRIPTION
The docblock for `$fieldArray` was updated to accurately reflect that its values can be `int` or `string`. Additionally, an explicit string cast has been added to `index_name` before calling `Solr::createCore()`. This guarantees the function always receives a string, preventing potential type-related issues and improving robustness.