### PR TITLE
[BUGFIX] Adjust Extbase persistence storage PID in CLI commands

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 
 /**
  * Base class for CLI Command classes.
@@ -72,6 +73,12 @@ class BaseCommand extends Command
 
     /**
      * @access protected
+     * @var ConfigurationManager
+     */
+    protected ConfigurationManager $configurationManager;
+
+    /**
+     * @access protected
      * @var int
      */
     protected int $storagePid;
@@ -94,6 +101,7 @@ class BaseCommand extends Command
         LibraryRepository $libraryRepository,
         SolrCoreRepository $solrCoreRepository,
         StructureRepository $structureRepository,
+        ConfigurationManager $configurationManager
     )
     {
         parent::__construct();
@@ -103,6 +111,7 @@ class BaseCommand extends Command
         $this->libraryRepository = $libraryRepository;
         $this->solrCoreRepository = $solrCoreRepository;
         $this->structureRepository = $structureRepository;
+        $this->configurationManager = $configurationManager;
     }
 
     /**
@@ -122,6 +131,10 @@ class BaseCommand extends Command
         $this->documentRepository->useStoragePid($this->storagePid);
         $this->libraryRepository->useStoragePid($this->storagePid);
         $this->structureRepository->useStoragePid($this->storagePid);
+
+        $frameworkConfiguration = $this->configurationManager->getConfiguration($this->configurationManager::CONFIGURATION_TYPE_FRAMEWORK);
+        $frameworkConfiguration['persistence']['storagePid'] = $this->storagePid;
+        $this->configurationManager->setConfiguration($frameworkConfiguration);
     }
 
     /**


### PR DESCRIPTION
Inject `ConfigurationManager` into `BaseCommand` to explicitly set the Extbase framework's `persistence.storagePid`. This ensures that all Extbase-managed repositories and queries within a CLI command consistently use the command's defined `storagePid`, preventing potential inconsistencies in data save. While individual repositories are already configured, this change aligns the global Extbase configuration for robustness in the CLI context.

There was too much removed in https://github.com/kitodo/kitodo-presentation/pull/1952/changes

<img width="1028" height="362" alt="image" src="https://github.com/user-attachments/assets/5d664afa-7f43-4469-9444-25e736894697" />


This bugfix restores necessary part. There is no need for `$request` and `$persitenceManager` initialization inside `BaseCommand` class, but injecting `storagePid` into `$frameworkConfiguration `is still needed.