### PR TITLE
[MAINTENANCE] Document InvalidArgumentException in SearchSuggest::process

### DIFF
--- a/Classes/Middleware/SearchSuggest.php
+++ b/Classes/Middleware/SearchSuggest.php
@@ -41,6 +41,8 @@ class SearchSuggest implements MiddlewareInterface
      * @param RequestHandlerInterface $handler
      *
      * @return ResponseInterface XML response of search suggestions
+     *
+     * @throws \InvalidArgumentException if no valid parameter passed
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -54,7 +56,7 @@ class SearchSuggest implements MiddlewareInterface
         $output = [];
         $solrCore = (string) $parameters['solrcore'];
         $uHash = (string) $parameters['uHash'];
-        if (hash_equals(GeneralUtility::hmac((string) (new Typo3Version()) . Environment::getExtensionsPath(), 'SearchSuggest'), $uHash) === false) {
+        if (hash_equals(GeneralUtility::hmac((new Typo3Version()) . Environment::getExtensionsPath(), 'SearchSuggest'), $uHash) === false) {
             throw new \InvalidArgumentException('No valid parameter passed!', 1580585079);
         }
         // Perform Solr query.


### PR DESCRIPTION
Adds the `@throws` annotation to the method's docblock to explicitly state the `InvalidArgumentException` that can be thrown. Additionally, removes a redundant `(string)` cast for `Typo3Version` as it is implicitly cast to a string when concatenated.