### PR TITLE
[MAINTENANCE] Remove redundant `isset` check in IIIF manifest

### DIFF
--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -779,7 +779,7 @@ final class IiifManifest extends AbstractDocument
      */
     protected function magicGetSmLinks(): array
     {
-        if (!$this->smLinksLoaded && isset($this->iiif) && $this->iiif instanceof ManifestInterface) {
+        if (!$this->smLinksLoaded && $this->iiif instanceof ManifestInterface) {
             if (!empty($this->iiif->getDefaultCanvases())) {
                 foreach ($this->iiif->getDefaultCanvases() as $canvas) {
                     $this->smLinkCanvasToResource($canvas, $this->iiif);


### PR DESCRIPTION
The `instanceof` operator correctly handles null values, making the explicit `isset` check redundant for the `$this->iiif` property. This simplifies the conditional statement without changing its logic.