### PR TITLE
[MAINTENANCE] Return nullable and cloned IIIF resource from `getIiif()`

### DIFF
--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -819,11 +819,16 @@ final class IiifManifest extends AbstractDocument
      *
      * @access public
      *
-     * @return IiifResourceInterface
+     * @api
+     *
+     * @return IiifResourceInterface|null
      */
-    public function getIiif(): IiifResourceInterface
+    public function getIiif(): ?IiifResourceInterface
     {
-        return $this->iiif;
+        if ($this->iiif !== null) {
+            return clone $this->iiif;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
The method now defensively returns a clone of the internal IIIF resource, preventing direct external modification. It also handles the absence of a resource by returning `null`, updating its API contract.