### PR TITLE
[BUGFIX] Correctly filter null values from collections

### DIFF
--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -895,7 +895,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
     private function filterCollections(): void
     {
         if (is_array($this->collections)) {
-            array_filter($this->collections, fn ($value) => $value !== null);
+            $this->collections = array_filter($this->collections, fn ($value) => $value !== null);
         }
     }
 


### PR DESCRIPTION
The `array_filter()` function returns the filtered array and does not modify the original in place. Assigning the result back to `$this->collections` ensures that the intended filtering of `null` values is actually applied.