### PR TITLE
[MAINTENANCE] Apply scalar type hints and property declarations

### DIFF
--- a/Classes/Common/IiifManifest.php
+++ b/Classes/Common/IiifManifest.php
@@ -992,7 +992,7 @@ final class IiifManifest extends AbstractDocument
      *
      * @access private
      *
-     * @return integer value 0 or 1
+     * @return int value 0 or 1
      */
     private function getIndexAnnotations(): int
     {

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -828,7 +828,7 @@ final class MetsDocument extends AbstractDocument
      * @param mixed[] $metadata
      * @param mixed[] $metadataSections
      *
-     * @return boolean
+     * @return bool
      */
     private function extractAndProcessMetadata(string $dmdId, string $mdSectionType, array &$metadata, array $metadataSections): bool
     {
@@ -862,7 +862,7 @@ final class MetsDocument extends AbstractDocument
      * @param string $currentMetadataSection
      * @param string $searchedMetadataSection
      *
-     * @return boolean
+     * @return bool
      */
     private function hasMetadataSection(array $metadataSections, string $currentMetadataSection, string $searchedMetadataSection): bool
     {

--- a/Classes/Common/Solr/SolrSearch.php
+++ b/Classes/Common/Solr/SolrSearch.php
@@ -727,7 +727,7 @@ class SolrSearch implements \Countable, \Iterator, \ArrayAccess, QueryResultInte
      * @access protected
      *
      * @param mixed[] $parameters Additional search parameters
-     * @param boolean $enableCache Enable caching of Solr requests
+     * @param bool $enableCache Enable caching of Solr requests
      *
      * @return mixed[] The Apache Solr Documents that were fetched
      */

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -397,7 +397,7 @@ abstract class AbstractController extends ActionController implements LoggerAwar
     }
 
     /**
-     * Safely gets integer parameters from request if they exist, otherwise returns 0.
+     * Safely gets array parameters from request if they exist, otherwise returns empty array.
      *
      * @access protected
      *

--- a/Classes/Domain/Model/PageSelectForm.php
+++ b/Classes/Domain/Model/PageSelectForm.php
@@ -26,27 +26,27 @@ class PageSelectForm extends AbstractEntity
 {
     /**
      * @access protected
-     * @var integer
+     * @var int
      */
-    protected $id;
+    protected int $id;
 
     /**
      * @access protected
      * @var string
      */
-    protected $recordId;
+    protected string $recordId;
 
     /**
      * @access protected
      * @var string
      */
-    protected $double;
+    protected string $double;
 
     /**
      * @access protected
-     * @var integer
+     * @var int
      */
-    protected $page;
+    protected int $page;
 
     /**
      * @return int
@@ -83,7 +83,7 @@ class PageSelectForm extends AbstractEntity
     /**
      * @return string
      */
-    public function getDouble(): ?string
+    public function getDouble(): string
     {
         return $this->double;
     }
@@ -111,7 +111,4 @@ class PageSelectForm extends AbstractEntity
     {
         $this->page = $page;
     }
-
-
-
 }


### PR DESCRIPTION
This change introduces native scalar type declarations for properties and updates PHPDoc type hints for scalar return and parameter types. This improves code readability, enables better static analysis, and aligns the codebase with modern PHP practices.