### PR TITLE
[MAINTENANCE] Improve repository method signatures and usage

### DIFF
--- a/Classes/Controller/BasketController.php
+++ b/Classes/Controller/BasketController.php
@@ -683,7 +683,7 @@ class BasketController extends AbstractController
         $printerId = $this->requestData['print_action'];
 
         // get id from db and send selected doc download link
-        $printer = $this->printerRepository->findOneBy(['uid' => $printerId]);
+        $printer = $this->printerRepository->findByUid($printerId);
 
         // printer is selected
         if ($printer) {

--- a/Classes/Domain/Repository/BasketRepository.php
+++ b/Classes/Domain/Repository/BasketRepository.php
@@ -22,7 +22,7 @@ use Kitodo\Dlf\Domain\Model\Basket;
  *
  * @access public
  *
- * @method Basket|null findOneBy(array $criteria) Get a basket by criteria
+ * @method Basket|null findOneBy(array<string,int|string> $criteria) Get a basket by criteria
  *
  * @extends AbstractRepository<Basket>
  */

--- a/Classes/Domain/Repository/CollectionRepository.php
+++ b/Classes/Domain/Repository/CollectionRepository.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  * @access public
  *
  * @method array<Collection>|QueryResultInterface<int,Collection> findAll() Returns all objects of this repository.
- * @method Collection|null findOneBy(array $criteria) Get a collection by criteria
+ * @method Collection|null findOneBy(array<string,int|string> $criteria) Get a collection by criteria
  *
  * @extends AbstractRepository<Collection>
  */

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -36,8 +36,8 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
  * @access public
  *
  * @method array<Document>|QueryResultInterface<int, Document> findAll() Get all documents
- * @method Document|null findByUid(int|null $uid) Get a document by its UID
- * @method Document|null findOneBy(array $criteria) Get a document by criteria
+ * @method Document|null findByUid(int $uid) Get a document by its UID
+ * @method Document|null findOneBy(array<string,int|string> $criteria) Get a document by criteria
  *
  * @extends AbstractRepository<Document>
  */
@@ -73,7 +73,7 @@ class DocumentRepository extends AbstractRepository
 
         if (isset($parameters['id']) && MathUtility::canBeInterpretedAsInteger($parameters['id'])) {
 
-            $document = $this->findByUid($parameters['id']);
+            $document = $this->findByUid((int) $parameters['id']);
 
         } elseif (isset($parameters['recordId'])) {
 
@@ -723,7 +723,7 @@ class DocumentRepository extends AbstractRepository
      */
     public function getPreviousDocumentUid(int $uid): ?int
     {
-        $currentDocument = $this->findOneBy(['uid' => $uid]);
+        $currentDocument = $this->findByUid($uid);
         if ($currentDocument) {
             $parentId = $currentDocument->getPartof();
 
@@ -771,7 +771,7 @@ class DocumentRepository extends AbstractRepository
      */
     public function getNextDocumentUid(int $uid): ?int
     {
-        $currentDocument = $this->findOneBy(['uid' => $uid]);
+        $currentDocument = $this->findByUid($uid);
         if ($currentDocument) {
             $parentId = $currentDocument->getPartof();
 

--- a/Classes/Domain/Repository/LibraryRepository.php
+++ b/Classes/Domain/Repository/LibraryRepository.php
@@ -22,8 +22,8 @@ use Kitodo\Dlf\Domain\Model\Library;
  *
  * @access public
  *
- * @method Library|null findByUid(int|null $uid) Get a library by its UID
- * @method Library|null findOneBy(array $criteria) Get a library by criteria
+ * @method Library|null findByUid(int $uid) Get a library by its UID
+ * @method Library|null findOneBy(array<string,int|string> $criteria) Get a library by criteria
  *
  * @extends AbstractRepository<Library>
  */

--- a/Classes/Domain/Repository/PrinterRepository.php
+++ b/Classes/Domain/Repository/PrinterRepository.php
@@ -22,7 +22,8 @@ use Kitodo\Dlf\Domain\Model\Printer;
  *
  * @access public
  *
- * @method Printer|null findOneBy(array $criteria) Get a printer by criteria
+ * @method Printer|null findByUid(int $uid) Get a printer by its UID
+ * @method Printer|null findOneBy(array<string,int|string> $criteria) Get a printer by criteria
  *
  * @extends AbstractRepository<Printer>
  */

--- a/Classes/Domain/Repository/StructureRepository.php
+++ b/Classes/Domain/Repository/StructureRepository.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @access public
  *
- * @method Structure|null findOneBy(array $criteria) Get a structure by criteria
+ * @method Structure|null findOneBy(array<string,int|string> $criteria) Get a structure by criteria
  *
  * @extends AbstractRepository<Structure>
  */


### PR DESCRIPTION
Updates `findOneBy` docblock type hints to be more specific, e.g., `array`. Introduces and utilizes dedicated `findByUid` methods where appropriate, migrating calls from `findOneBy(['uid' => ...])` to enhance clarity and type safety.