### PR TITLE
[MAINTENANCE] Refine InvalidArgumentException message and document throw

### DIFF
--- a/Classes/Middleware/SearchInDocument.php
+++ b/Classes/Middleware/SearchInDocument.php
@@ -59,6 +59,8 @@ class SearchInDocument implements MiddlewareInterface
      * @param RequestHandlerInterface $handler
      *
      * @return ResponseInterface JSON response of search suggestions
+     *
+     * @throws \InvalidArgumentException if no valid parameter passed
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -71,7 +73,7 @@ class SearchInDocument implements MiddlewareInterface
 
         $encrypted = (string) $parameters['encrypted'];
         if (empty($encrypted)) {
-            throw new \InvalidArgumentException('No valid parameter passed: ' . $parameters['middleware'] . '  ' . $parameters['encrypted'] . '!', 1580585079);
+            throw new \InvalidArgumentException('No valid parameter passed in middleware: ' . $parameters['middleware'] . '!', 1580585079);
         }
 
         $output = [


### PR DESCRIPTION
The exception message for missing parameter in the `SearchInDocument` middleware is adjusted.

Additionally, the method's docblock is updated to explicitly declare the `InvalidArgumentException` that can be thrown, improving API clarity.