### PR TITLE
[MAINTENANCE] Centralize Extbase storage PID handling in repositories

### DIFF
--- a/Classes/Command/BaseCommand.php
+++ b/Classes/Command/BaseCommand.php
@@ -29,7 +29,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 
 /**
  * Base class for CLI Command classes.
@@ -73,12 +72,6 @@ class BaseCommand extends Command
 
     /**
      * @access protected
-     * @var ConfigurationManager
-     */
-    protected ConfigurationManager $configurationManager;
-
-    /**
-     * @access protected
      * @var int
      */
     protected int $storagePid;
@@ -100,8 +93,7 @@ class BaseCommand extends Command
         DocumentRepository $documentRepository,
         LibraryRepository $libraryRepository,
         SolrCoreRepository $solrCoreRepository,
-        StructureRepository $structureRepository,
-        ConfigurationManager $configurationManager
+        StructureRepository $structureRepository
     )
     {
         parent::__construct();
@@ -111,7 +103,6 @@ class BaseCommand extends Command
         $this->libraryRepository = $libraryRepository;
         $this->solrCoreRepository = $solrCoreRepository;
         $this->structureRepository = $structureRepository;
-        $this->configurationManager = $configurationManager;
     }
 
     /**
@@ -131,10 +122,6 @@ class BaseCommand extends Command
         $this->documentRepository->useStoragePid($this->storagePid);
         $this->libraryRepository->useStoragePid($this->storagePid);
         $this->structureRepository->useStoragePid($this->storagePid);
-
-        $frameworkConfiguration = $this->configurationManager->getConfiguration($this->configurationManager::CONFIGURATION_TYPE_FRAMEWORK);
-        $frameworkConfiguration['persistence']['storagePid'] = $this->storagePid;
-        $this->configurationManager->setConfiguration($frameworkConfiguration);
     }
 
     /**

--- a/Classes/Controller/Backend/NewTenantController.php
+++ b/Classes/Controller/Backend/NewTenantController.php
@@ -178,16 +178,12 @@ class NewTenantController extends AbstractController
      */
     protected function initializeAction(): void
     {
-        $this->pid = (int) ($this->request->getQueryParams()['id'] ?? null);
+        $this->pid = (int) ($this->request->getQueryParams()['id'] ?? 0);
 
         $this->formatRepository->useStoragePid($this->pid);
         $this->metadataRepository->useStoragePid($this->pid);
         $this->solrCoreRepository->useStoragePid($this->pid);
         $this->structureRepository->useStoragePid($this->pid);
-
-        $frameworkConfiguration = $this->configurationManager->getConfiguration($this->configurationManager::CONFIGURATION_TYPE_FRAMEWORK);
-        $frameworkConfiguration['persistence']['storagePid'] = $this->pid;
-        $this->configurationManager->setConfiguration($frameworkConfiguration);
 
         $this->languageFactory = GeneralUtility::makeInstance(LocalizationFactory::class);
 
@@ -198,7 +194,6 @@ class NewTenantController extends AbstractController
         }
         $this->siteLanguages = $site->getLanguages();
     }
-
 
     /**
      * Action adding formats records

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -15,6 +15,7 @@ namespace Kitodo\Dlf\Domain\Repository;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Generic\Storage\Typo3DbQueryParser;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
@@ -41,6 +42,33 @@ class AbstractRepository extends Repository
     protected bool $debug = false;
 
     /**
+     * @access protected
+     * @var int
+     */
+    protected int $storagePid = 0;
+
+    /**
+     * Add storage pid to object if repository has a storage pid set.
+     * @see Repository::add()
+     *
+     * @access public
+     *
+     * @param object $object
+     * @phpstan-param T $object
+     *
+     * @return void
+     *
+     * @throws IllegalObjectTypeException
+     */
+    public function add($object): void
+    {
+        if ($this->storagePid > 0) {
+            $object->setPid($this->storagePid);
+        }
+        parent::add($object);
+    }
+
+    /**
      * Activate debug mode for the repository,
      * which allows to output the generated SQL queries in the debug log.
      *
@@ -48,7 +76,6 @@ class AbstractRepository extends Repository
      *
      * @return void
      */
-
     public function activateDebugMode(): void
     {
         $this->debug = true;
@@ -91,6 +118,7 @@ class AbstractRepository extends Repository
      */
     public function ignoreStoragePid(): void
     {
+        $this->storagePid = 0;
         $querySettings = $this->getDefaultQuerySettings();
         $querySettings->setRespectStoragePage(false);
         $this->setDefaultQuerySettings($querySettings);
@@ -107,6 +135,7 @@ class AbstractRepository extends Repository
      */
     public function useStoragePid(int $storagePid): void
     {
+        $this->storagePid = $storagePid;
         $querySettings = $this->getDefaultQuerySettings();
         $querySettings->setRespectStoragePage(true);
         $querySettings->setStoragePageIds([$storagePid]);
@@ -138,6 +167,40 @@ class AbstractRepository extends Repository
     {
         $querySettings = $this->getDefaultQuerySettings();
         $querySettings->setIgnoreEnableFields(true);
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
+    /**
+     * Persist objects.
+     *
+     * @access public
+     *
+     * @return void
+     */
+    public function persistAll(): void
+    {
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * Sets settings for queries in the repository.
+     *
+     * @access public
+     *
+     * @param int $storagePid
+     * @param bool $showHidden
+     * @param bool $showDeleted
+     * @param bool $useStoragePid
+     *
+     * @return void
+     */
+    public function setSettings(int $storagePid, bool $showHidden = false, bool $showDeleted = false, bool $useStoragePid = true): void
+    {
+        $querySettings = $this->getDefaultQuerySettings();
+        $querySettings->setIgnoreEnableFields($showHidden);
+        $querySettings->setIncludeDeleted($showDeleted);
+        $querySettings->setRespectStoragePage($useStoragePid);
+        $querySettings->setStoragePageIds([$storagePid]);
         $this->setDefaultQuerySettings($querySettings);
     }
 
@@ -175,40 +238,6 @@ class AbstractRepository extends Repository
             DebuggerUtility::var_dump($queryBuilder->getSQL());
             DebuggerUtility::var_dump($queryBuilder->getParameters());
         }
-    }
-
-    /**
-     * Persist objects.
-     *
-     * @access public
-     *
-     * @return void
-     */
-    public function persistAll(): void
-    {
-        $this->persistenceManager->persistAll();
-    }
-
-    /**
-     * Sets settings for queries in the repository.
-     *
-     * @access public
-     *
-     * @param int $storagePid
-     * @param bool $showHidden
-     * @param bool $showDeleted
-     * @param bool $useStoragePid
-     *
-     * @return void
-     */
-    public function setSettings(int $storagePid, bool $showHidden = false, bool $showDeleted = false, bool $useStoragePid = true): void
-    {
-        $querySettings = $this->getDefaultQuerySettings();
-        $querySettings->setIgnoreEnableFields($showHidden);
-        $querySettings->setIncludeDeleted($showDeleted);
-        $querySettings->setRespectStoragePage($useStoragePid);
-        $querySettings->setStoragePageIds([$storagePid]);
-        $this->setDefaultQuerySettings($querySettings);
     }
 
     /**


### PR DESCRIPTION
The `ConfigurationManager` is no longer used in commands and controllers to set the global `persistence.storagePid`.

Instead, the `AbstractRepository` now manages an internal `storagePid` property. When a `storagePid` is set via `useStoragePid()`, any new domain objects added to the repository using the `add()` method will automatically have their PID set to this value.

This simplifies repository usage and improves consistency by ensuring new records are persisted to the correct storage page without relying on global framework configuration changes.

I have decided for this change after analyzing TYPO3 handling of the storage pid: https://github.com/TYPO3/typo3/blob/31f881a2129e79d3d8d8dc5e7910c416e6dd018f/typo3/sysext/extbase/Classes/Persistence/Generic/Backend.php#L919

```
    protected function determineStoragePageIdForNewRecord(?DomainObjectInterface $object = null)
    {
        $frameworkConfiguration = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
        if ($object !== null) {
            if (ObjectAccess::isPropertyGettable($object, AbstractDomainObject::PROPERTY_PID)) {
                $pid = ObjectAccess::getProperty($object, AbstractDomainObject::PROPERTY_PID);
                if (isset($pid)) {
                    return (int)$pid;
                }
            }
            $className = get_class($object);
            if (isset($frameworkConfiguration['persistence']['classes'][$className]) && !empty($frameworkConfiguration['persistence']['classes'][$className]['newRecordStoragePid'])) {
                return (int)$frameworkConfiguration['persistence']['classes'][$className]['newRecordStoragePid'];
            }
        }
        $storagePidList = GeneralUtility::intExplode(',', (string)($frameworkConfiguration['persistence']['storagePid'] ?? ''));
        return (int)$storagePidList[0];
    }
```

As first here is checked the pid of the object and then after it is missing the framework configuration is accessed.