### PR TITLE
[MAINTENANCE] Enhance repository query error handling and logging

### DIFF
--- a/Classes/Controller/TableOfContentsController.php
+++ b/Classes/Controller/TableOfContentsController.php
@@ -87,24 +87,22 @@ class TableOfContentsController extends AbstractController
                 $menuArray[] = $this->getMenuEntry($entry, false);
             }
             // Build table of contents from database.
-            $result = $this->documentRepository->getTableOfContentsFromDb($this->document->getUid(), $this->document->getPid(), $this->settings);
+            $results = $this->documentRepository->getTableOfContents($this->document->getUid(), $this->document->getPid(), $this->settings);
 
-            $allResults = $result->fetchAllAssociative();
-
-            if (count($allResults) > 0) {
+            if (count($results) > 0) {
                 $menuArray[0]['ITEM_STATE'] = 'CURIFSUB';
                 $menuArray[0]['_SUB_MENU'] = [];
-                foreach ($allResults as $resArray) {
+                foreach ($results as $result) {
                     $entry = [
-                        'label' => !empty($resArray['mets_label']) ? $resArray['mets_label'] : $resArray['title'],
-                        'type' => $resArray['type'],
-                        'volume' => $resArray['volume'],
-                        'year' => $resArray['year'],
-                        'orderlabel' => $resArray['mets_orderlabel'],
+                        'label' => !empty($result['mets_label']) ? $result['mets_label'] : $result['title'],
+                        'type' => $result['type'],
+                        'volume' => $result['volume'],
+                        'year' => $result['year'],
+                        'orderlabel' => $result['mets_orderlabel'],
                         'pagination' => '',
-                        'targetUid' => $resArray['uid']
+                        'targetUid' => $result['uid']
                     ];
-                    $menuArray[0]['_SUB_MENU'][] = $this->getMenuEntry($entry, false);
+                    $menuArray[0]['_SUB_MENU'][] = $this->getMenuEntry($entry);
                 }
             }
         }

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -13,6 +13,8 @@
 namespace Kitodo\Dlf\Domain\Repository;
 
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Log\Logger;
+use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
@@ -43,9 +45,26 @@ class AbstractRepository extends Repository
 
     /**
      * @access protected
+     * @var Logger This holds the logger
+     */
+    protected Logger $logger;
+
+    /**
+     * @access protected
      * @var int
      */
     protected int $storagePid = 0;
+
+    /**
+     * Constructor for the repository,
+     * initializes the logger.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(static::class);
+    }
 
     /**
      * Add storage pid to object if repository has a storage pid set.

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -12,7 +12,6 @@
 
 namespace Kitodo\Dlf\Domain\Repository;
 
-use Doctrine\DBAL\Result;
 use Kitodo\Dlf\Common\AbstractDocument;
 use Kitodo\Dlf\Common\Helper;
 use Kitodo\Dlf\Common\Solr\SolrSearch;
@@ -429,9 +428,9 @@ class DocumentRepository extends AbstractRepository
      * @param int $pid
      * @param array<string, mixed> $settings
      *
-     * @return Result
+     * @return list<array<string,mixed>>
      */
-    public function getTableOfContentsFromDb(int $uid, int $pid, array $settings): Result
+    public function getTableOfContents(int $uid, int $pid, array $settings): array
     {
         // Build table of contents from database.
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
@@ -473,7 +472,12 @@ class DocumentRepository extends AbstractRepository
 
         $this->debugQueryBuilder($queryBuilder);
 
-        return $queryBuilder->executeQuery();
+        try {
+            return $queryBuilder->executeQuery()->fetchAllAssociative();
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not fetch table of contents for document uid "' . $uid . '". Error: ' . $e->getMessage() . '.');
+            return [];
+        }
     }
 
     /**
@@ -508,9 +512,14 @@ class DocumentRepository extends AbstractRepository
 
         $qb->getConcreteQueryBuilder()->setMaxResults(1);
 
-        $this->debugQueryBuilder($queryBuilder);
+        $this->debugQueryBuilder($qb);
 
-        return $qb->executeQuery()->fetchAssociative();
+        try {
+            return $qb->executeQuery()->fetchAssociative();
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not fetch OAI record for identifier "' . $parameters['identifier'] . '". Error: ' . $e->getMessage() . '.');
+            return false;
+        }
     }
 
     /**
@@ -539,9 +548,14 @@ class DocumentRepository extends AbstractRepository
             ->andWhere($queryBuilder->expr()->eq('tx_dlf_collections_join.deleted', 0))
             ->groupBy('tx_dlf_documents.uid');
 
-        $this->debugQueryBuilder($queryBuilder);
+        $this->debugQueryBuilder($qb);
 
-        return $qb->executeQuery()->fetchAllAssociative();
+        try {
+            return $qb->executeQuery()->fetchAllAssociative();
+        } catch (\Exception $e) {
+            $this->logger->warning('Could not fetch OAI document list for documents "' . implode(',', $documentsToProcess) . '". Error: ' . $e->getMessage() . '.');
+            return [];
+        }
     }
 
     /**


### PR DESCRIPTION
Integrate structured logging into `AbstractRepository` to provide better insights into query failures. Wrap database query executions in `DocumentRepository` with try-catch blocks to catch exceptions, log warnings, and return graceful defaults (e.g., empty arrays or false) instead of propagating exceptions. Refactor `getTableOfContents` to directly return associative arrays, simplifying its usage in calling code.