### PR TITLE
[BUGFIX] Missing Chapters in Audio Documents

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -542,7 +542,7 @@ final class MetsDocument extends AbstractDocument
             $details['thumbnailId'] = $this->getThumbnail($details['id']);
             // Get page/track number of the first page/track related to this structure element.
             $details['pagination'] = $this->physicalStructureInfo[$this->smLinks['l2p'][$details['id']][0]]['orderlabel'];
-            $details['videoChapter'] = $this->getTimecode($details);
+            $details['mediaChapter'] = $this->getTimecode($details);
         } elseif ($details['id'] == $this->getToplevelId()) {
             // Point to self if this is the toplevel structure.
             $details['points'] = 1;

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -198,7 +198,7 @@ final class MetsDocument extends AbstractDocument
      * @access protected
      * @var MediaPlayerService the media player service
      */
-    protected readonly MediaPlayerService $mediaPlayerService;
+    protected MediaPlayerService $mediaPlayerService;
 
     /**
      * This holds the musical structure

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -21,6 +21,7 @@ use Kitodo\Dlf\Domain\Repository\FormatRepository;
 use Kitodo\Dlf\Domain\Repository\MetadataRepository;
 use Kitodo\Dlf\Domain\Repository\StructureRepository;
 use Kitodo\Dlf\Hooks\KitodoProductionHacks;
+use Kitodo\Dlf\Service\MediaPlayerService;
 use SimpleXMLElement;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Log\LogManager;
@@ -192,6 +193,12 @@ final class MetsDocument extends AbstractDocument
      * @var mixed[] the extension settings
      */
     protected array $settings = [];
+
+    /**
+     * @access protected
+     * @var MediaPlayerService the media player service
+     */
+    protected readonly MediaPlayerService $mediaPlayerService;
 
     /**
      * This holds the musical structure
@@ -564,7 +571,7 @@ final class MetsDocument extends AbstractDocument
     protected function getTimecode(array $logInfo): ?array
     {
         // Load plugin configuration.
-        $useGroupsVideo = $this->useGroupsConfiguration->getVideo();
+        $useGroupsVideo = $this->mediaPlayerService->getMediaplayerUseGroups();
 
         foreach ($useGroupsVideo as $useGroupVideo) {
             if (!isset($this->smLinks['l2p'][$logInfo['id']][0])) {
@@ -1201,6 +1208,7 @@ final class MetsDocument extends AbstractDocument
         $this->formatRepository = GeneralUtility::makeInstance(FormatRepository::class);
         $this->metadataRepository = GeneralUtility::makeInstance(MetadataRepository::class);
         $this->structureRepository = GeneralUtility::makeInstance(StructureRepository::class);
+        $this->mediaPlayerService = GeneralUtility::makeInstance(MediaPlayerService::class);
         $this->formatRepository->useStoragePid($this->configPid);
         $this->metadataRepository->useStoragePid($this->configPid);
         $this->structureRepository->useStoragePid($this->configPid);

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -554,7 +554,7 @@ final class MetsDocument extends AbstractDocument
     }
 
     /**
-     * Get timecode and file IDs that link to first matching fileGrpVideo/USE.
+     * Get timecode and file IDs that link to first matching Audio and Video UseGroupsConfiguration.
      *
      * Returns either `null` or an array with the following keys:
      * - `fileIds`: Array of linked file IDs
@@ -571,15 +571,15 @@ final class MetsDocument extends AbstractDocument
     protected function getTimecode(array $logInfo): ?array
     {
         // Load plugin configuration.
-        $useGroupsVideo = $this->mediaPlayerService->getMediaplayerUseGroups();
+        $mediaplayerUseGroups = $this->mediaPlayerService->getMediaplayerUseGroups();
 
-        foreach ($useGroupsVideo as $useGroupVideo) {
+        foreach ($mediaplayerUseGroups as $mediaplayerUseGroup) {
             if (!isset($this->smLinks['l2p'][$logInfo['id']][0])) {
                 continue;
             }
 
             $physInfo = $this->physicalStructureInfo[$this->smLinks['l2p'][$logInfo['id']][0]];
-            $fileIds = $physInfo['all_files'][$useGroupVideo] ?? [];
+            $fileIds = $physInfo['all_files'][$mediaplayerUseGroup] ?? [];
 
             $chapter = null;
 

--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1206,9 +1206,9 @@ final class MetsDocument extends AbstractDocument
     {
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(get_class($this));
         $this->formatRepository = GeneralUtility::makeInstance(FormatRepository::class);
+        $this->mediaPlayerService = GeneralUtility::makeInstance(MediaPlayerService::class);
         $this->metadataRepository = GeneralUtility::makeInstance(MetadataRepository::class);
         $this->structureRepository = GeneralUtility::makeInstance(StructureRepository::class);
-        $this->mediaPlayerService = GeneralUtility::makeInstance(MediaPlayerService::class);
         $this->formatRepository->useStoragePid($this->configPid);
         $this->metadataRepository->useStoragePid($this->configPid);
         $this->structureRepository->useStoragePid($this->configPid);

--- a/Classes/Controller/MediaPlayerController.php
+++ b/Classes/Controller/MediaPlayerController.php
@@ -182,13 +182,13 @@ class MediaPlayerController extends AbstractController
      */
     protected function recurseChapters(array $logInfo, array &$outChapters): void
     {
-        if (empty($logInfo['children']) && isset($logInfo['videoChapter'])) {
+        if (empty($logInfo['children']) && isset($logInfo['mediaChapter'])) {
             $outChapters[] = [
-                'fileIds' => $logInfo['videoChapter']['fileIds'],
-                'fileIdsJoin' => $logInfo['videoChapter']['fileIdsJoin'],
+                'fileIds' => $logInfo['mediaChapter']['fileIds'],
+                'fileIdsJoin' => $logInfo['mediaChapter']['fileIdsJoin'],
                 'pageNo' => $logInfo['points'],
                 'title' => $logInfo['label'] ?? '',
-                'timecode' => $logInfo['videoChapter']['timecode'],
+                'timecode' => $logInfo['mediaChapter']['timecode'],
             ];
         }
 

--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -130,12 +130,12 @@ class TableOfContentsController extends AbstractController
         // Set "title", "volume", "type" and "pagination" from $entry array.
         $entryArray['title'] = $this->setTitle($entry);
         $entryArray['volume'] = $entry['volume'];
-        if (isset($entry['videoChapter'])) {
+        if (isset($entry['mediaChapter'])) {
             // Now consumers such as `slub_digitalcollections` may intercept clicks on these links
             // and use the timecode to directly jump to that video position
             // NOTE: Remember that the URL also contains parameters such as `tx_dlf[page]` and `cHash`
             // TODO: For simplicity, this currently assumes all chapters are within the same video file
-            $entryArray['section'] = 'timecode=' . $entry['videoChapter']['timecode'] . ';fileIds=' . $entry['videoChapter']['fileIdsJoin'];
+            $entryArray['section'] = 'timecode=' . $entry['mediaChapter']['timecode'] . ';fileIds=' . $entry['mediaChapter']['fileIdsJoin'];
         }
         $entryArray['year'] = $entry['year'];
         $entryArray['orderlabel'] = $entry['orderlabel'];

--- a/Classes/Service/MediaPlayerService.php
+++ b/Classes/Service/MediaPlayerService.php
@@ -60,9 +60,22 @@ class MediaPlayerService
     }
 
     /**
+     * Get the combined list of audio and video use groups for the mediaplayer.
+     * 
+     * Combines configured audio and video use groups (without duplicates).
+     * 
+     * @return string[] An array of unique use group identifiers for audio and video.
+     */
+    public function getMediaplayerUseGroups(): array
+    {
+        $audioUseGroups = $this->useGroupsConfiguration->getAudio();
+        $videoUseGroups = $this->useGroupsConfiguration->getVideo();
+
+        return array_unique([...$audioUseGroups, ...$videoUseGroups]);
+    }
+
+    /**
      * Returns playable media sources (audio and video) for a given document page.
-     *
-     * Combines configured audio and video use groups (without duplicates)
      *
      * @param AbstractDocument $doc The document object.
      * @param int $pageNo The page number.
@@ -71,11 +84,7 @@ class MediaPlayerService
      */
     public function getMediaplayerSources(AbstractDocument $doc, int $pageNo): array
     {
-        $audioUseGroups = $this->useGroupsConfiguration->getAudio();
-        $videoUseGroups = $this->useGroupsConfiguration->getVideo();
-        $mediaplayerUseGroups = array_unique([...$audioUseGroups, ...$videoUseGroups]);
-
-        return $this->collectMediaSources($doc, $pageNo, $mediaplayerUseGroups);
+        return $this->collectMediaSources($doc, $pageNo, $this->getMediaplayerUseGroups());
     }
 
     /**

--- a/Classes/Service/MediaPlayerService.php
+++ b/Classes/Service/MediaPlayerService.php
@@ -61,9 +61,9 @@ class MediaPlayerService
 
     /**
      * Get the combined list of audio and video use groups for the mediaplayer.
-     * 
+     *
      * Combines configured audio and video use groups (without duplicates).
-     * 
+     *
      * @return string[] An array of unique use group identifiers for audio and video.
      */
     public function getMediaplayerUseGroups(): array

--- a/Tests/Functional/Common/MetsDocumentTest.php
+++ b/Tests/Functional/Common/MetsDocumentTest.php
@@ -104,7 +104,7 @@ class MetsDocumentTest extends FunctionalTestCase
         self::assertArrayMatches([
             'dmdId' => 'DMDLOG_0000',
             'admId' => 'AMD',
-            'videoChapter' => [
+            'mediaChapter' => [
                 'fileIds' => ['FILE_0000_DEFAULT_MOV', 'FILE_0000_DEFAULT_MP4'],
                 'timecode' => 0,
             ],
@@ -113,7 +113,7 @@ class MetsDocumentTest extends FunctionalTestCase
                     'id' => 'LOG_0001',
                     'dmdId' => '',
                     'admId' => '',
-                    'videoChapter' => [
+                    'mediaChapter' => [
                         'fileIds' => ['FILE_0000_DEFAULT_MOV', 'FILE_0000_DEFAULT_MP4'],
                         'timecode' => 0,
                     ],
@@ -122,7 +122,7 @@ class MetsDocumentTest extends FunctionalTestCase
                     'id' => 'LOG_0002',
                     'dmdId' => '',
                     'admId' => '',
-                    'videoChapter' => [
+                    'mediaChapter' => [
                         'fileIds' => ['FILE_0000_DEFAULT_MOV', 'FILE_0000_DEFAULT_MP4'],
                         'timecode' => 20.5,
                     ],
@@ -131,7 +131,7 @@ class MetsDocumentTest extends FunctionalTestCase
                     'id' => 'LOG_0003',
                     'dmdId' => '',
                     'admId' => '',
-                    'videoChapter' => [
+                    'mediaChapter' => [
                         'fileIds' => ['FILE_0000_DEFAULT_MOV', 'FILE_0000_DEFAULT_MP4'],
                         'timecode' => 40,
                     ],
@@ -140,7 +140,7 @@ class MetsDocumentTest extends FunctionalTestCase
                     'id' => 'LOG_0004',
                     'dmdId' => '',
                     'admId' => '',
-                    'videoChapter' => [
+                    'mediaChapter' => [
                         'fileIds' => ['FILE_0000_DEFAULT_MOV', 'FILE_0000_DEFAULT_MP4'],
                         'timecode' => 60,
                     ],


### PR DESCRIPTION
Fixed by adding the missing Audio useGroup needed to build the `$details['mediaChapter']` array in `MetsDocument`.
Use the combined `getMediaplayerUseGroups()` function from `Classes/Service/MediaPlayerService.php`.

closes: #2106 