### PR TITLE
[MAINTENANCE] Adjust fulltext availability check

### DIFF
--- a/Classes/Common/Indexer.php
+++ b/Classes/Common/Indexer.php
@@ -455,7 +455,8 @@ class Indexer
     {
         $doc = $document->getCurrentDocument();
         $doc->configPid = $document->getPid();
-        if ($doc->hasFulltext && $fullText = $doc->getFullText($physicalUnit['id'])) {
+        $fullText = $doc->getFullText($physicalUnit['id']);
+        if (!empty($fullText)) {
             // Read extension configuration.
             $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(self::$extKey, 'files');
             // Create new Solr document.


### PR DESCRIPTION
This change simplifies the logic to solely evaluate the result of `getFullText()` using `!empty()`. This function has already included `hasFulltext` check and if it is false then returns empty string. There is no need for double checking.