### PR TITLE
[BUGFIX] Ensure Token options are always returned as an array

### DIFF
--- a/Classes/Controller/OaiPmhController.php
+++ b/Classes/Controller/OaiPmhController.php
@@ -326,7 +326,7 @@ class OaiPmhController extends AbstractController
 
         if ($token) {
             $options = $token->getOptions();
-            if (is_array($options)) {
+            if (!empty($options)) {
                 return $options;
             }
         }

--- a/Classes/Domain/Model/Token.php
+++ b/Classes/Domain/Model/Token.php
@@ -63,7 +63,11 @@ class Token extends AbstractEntity
      */
     public function getOptions(): array
     {
-        return unserialize($this->options);
+        $options = unserialize($this->options);
+        if (!is_array($options)) {
+            return [];
+        }
+        return $options;
     }
 
     /**


### PR DESCRIPTION
The `Token::getOptions()` method can receive non-array data from `unserialize()` if the stored data is invalid or represents a non-array value. This change guarantees an array return, preventing `TypeError` exceptions. The `OaiPmhController`'s check is also updated to reflect this guarantee and consider only non-empty options.