### PR TITLE
[MAINTENANCE] Make `$mets` property accessible only in `MetsDocument`

### DIFF
--- a/Classes/Common/DocumentAnnotation.php
+++ b/Classes/Common/DocumentAnnotation.php
@@ -401,8 +401,9 @@ class DocumentAnnotation
         $annotationData = [];
         $conf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('dlf');
         $apiBaseUrl = $conf['annotationServerUrl'] ?? null;
-        if ($apiBaseUrl && $document->getCurrentDocument() instanceof MetsDocument) {
-            $purl = $document->getCurrentDocument()->mets->xpath('//mods:mods/mods:identifier[@type="purl"]') ?: [];
+        $currentDocument = $document->getCurrentDocument();
+        if ($apiBaseUrl && $currentDocument instanceof MetsDocument) {
+            $purl = $currentDocument->getMets()->xpath('//mods:mods/mods:identifier[@type="purl"]') ?: [];
             if (count($purl) > 0) {
                 $annotationRequest = new AnnotationRequest($apiBaseUrl);
                 $annotationData = $annotationRequest->getAll((string) $purl[0]);

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1430,18 +1430,6 @@ final class MetsDocument extends AbstractDocument
     }
 
     /**
-     * This returns $this->mets via __get()
-     *
-     * @access protected
-     *
-     * @return SimpleXMLElement|null The XML's METS part as SimpleXMLElement object or null if not found
-     */
-    protected function magicGetMets(): ?SimpleXMLElement
-    {
-        return $this->mets;
-    }
-
-    /**
      * @see AbstractDocument::magicGetPhysicalStructure()
      */
     protected function magicGetPhysicalStructure(): array


### PR DESCRIPTION
Only copy of `$mets` property should be accessed outside.